### PR TITLE
Crash when export with no arguments

### DIFF
--- a/pythran/spec.py
+++ b/pythran/spec.py
@@ -107,8 +107,9 @@ class SpecParser:
         p[0] = eval(p[1])
 
     def p_error(self, p):
-        err = SyntaxError("Invalid Pythran spec near '" + str(p.value) + "'")
-        err.lineno = p.lineno
+        p_val = p.value if p else ''
+        err = SyntaxError("Invalid Pythran spec near '" + str(p_val) + "'")
+        err.lineno = self.lexer.lineno
         if self.input_file:
             err.filename = self.input_file
         raise err;


### PR DESCRIPTION
The previous, verbose code actually crashed when for example someone forgets to put parenthesis:

``` python
#pythran export test
def test():
    ...
```

In that case the `p` lex token passed to `p_error` is `None`, and so it crashes when trying to access `p.value`.

That crash was discovered by my own clumsiness yet again :o It's also a regression introduced by my previous commit on the matter.
