### PR TITLE
numpy.allclose(): check for nan explicitely

### DIFF
--- a/pythran/pythonic++/modules/numpy.h
+++ b/pythran/pythonic++/modules/numpy.h
@@ -707,7 +707,10 @@ namespace pythonic {
                 if( u_s == v_s ) {
                     for(long i=0;i < u_s; ++i) {
                         auto v_i = v.at(i);
-                        if( std::abs(u.at(i)-v_i) > (atol + rtol * std::abs(v_i)))
+                        auto u_i = u.at(i);
+                        if( v_i != v_i || // Check for nan
+                            u_i != u_i || // Check for nan
+                            std::abs(u.at(i)-v_i) > (atol + rtol * std::abs(v_i)))
                             return false;
                     }
                     return true;


### PR DESCRIPTION
Should fix the last testcase.

I wonder how it is possible that the test didn't fail for you... A possible explanation would be that std::numeric_limits::has_quiet_NaN returns false, which is not tested in Pythran right now.
