### PR TITLE
Ignore error on shutil.rmtree()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ class BuildWithPly(build):
             check_call(build_cmd)
             os.chdir(cwd)
 
-        check_call(['make', '-C', nt2_build_dir, 'install'])
+        check_call(['make', '-C', nt2_build_dir, 'install','-j'])
         for d in ('nt2', 'boost'):
             src = os.path.join(nt2_build_dir, 'include', d)
             target = os.path.join(self.build_lib, 'pythran', d)


### PR DESCRIPTION
Useful if target does not exist...
