### PR TITLE
Prevent boost python registration warning

### DIFF
--- a/pythran/pythran.h
+++ b/pythran/pythran.h
@@ -1352,9 +1352,9 @@ struct pythran_to_python {
 
 template<class Type, class Converter>
 static void register_once() {
-    static bool registered=false;
-    if(not registered) {
-        registered=true;
+    boost::python::type_info info = boost::python::type_id<Type >();
+    const boost::python::converter::registration* reg = boost::python::converter::registry::query(info);
+    if(not reg or not (*reg).m_to_python) {
         boost::python::to_python_converter< Type, Converter >();
     }
 }


### PR DESCRIPTION
Now check whether the converter is already registered in a more robust
way.
