### PR TITLE
OpenMP shared library loading, fix bug introduced in 0b41090

### DIFF
--- a/omp/__init__.py
+++ b/omp/__init__.py
@@ -24,7 +24,7 @@ class omp(object):
         for path in paths:
             if libgomp_path:
                 break
-            libgomp_path = ctypes.util.find_library(path+"gomp")
+            libgomp_path = ctypes.util.find_library(path+"libgomp")
 
         if not libgomp_path:
             raise EnvironmentError("I can't find a shared library for libgomp,"


### PR DESCRIPTION
ctypes.util.find_library need the lib prefix when using absolute
path.
