### PR TITLE
Portable specialization of boost::hash_value

### DIFF
--- a/pythran/pythonic++/core/string.h
+++ b/pythran/pythonic++/core/string.h
@@ -353,9 +353,12 @@ namespace std {
         }
     };
 }
-namespace boost {
-    std::size_t hash_value(pythonic::core::string  const &x) {
-        return std::hash<pythonic::core::string>()(x);
+
+namespace pythonic {
+    namespace core {
+        std::size_t hash_value(string  const &x) {
+            return std::hash<string>()(x);
+        }
     }
 }
 

--- a/pythran/pythonic++/core/tuple.h
+++ b/pythran/pythonic++/core/tuple.h
@@ -339,20 +339,22 @@ namespace std {
         };
 }
 
-#include <boost/version.hpp>
+#include <boost/functional/hash/extensions.hpp>
 
 /* and boost's */
-namespace boost {
-#if BOOST_VERSION < 105400
-    template<class... Types>
-        std::size_t hash_value(std::tuple<Types...>  const &x) {
-            return std::hash<std::tuple<Types...>>()(x);
-        }
+namespace pythonic {
+    namespace core {
+#ifdef BOOST_NO_CXX11_HDR_TUPLE
+        template<class... Types>
+            std::size_t hash_value(std::tuple<Types...>  const &x) {
+                return std::hash<std::tuple<Types...>>()(x);
+            }
 #endif
-    template<class T, size_t N>
-        std::size_t hash_value(pythonic::core::array<T,N>  const &x) {
-            return std::hash<pythonic::core::array<T,N>>()(x);
-        }
+        template<class T, size_t N>
+            std::size_t hash_value(pythonic::core::array<T,N>  const &x) {
+                return std::hash<pythonic::core::array<T,N>>()(x);
+            }
+    }
 }
 
 


### PR DESCRIPTION
Fix #175
