### PR TITLE
My comments on the documentation

### DIFF
--- a/doc/MANUAL
+++ b/doc/MANUAL
@@ -228,7 +228,7 @@ Alternatively, one can run the great::
 
     pythran -ppythran.analysis.ParallelMaps -e as.py
 
-which runs a code analyzer that displays extra information concerning parallel ``map`` found int he code.
+which runs a code analyzer that displays extra information concerning parallel ``map`` found in the code.
 
 Getting Pure C++
 ----------------

--- a/doc/TUTORIAL
+++ b/doc/TUTORIAL
@@ -2,7 +2,7 @@
 Pythran Developer Tutorial
 ==========================
 
-This is a long tutorial to help new Pythran developer discover the Pytrhan
+This is a long tutorial to help new Pythran developer discover the Pythran
 architecture. This is *not* a developer documentation, but it aims at giving a
 good overview of Pythran capacity.
 


### PR DESCRIPTION
In the DEVGUIDE some comments :
- I don't understand where avoiding backslashes is needed
- I assume the tab comment means the tab is is 4 spaces
