### PR TITLE
Add guards to pythran_gmp.h

### DIFF
--- a/pythran/pythran_gmp.h
+++ b/pythran/pythran_gmp.h
@@ -1,3 +1,6 @@
+#ifndef PYTHRAN_GMP_H
+#define PYTHRAN_GMP_H
+
 #include <gmpxx.h>
 #include <type_traits>
 
@@ -226,3 +229,4 @@ struct pythran_to_python< mpz_class > {
     }
 };
 
+#endif


### PR DESCRIPTION
This came up while trying to add a sqrt function for mpz_class.

I'm having this issue after adding the sqrt function and running prime_decomposition (on a 32 bit machine) at the moment: http://pastebin.com/xKiKDvSA
