### PR TITLE
Follow-up on Shared ref

### DIFF
--- a/pythran/pythonic++/core/dict.h
+++ b/pythran/pythonic++/core/dict.h
@@ -109,7 +109,7 @@ namespace  pythonic {
                 typedef typename container_type::const_pointer const_pointer;
 
                 // constructors
-                dict() : data(impl::no_memory()) {}
+                dict() : data() {}
                 dict(empty_dict const &) : data(impl::shared_ref<container_type>::make_ref(DEFAULT_DICT_SIZE)) {}
                 dict(std::initializer_list<value_type> l) : data(impl::shared_ref<container_type>::make_ref(l.begin(), l.end())) {}
                 dict(dict<K,V> const & other) : data(other.data) {}

--- a/pythran/pythonic++/core/dict.h
+++ b/pythran/pythonic++/core/dict.h
@@ -110,13 +110,13 @@ namespace  pythonic {
 
                 // constructors
                 dict() : data(impl::no_memory()) {}
-                dict(empty_dict const &) : data(DEFAULT_DICT_SIZE) {}
-                dict(std::initializer_list<value_type> l) : data(l.begin(), l.end()) {}
+                dict(empty_dict const &) : data(impl::shared_ref<container_type>::make_ref(DEFAULT_DICT_SIZE)) {}
+                dict(std::initializer_list<value_type> l) : data(impl::shared_ref<container_type>::make_ref(l.begin(), l.end())) {}
                 dict(dict<K,V> const & other) : data(other.data) {}
                 template<class Kp, class Vp>
-                    dict(dict<Kp,Vp> const & other) : data(other.item_begin(), other.item_end()) {}
+                    dict(dict<Kp,Vp> const & other) : data(impl::shared_ref<container_type>::make_ref(other.item_begin(), other.item_end())) {}
                 template<class B, class E>
-                    dict(B begin, E end) : data(begin, end) {}
+                    dict(B begin, E end) : data(impl::shared_ref<container_type>::make_ref(begin, end)) {}
 
                 // iterators
                 iterator begin() { return iterator(data->begin()); }

--- a/pythran/pythonic++/core/file.h
+++ b/pythran/pythonic++/core/file.h
@@ -71,7 +71,7 @@ namespace  pythonic {
 					// Python enforces that the mode, after stripping 'U', begins with 'r', 'w' or 'a'.
 					if(*smode=='U') {++smode;}// Not implemented yet
 
-					data = impl::shared_ref<container_type>(filename, smode);
+					data = impl::shared_ref<container_type>::make_ref(filename, smode);
 					if(not **data)
 						throw core::IOError("Couldn't open file " + filename);
 					is_open = true;

--- a/pythran/pythonic++/core/file.h
+++ b/pythran/pythonic++/core/file.h
@@ -56,8 +56,8 @@ namespace  pythonic {
                 typedef core::string value_type;
 
 				// Constructors
-				file() : data(impl::no_memory()) {}
-				file(core::string const& filename, core::string const& strmode = "r") : data(impl::no_memory()), mode(strmode), name(filename), newlines('\n'){
+				file() : data() {}
+				file(core::string const& filename, core::string const& strmode = "r") : data(), mode(strmode), name(filename), newlines('\n'){
 					open(filename, strmode);
 				}
 

--- a/pythran/pythonic++/core/list.h
+++ b/pythran/pythonic++/core/list.h
@@ -125,14 +125,14 @@ namespace  pythonic {
                 // constructors
                 list() : data(impl::no_memory()) {}
                 template<class InputIterator>
-                    list(InputIterator start, InputIterator stop) : data() {
+                    list(InputIterator start, InputIterator stop) : data(impl::shared_ref<container_type>::make_ref()) {
                         data->reserve(DEFAULT_LIST_CAPACITY);
                         std::copy(start, stop, std::back_inserter(*data));
                     }
                 list(empty_list const&) :data(0) {}
-                list(size_type sz) :data(sz) {}
-                list(T const& value, single_value) : data(1) { (*data)[0] = value; }
-                list(std::initializer_list<T> l) : data(std::move(l)) {}
+                list(size_type sz) :data(impl::shared_ref<container_type>::make_ref(sz)) {}
+                list(T const& value, single_value) : data(impl::shared_ref<container_type>::make_ref(1)) { (*data)[0] = value; }
+                list(std::initializer_list<T> l) : data(impl::shared_ref<container_type>::make_ref(std::move(l))) {}
                 list(list<T> && other) : data(std::move(other.data)) {}
                 list(list<T> const & other) : data(other.data) {}
                 template<class F>
@@ -140,10 +140,10 @@ namespace  pythonic {
                         std::copy(other.begin(), other.end(), begin());
                     }
                 template<class... Types>
-                    list(std::tuple<Types...> const& t) : data(sizeof...(Types)) {
+                    list(std::tuple<Types...> const& t) : data(impl::shared_ref<container_type>::make_ref(sizeof...(Types))) {
                         tuple_dump(t, *this, int_<sizeof...(Types)-1>());
                     }
-                list(list_view<T> const & other) : data( other.begin(), other.end()) {}
+                list(list_view<T> const & other) : data( impl::shared_ref<container_type>::make_ref(other.begin(), other.end())) {}
 
                 list<T>& operator=(list<T> && other) {
                     data=std::move(other.data);
@@ -154,7 +154,7 @@ namespace  pythonic {
                     return *this;
                 }
                 list<T>& operator=(empty_list const & ) {
-                    data=impl::shared_ref<container_type>();
+                    data=impl::shared_ref<container_type>::make_ref();
                     return *this;
                 }
 
@@ -164,7 +164,7 @@ namespace  pythonic {
                         data->resize(it - data->begin());
                     }
                     else {
-                        data=impl::shared_ref<T>(other.begin(),other.end());
+                        data=impl::shared_ref<T>::make_ref(other.begin(),other.end());
                     }
                     return *this;
                 }

--- a/pythran/pythonic++/core/list.h
+++ b/pythran/pythonic++/core/list.h
@@ -53,7 +53,7 @@ namespace  pythonic {
                 typedef typename container_type::const_reverse_iterator const_reverse_iterator;
 
                 // constructor
-                list_view(): data(impl::no_memory()) {}
+                list_view(): data() {}
                 list_view(list_view<T> const & s): data(s.data), slicing(s.slicing) {}
                 list_view(list<T> & other, slice const & s) : data(other.data), slicing(s.normalize(other.size())) {}
 
@@ -123,20 +123,20 @@ namespace  pythonic {
 
 
                 // constructors
-                list() : data(impl::no_memory()) {}
+                list() : data() {}
                 template<class InputIterator>
                     list(InputIterator start, InputIterator stop) : data(impl::shared_ref<container_type>::make_ref()) {
                         data->reserve(DEFAULT_LIST_CAPACITY);
                         std::copy(start, stop, std::back_inserter(*data));
                     }
-                list(empty_list const&) :data(0) {}
+                list(empty_list const&) :data(impl::shared_ref<container_type>::make_ref()) {}
                 list(size_type sz) :data(impl::shared_ref<container_type>::make_ref(sz)) {}
                 list(T const& value, single_value) : data(impl::shared_ref<container_type>::make_ref(1)) { (*data)[0] = value; }
                 list(std::initializer_list<T> l) : data(impl::shared_ref<container_type>::make_ref(std::move(l))) {}
                 list(list<T> && other) : data(std::move(other.data)) {}
                 list(list<T> const & other) : data(other.data) {}
                 template<class F>
-                    list(list<F> const & other) : data(other.size()) {
+                    list(list<F> const & other) : data(impl::shared_ref<container_type>::make_ref(other.size())) {
                         std::copy(other.begin(), other.end(), begin());
                     }
                 template<class... Types>

--- a/pythran/pythonic++/core/ndarray.h
+++ b/pythran/pythonic++/core/ndarray.h
@@ -400,7 +400,8 @@ namespace  pythonic {
                     gslice(),
                     gshape(),
                     shape(),
-                    data(data)
+                    data(data),
+                    to_index(impl::shared_ref<raw_array<long>>::make_ref())
                 {
                     std::copy_n(data.shape.begin(), M, gshape.begin());
                     for(size_t i=0, j=0;i<M;i++) {
@@ -751,7 +752,7 @@ namespace  pythonic {
                         >
                         ndarray(Iterable&& iterable):
                             data_size(0),
-                            mem(nested_container_size<Iterable>::size(std::forward<Iterable>(iterable))),
+                            mem(impl::shared_ref<raw_array<T>>::make_ref(nested_container_size<Iterable>::size(std::forward<Iterable>(iterable)))),
                             buffer(mem->data),
                             shape()
                 {
@@ -762,7 +763,7 @@ namespace  pythonic {
                 /* from a shape */
                 ndarray(core::array<long, N> const& shape, T value):
                     data_size(shape[0]),
-                    mem(std::accumulate(shape.begin(), shape.end(), 1, std::multiplies<long>())),
+                    mem(impl::shared_ref<raw_array<T>>::make_ref(std::accumulate(shape.begin(), shape.end(), 1, std::multiplies<long>()))),
                     buffer(mem->data),
                     shape(shape)
 
@@ -773,7 +774,7 @@ namespace  pythonic {
                 /* from a shape without setting values */
                 ndarray(core::array<long, N> const& shape, none_type):
                     data_size(shape[0]),
-                    mem(std::accumulate(shape.begin(), shape.end(), 1, std::multiplies<long>())),
+                    mem(impl::shared_ref<raw_array<T>>::make_ref(std::accumulate(shape.begin(), shape.end(), 1, std::multiplies<long>()))),
                     buffer(mem->data),
                     shape(shape)
                 {
@@ -782,7 +783,7 @@ namespace  pythonic {
                 /* from a foreign pointer */
                 ndarray(T* data, long * pshape):
                     data_size(*pshape),
-                    mem(data),
+                    mem(impl::shared_ref<raw_array<T>>::make_ref(data)),
                     buffer(mem->data),
                     shape()
                 {
@@ -827,7 +828,7 @@ namespace  pythonic {
                 template<class Op, class Arg0, class Arg1>
                     ndarray(numpy_expr<Op, Arg0, Arg1> const & expr) :
                         data_size(expr.shape[0]),
-                        mem(expr.size()),
+                        mem(impl::shared_ref<raw_array<T>>::make_ref(expr.size())),
                         buffer(mem->data),
                         shape(expr.shape)
                 {
@@ -837,7 +838,7 @@ namespace  pythonic {
                 template<class Op, class Arg0>
                     ndarray(numpy_uexpr<Op, Arg0> const & expr) :
                         data_size(expr.shape[0]),
-                        mem(expr.size()),
+                        mem(impl::shared_ref<raw_array<T>>::make_ref(expr.size())),
                         buffer(mem->data),
                         shape(expr.shape)
                 {
@@ -847,7 +848,7 @@ namespace  pythonic {
                 template<class E>
                     ndarray(sliced_ndarray<E> const& expr):
                         data_size(expr.shape[0]),
-                        mem(expr.size()),
+                        mem(impl::shared_ref<raw_array<T>>::make_ref(expr.size())),
                         buffer(mem->data),
                         shape(expr.shape)
                 {
@@ -856,7 +857,7 @@ namespace  pythonic {
                 template<class E, size_t M, size_t L>
                     ndarray(gsliced_ndarray<E,M,L> const& expr):
                         data_size(expr.shape[0]),
-                        mem(expr.size()),
+                        mem(impl::shared_ref<raw_array<T>>::make_ref(expr.size())),
                         buffer(mem->data),
                         shape(expr.shape)
                 {
@@ -865,7 +866,7 @@ namespace  pythonic {
                 template<class Tp>
                 ndarray(indexed_ndarray<Tp,N> const& expr):
                     data_size(expr.shape[0]),
-                    mem(expr.size()),
+                    mem(impl::shared_ref<raw_array<T>>::make_ref(expr.size())),
                     buffer(mem->data),
                     shape(expr.shape)
                 {

--- a/pythran/pythonic++/core/ndarray.h
+++ b/pythran/pythonic++/core/ndarray.h
@@ -722,7 +722,7 @@ namespace  pythonic {
                 core::array<long, N> shape;             // shape of the multidimensional array
 
                 /* constructors */
-                ndarray() : data_size(0), mem(impl::no_memory()), buffer(nullptr), shape() {}
+                ndarray() : data_size(0), mem(), buffer(nullptr), shape() {}
 
                 /* copy */
                 ndarray(ndarray<T,N> const& other) :

--- a/pythran/pythonic++/core/set.h
+++ b/pythran/pythonic++/core/set.h
@@ -50,11 +50,11 @@ namespace  pythonic {
                     set(InputIterator start, InputIterator stop) :  data() {
                         std::copy(start, stop, std::back_inserter(*this));
                     }
-                set(empty_set const &) : data() {}
-                set(std::initializer_list<value_type> l) : data(std::move(l)) {}
+                set(empty_set const &) : data(impl::shared_ref<container_type>::make_ref()) {}
+                set(std::initializer_list<value_type> l) : data(impl::shared_ref<container_type>::make_ref(std::move(l))) {}
                 set(set<T> const & other) : data(other.data) {}
                 template<class F>
-                    set(set<F> const & other) :  data(){
+                    set(set<F> const & other) :  data(impl::shared_ref<container_type>::make_ref()){
                         std::copy(other.begin(), other.end(), std::inserter(*data, data->begin()));
                     }
 

--- a/pythran/pythonic++/core/set.h
+++ b/pythran/pythonic++/core/set.h
@@ -45,7 +45,7 @@ namespace  pythonic {
                 typedef typename container_type::const_reverse_iterator const_reverse_iterator;
 
                 // constructors
-                set() : data(impl::no_memory()) {}
+                set() : data() {}
                 template<class InputIterator>
                     set(InputIterator start, InputIterator stop) :  data() {
                         std::copy(start, stop, std::back_inserter(*this));

--- a/pythran/pythonic++/core/shared_ref.h
+++ b/pythran/pythonic++/core/shared_ref.h
@@ -15,8 +15,6 @@ namespace pythonic {
 #endif
 
     namespace impl {
-        // Force construction of an uninitialized shared_ref
-        struct no_memory{};
 
         /** Light-weight shared_ptr like-class
          *
@@ -38,19 +36,16 @@ namespace pythonic {
                 public:
 
                     // Uninitialized ctor
-                    shared_ref(no_memory const&) noexcept
+                    shared_ref() noexcept
                         : mem(nullptr)
-                    {}
-                    // Uninitialized ctor (rvalue ref)
-                    shared_ref(no_memory &&) noexcept
-                        : mem(nullptr)
-                    {}
+                    {
+                    }
 
                     // Ctor allocate T and forward all arguments to T ctor
                     template<class... Types>
                     static shared_ref<T> make_ref(Types&&... args)
                         {
-                          shared_ref<T> ref{no_memory()};
+                          shared_ref<T> ref;
                           ref.mem = new memory(std::forward<Types>(args)...);
                           ref.acquire();
                           return ref;
@@ -66,11 +61,6 @@ namespace pythonic {
                         : mem(p.mem)
                     {if(mem) acquire();}
 
-                    // Copy Ctor, again
-                    // Without a non-const copy-ctor here, the greedy variadic template ctor takes over
-                    shared_ref(shared_ref<T> & p) noexcept
-                        : mem(p.mem)
-                    {if(mem) acquire();}
 
                     ~shared_ref() noexcept
                     {dispose();}

--- a/pythran/pythonic++/core/shared_ref.h
+++ b/pythran/pythonic++/core/shared_ref.h
@@ -48,9 +48,13 @@ namespace pythonic {
 
                     // Ctor allocate T and forward all arguments to T ctor
                     template<class... Types>
-                        shared_ref(Types&&... args)
-                            : mem( new memory(std::forward<Types>(args)...) )
-                        {}
+                    static shared_ref<T> make_ref(Types&&... args)
+                        {
+                          shared_ref<T> ref{no_memory()};
+                          ref.mem = new memory(std::forward<Types>(args)...);
+                          ref.acquire();
+                          return ref;
+                        }
 
                     // Move Ctor
                     shared_ref(shared_ref<T>&& p) noexcept

--- a/pythran/pythonic++/core/string.h
+++ b/pythran/pythonic++/core/string.h
@@ -49,7 +49,7 @@ namespace pythonic {
 
             // constructors
 
-            string_view(): data(impl::no_memory()) {}
+            string_view(): data() {}
 
             string_view(string_view const & s)
               : data(s.data),

--- a/pythran/pythonic++/core/string.h
+++ b/pythran/pythonic++/core/string.h
@@ -47,10 +47,19 @@ namespace pythonic {
             typedef container_type::pointer pointer;
             typedef container_type::const_pointer const_pointer;
 
-            // constructor
+            // constructors
+
             string_view(): data(impl::no_memory()) {}
-            string_view(string_view const & s): data(s.data), slicing(s.slicing) {}
-            string_view(string_view const & s, normalized_slice const& sl): data(s.data), slicing(s.slicing.lower + sl.lower, s.slicing.lower + sl.upper, s.slicing.step * sl.step) {}
+
+            string_view(string_view const & s)
+              : data(s.data),
+                slicing(s.slicing) {}
+
+            string_view(string_view const & s, normalized_slice const& sl)
+              : data(s.data),
+                slicing(s.slicing.lower + sl.lower,
+                        s.slicing.lower + sl.upper,
+                        s.slicing.step * sl.step) {}
             string_view(core::string & other, normalized_slice const & s);
 
             // const getter
@@ -99,15 +108,15 @@ namespace pythonic {
             typedef core::string value_type;
             typedef container_type::iterator iterator;
 
-            string() : data() {}
-            string(std::string const & s) : data(s) {}
-            string(std::string && s) : data(std::move(s)) {}
-            string(const char*s) : data(s) {}
-            string(const char*s, size_t n) : data(s,n) {}
-            string(char c) : data(1,c) {}
-            string(string_view const & other) : data( other.begin(), other.end()) {}
+            string() : data(impl::shared_ref<container_type>::make_ref()) {}
+            string(std::string const & s) : data(impl::shared_ref<container_type>::make_ref(s)) {}
+            string(std::string && s) : data(impl::shared_ref<container_type>::make_ref(std::move(s))) {}
+            string(const char*s) : data(impl::shared_ref<container_type>::make_ref(s)) {}
+            string(const char*s, size_t n) : data(impl::shared_ref<container_type>::make_ref(s,n)) {}
+            string(char c) : data(impl::shared_ref<container_type>::make_ref(1,c)) {}
+            string(string_view const & other) : data(impl::shared_ref<container_type>::make_ref(other.begin(), other.end())) {}
             template<class T>
-                string(T const& begin, T const& end) : data( begin, end) {}
+                string(T const& begin, T const& end) : data(impl::shared_ref<container_type>::make_ref(begin, end)) {}
 
             explicit operator char() const {
                 assert(size() == 1);


### PR DESCRIPTION
Continuation of the previous PR. API change: default ctor is now state unitialized and static member make_ref is mandatory for build an initialized ref.
It is more clear and removes ambiguity within constructors.
