### PR TITLE
[range] Transform range into xrange when it is use in for loop

### DIFF
--- a/pythran/analysis.py
+++ b/pythran/analysis.py
@@ -365,3 +365,15 @@ class FlagTemporaries(ast.NodeVisitor):
 
 def flag_temporaries(node):
     FlagTemporaries().visit(node)
+##
+class FlagRange(ast.NodeVisitor):
+    def visit_For(self, node):
+        self.visit(node.target)
+        [self.visit(n) for n in node.body]
+        [self.visit(n) for n in node.orelse]
+        self.visit(node.iter)
+        if isinstance(node.iter,ast.Call) and isinstance(node.iter.func,ast.Name) and node.iter.func.id == "range":
+            metadata.add(node.iter, metadata.IsXrange())
+            
+def flag_range(node):
+    FlagRange().visit(node)

--- a/pythran/metadata.py
+++ b/pythran/metadata.py
@@ -21,6 +21,9 @@ class Comprehension(AST):
 class NotTemporary(AST):
     pass
 
+class IsXrange(AST):
+    pass
+
 class OMPDirective(AST):
     default_mode=' default(none)'
     keywords=('omp', 'parallel', 'for', 'shared', 'private', 'reduction', 'default', 'single', 'nowait', 'task', 'if', 'atomic')

--- a/pythran/middlend.py
+++ b/pythran/middlend.py
@@ -1,11 +1,14 @@
 '''This module turns a python AST into an optimized, pythran compatible ast'''
 from passes import remove_comprehension, remove_nested_functions, remove_lambdas, normalize_tuples, normalize_return, normalize_method_calls, normalize_attributes, unshadow_parameters, expand_imports, gather_omp_data, normalize_exception
-from analysis import flag_temporaries
+from analysis import flag_temporaries, flag_range
 
 def refine(node):
     """refine node in place until it matches pythran's expectations"""
     # parse openmp directive
     gather_omp_data(node)
+
+    #flag to normalize
+    flag_range(node)
 
     # sanitize input
     normalize_exception(node)

--- a/pythran/passes.py
+++ b/pythran/passes.py
@@ -332,6 +332,8 @@ class NormalizeMethodCalls(ast.NodeVisitor):
         if isinstance(node.func, ast.Attribute) and node.func.attr in methods:
             node.args.insert(0,  node.func.value)
             node.func=ast.Attribute(ast.Name(methods[node.func.attr][0],ast.Load()), node.func.attr, ast.Load())
+        if isinstance(node.func, ast.Name) and metadata.get(node,metadata.IsXrange):
+            node.func.id = "xrange"
 
 def normalize_method_calls(node):
     '''Turns built in method calls into function calls'''


### PR DESCRIPTION
Voila une version qui semble fonctionner correctement. Je ne trouve pas très élégant de comparer les nom de fonction mais je pense pas qu'on puisse faire autrement dans ce cas.
L'autre difficulté est le : "quand c'est possible"
J'ai donc dit : c'est possible quand le range est utilisé en tant qu'iterateur de boucle for. Mais je loupe les range qui sont assigné a une variable puis passé en boucle for.
Une autre approche que j'ai vu c'est plutot de dire quand est ce que ce n'est pas possible: utilisation de fonction définie sur les liste, utilisation de "augassign", ...
J'ai préféré la premiére approche parce que on peut se permettre de ne pas être exaustif contraitement a la deuxiéme ou si on oublie de mettre un flag, on peut se retrouver avec un xrange au lieu d'un range qui fait planter tout le programme. (Ça semble aussi aller dans le sens du : si c'est possible)

Passe de bonnes nuits :-D
