### PR TITLE
Fix bad module naming when using custom output, again …

### DIFF
--- a/pythran/toolchain.py
+++ b/pythran/toolchain.py
@@ -310,12 +310,17 @@ def compile_pythranfile(file_path, module_so=None, module_name=None,
     Returns the generated .so (or .cpp if `cpponly` is set to true).
 
     '''
-    # derive destination from file name
-    module_so = module_so or os.path.join(basedir, module_name + ".so")
+    if not module_so:
+        # derive module name from input file name
+        basedir, basename = os.path.split(file_path)
+        module_name = module_name or os.path.splitext(basename)[0]
 
-    # derive module name from file name
-    _, basename = os.path.split(module_so)
-    module_name = module_name or os.path.splitext(basename)[0]
+        # derive destination from file name
+        module_so = os.path.join(basedir, module_name + ".so")
+    else:
+        # derive module name from destination module_so name
+        _, basename = os.path.split(module_so)
+        module_name = module_name or os.path.splitext(basename)[0]
 
     dl = compile_pythrancode(module_name, file(file_path).read(),
                              module_so=module_so, cpponly=cpponly, **kwargs)


### PR DESCRIPTION
This mostly reverts commit d0f4149
and fixes the issue described.
