### PR TITLE
Itertools corrections and optimizations.

### DIFF
--- a/pythran/pythonic++/core/utils.h
+++ b/pythran/pythonic++/core/utils.h
@@ -1,6 +1,9 @@
 #ifndef PYTHONIC_UTILS_H
 #define PYTHONIC_UTILS_H
 
+#include <type_traits>
+#include <iterator>
+
 //Use when the C/C++ function do not have the same name
 //than in python
 #define WRAP(type,name,cname,argType)\
@@ -89,6 +92,19 @@ namespace pythonic {
     template<typename... Types>
         void fwd(Types const&... types) {
         }
+        
+    /* Get the "minimum" of all iterators :
+     - only random => random
+     - at least one forward => forward 
+    */
+    template<typename... Iters>
+        struct min_iterator;
+
+    template<typename T>
+        struct min_iterator<T> {typedef typename T::iterator_category type;};
+
+    template<typename T, typename... Iters>
+        struct min_iterator<T, Iters...> {typedef typename std::conditional<std::is_same<typename T::iterator_category, std::forward_iterator_tag>::value, std::forward_iterator_tag, typename pythonic::min_iterator<Iters...>::type >::type type;};
 
 }
 #endif

--- a/pythran/tests/test_itertools.py
+++ b/pythran/tests/test_itertools.py
@@ -7,7 +7,7 @@ class TestItertools(TestEnv):
         self.run_test("def imap_(l0,v): from itertools import imap; return sum(imap(lambda x:x*v, l0))", [0,1,2], 2, imap_=[[int], int])
 
     def test_imap_on_generator(self):
-        self.run_test("def imap_on_generator(l,v): from itertools import imap; return sum(imap(lambda x:x*v, (x for x in l)))", [2,3,5], 1, imap_on_generator=[[int], int])  
+        self.run_test("def imap_on_generator(l,v): from itertools import imap; return sum(imap(lambda x:x*v, (y for x in l for y in xrange(x))))", [2,3,5], 1, imap_on_generator=[[int], int])  
 
     def test_imap2(self):
         self.run_test("def imap2_(l0, l1,v): from itertools import imap; return sum(imap(lambda x,y:x*v+y, l0, l1))", [0,1,2], [0,1.1,2.2], 1, imap2_=[[int], [float], int]) 
@@ -17,7 +17,7 @@ class TestItertools(TestEnv):
         self.run_test("def imap2_(l0, l1,v): from itertools import imap; return sum(imap(lambda x,y:x*v+y, l0, l1))", [0,1,2,3], [0,1.1,2.2], 1, imap2_=[[int], [float], int]) 
 
     def test_imap2_on_generator(self):
-        self.run_test("def imap2_on_generator(l0,l1,v): from itertools import imap; return sum(imap(lambda x,y:x*v+y, (x*x for x in l0), (y*y for y in l1)))", [0,1,2], [0,1.1,2.2], 2, imap2_on_generator=[[int], [float], int])
+        self.run_test("def imap2_on_generator(l0,l1,v): from itertools import imap; return sum(imap(lambda x,y:x*v+y, (z*z for x in l0 for z in xrange(x)), (z*2 for y in l1 for z in xrange(y))))", [0,1,2,3], [3,2,1,0], 2, imap2_on_generator=[[int], [float], int])
 
     def test_imap_none(self):
         self.run_test("""
@@ -44,7 +44,7 @@ def imap_none2(l0):
 def imap_none_g(l0): 
     from itertools import imap
     t= 0
-    for a in imap(None, (x for x in l0)) : 
+    for a in imap(None, (y for x in l0 for y in xrange(x))) : 
         t += a[0]
     return t
 """, [0,1,2], imap_none_g=[[int]])
@@ -54,7 +54,7 @@ def imap_none_g(l0):
 def imap_none2_g(l0): 
     from itertools import imap
     t=0 
-    for a in imap(None, (x for x in l0), (y for y in l0)) : 
+    for a in imap(None, (z for x in l0 for z in xrange(x)), (z for y in l0 for z in xrange(y))) : 
         t += sum(a)
     return t
 """, [0,1,2], imap_none2_g=[[int]])
@@ -63,7 +63,7 @@ def imap_none2_g(l0):
         self.run_test("def ifilter_(l0): from itertools import ifilter; return sum(ifilter(lambda x: (x % 2) == 1, l0))", [0,1,2,3,4,5], ifilter_=[[int]])  
 
     def test_ifilter_on_generator(self):
-        self.run_test("def ifilterg_(l0): from itertools import ifilter; return sum(ifilter(lambda x: (x % 2) == 1, (x for x in l0)))", [0,1,2,3,4,5], ifilterg_=[[int]])  
+        self.run_test("def ifilterg_(l0): from itertools import ifilter; return sum(ifilter(lambda x: (x % 2) == 1, (y for x in l0 for y in xrange(x))))", [0,1,2,3,4,5], ifilterg_=[[int]])  
 
     def test_ifilter_none(self):
         self.run_test("""
@@ -78,18 +78,16 @@ def ifiltern_(l0):
     def test_product(self):
         self.run_test("def product_(l0,l1): from itertools import product; return sum(map(lambda (x,y) : x*y, product(l0,l1)))", [0,1,2,3,4,5], [10,11], product_=[[int],[int]])
 
+    def test_product_on_generator(self):
+        self.run_test("def product_g(l0,l1): from itertools import product; return sum(map(lambda (x,y) : x*y, product((y for x in l0 for y in xrange(x)),(y for x in l1 for y in xrange(x)))))", [0,1,2,3,4], [4,3,2,1,0], product_g=[[int],[int]])
+
     def test_itertools(self):
-        self.run_test("def test_it(l0,l1): import itertools; return sum(itertools.imap(lambda (x,y) : x*y, itertools.ifilter(lambda (x,y) : x*y > 25, itertools.product(l0,l1))))", [0,1,2,3,4,5], [10,11], test_it=[[int],[int]])
+        self.run_test("def test_it(l0,l1): import itertools; return sum(itertools.imap(lambda (x,y) : x*y, itertools.product(itertools.ifilter(lambda x : x > 2, l0), itertools.ifilter(lambda x : x < 12, l1))))", [0,1,2,3,4,5], [10,11,12,13,14,15], test_it=[[int],[int]])
 
     def test_izip(self):
         self.run_test("def izip_(l0,l1): from itertools import izip; return sum(map(lambda (x,y) : x*y, izip(l0,l1)))", [0,1,2], [10,11,12], izip_=[[int],[int]]) 
 
     def test_izip_on_generator(self):
-        self.run_test("def izipg_(l0,l1): from itertools import izip; return sum(map(lambda (x,y) : x*y, izip((x for x in l0),(x for x in l1))))", [0,1,2], [10,11,12], izipg_=[[int],[int]]) 
+        self.run_test("def izipg_(l0,l1): from itertools import izip; return sum(map(lambda (x,y) : x*y, izip((z for x in l0 for z in xrange(x)),(z for x in l1 for z in xrange(x)))))", [0,1,2,3], [3,2,1,0], izipg_=[[int],[int]]) 
 
-    def test_imap_on_complex_generator(self):
-        code='''
-from itertools import imap
-def imap_on_complex_generator(n):
-    return [x for x in imap(lambda x : x*x, (y for x in xrange(n) for y in xrange(x)))]'''
-        self.run_test(code, 12, imap_on_complex_generator=[int])
+


### PR DESCRIPTION
- ifilter and product optimization (no more useless copy)
- using random_access iterators when possible, forward iterators otherwise
- itertools tests now use complex generator expressions
