### PR TITLE
Generic implementation of NUMPY_EXPR_TO_NDARRAY

### DIFF
--- a/pythran/pythonic/utils/numpy_conversion.hpp
+++ b/pythran/pythonic/utils/numpy_conversion.hpp
@@ -2,11 +2,11 @@
 #define PYTHONIC_UTILS_NUMPY_CONVERSION_HPP
 
 #define NUMPY_EXPR_TO_NDARRAY0(fname)\
-template<class Op, class Arg0, class Arg1, class... Types>\
-auto fname(types::numpy_expr<Op,Arg0, Arg1> const& expr, Types... others)\
--> decltype(fname(typename types::numpy_expr_to_ndarray<types::numpy_expr<Op,Arg0,Arg1>>::type(expr), std::forward<Types>(others)...)) \
+template<class E, class... Types>\
+auto fname(E const& expr, Types&&... others)\
+-> typename std::enable_if<types::is_array<E>::value, decltype(fname(typename types::numpy_expr_to_ndarray<E>::type(expr), std::forward<Types>(others)...))>::type \
 {\
-    return fname(typename types::numpy_expr_to_ndarray<types::numpy_expr<Op,Arg0, Arg1>>::type(expr), std::forward<Types>(others)...);\
+    return fname(typename types::numpy_expr_to_ndarray<E>::type(expr), std::forward<Types>(others)...);\
 }\
 
 

--- a/pythran/tests/test_numpy.py
+++ b/pythran/tests/test_numpy.py
@@ -629,23 +629,26 @@ def np_rosen_der(x):
     def test_rollaxis0(self):
         self.run_test("def np_rollaxis0(x): from numpy import rollaxis; return rollaxis(x, 1)", numpy.arange(24).reshape(2,3,4), np_rollaxis0=[numpy.array([[[int]]])])
 
+    def test_roll6(self):
+        self.run_test("def np_roll6(x): from numpy import roll; return roll(x[:,:,:-1], -1, 2)", numpy.arange(24).reshape(2,3,4), np_roll6=[numpy.array([[[int]]])])
+
     def test_roll5(self):
-        self.run_test("def np_roll5(x): from numpy import roll; return roll(x, -1, 2)", numpy.arange(24).reshape(2,3,4), np_roll5=[numpy.array([[int]])])
+        self.run_test("def np_roll5(x): from numpy import roll; return roll(x, -1, 2)", numpy.arange(24).reshape(2,3,4), np_roll5=[numpy.array([[[int]]])])
 
     def test_roll4(self):
-        self.run_test("def np_roll4(x): from numpy import roll; return roll(x, 1, 1)", numpy.arange(24).reshape(2,3,4), np_roll4=[numpy.array([[int]])])
+        self.run_test("def np_roll4(x): from numpy import roll; return roll(x, 1, 1)", numpy.arange(24).reshape(2,3,4), np_roll4=[numpy.array([[[int]]])])
 
     def test_roll3(self):
-        self.run_test("def np_roll3(x): from numpy import roll; return roll(x, -1, 0)", numpy.arange(24).reshape(2,3,4), np_roll3=[numpy.array([[int]])])
+        self.run_test("def np_roll3(x): from numpy import roll; return roll(x, -1, 0)", numpy.arange(24).reshape(2,3,4), np_roll3=[numpy.array([[[int]]])])
 
     def test_roll2(self):
-        self.run_test("def np_roll2(x): from numpy import roll; return roll(x, -1)", numpy.arange(24).reshape(2,3,4), np_roll2=[numpy.array([[int]])])
+        self.run_test("def np_roll2(x): from numpy import roll; return roll(x, -1)", numpy.arange(24).reshape(2,3,4), np_roll2=[numpy.array([[[int]]])])
 
     def test_roll1(self):
-        self.run_test("def np_roll1(x): from numpy import roll; return roll(x, 10)", numpy.arange(24).reshape(2,3,4), np_roll1=[numpy.array([[int]])])
+        self.run_test("def np_roll1(x): from numpy import roll; return roll(x, 10)", numpy.arange(24).reshape(2,3,4), np_roll1=[numpy.array([[[int]]])])
 
     def test_roll0(self):
-        self.run_test("def np_roll0(x): from numpy import roll; return roll(x, 3)", numpy.arange(24).reshape(2,3,4), np_roll0=[numpy.array([[int]])])
+        self.run_test("def np_roll0(x): from numpy import roll; return roll(x, 3)", numpy.arange(24).reshape(2,3,4), np_roll0=[numpy.array([[[int]]])])
 
     def test_searchsorted3(self):
         self.run_test("def np_searchsorted3(x): from numpy import searchsorted; return searchsorted(x, [[3,4],[1,87]])", numpy.arange(6), np_searchsorted3=[numpy.array([int])])


### PR DESCRIPTION
Previous implementation only worked for numpy_expr, it now works for
anything that matches types::is_array<...>

Thi is a bugfix for Ian
