### PR TITLE
Restore OpenMP support

### DIFF
--- a/pythran/pythonic/types/ndarray.hpp
+++ b/pythran/pythonic/types/ndarray.hpp
@@ -251,7 +251,7 @@ namespace pythonic {
                 /* from a  numpy expression */
                 template<class E>
                     void initialize_from_expr(E const & expr) {
-                        std::copy(expr.begin(), expr.end(), begin());
+                        utils::broadcast_copy(*this, expr, utils::int_<0>());
                     }
 
                 template<class Op, class Arg0, class Arg1>

--- a/pythran/pythonic/utils/broadcast_copy.hpp
+++ b/pythran/pythonic/utils/broadcast_copy.hpp
@@ -3,9 +3,17 @@
 
 #include "pythonic/types/tuple.hpp"
 
+#ifdef _OPENMP
+#include <omp.h>
+#ifndef PYTHRAN_OPENMP_MIN_ITERATION_COUNT
+#define PYTHRAN_OPENMP_MIN_ITERATION_COUNT 1000
+#endif
+#endif
+
 namespace pythonic {
 
     namespace utils {
+
         /* helper function to get the dimension of an array
          * yields 0 for scalar types
          */
@@ -41,12 +49,26 @@ namespace pythonic {
          */
         template<class E, class F>
             E& broadcast_copy(E& self, F const& other, utils::int_<0>) {
+#ifdef _OPENMP
+                size_t n = self.end() - self.begin();
+                #pragma omp parallel for if(n>=PYTHRAN_OPENMP_MIN_ITERATION_COUNT)
+                for(size_t i = 0; i< n; ++i)
+                    self[i] = other[i];
+#else
                 std::copy(other.begin(), other.end(), self.begin());
+#endif
                 return self;
             }
         template<class E, class F, size_t N>
             E& broadcast_copy(E& self, F const& other, utils::int_<N>) {
+#ifdef _OPENMP
+                size_t n = self.end() - self.begin();
+                #pragma omp parallel for if(n>=PYTHRAN_OPENMP_MIN_ITERATION_COUNT)
+                for(size_t i = 0; i< n; ++i)
+                    self[i] = other;
+#else
                 std::fill(self.begin(), self.end(), other);
+#endif
                 return self;
             }
 


### PR DESCRIPTION
Thanks to the rework of ndarray, everything is syndicated on a single
pair of functions!

Beware that nested parallelism is disabled, so parallelization of the
iteration over an int[2][1000000] is not good, while parallelization of
the iteration over int[1000000][2] is great. What can we do about this?
