### PR TITLE
Fix modulo performance (thanks coyotte)

### DIFF
--- a/pythran/pythonic/numpy/bitwise_not.hpp
+++ b/pythran/pythonic/numpy/bitwise_not.hpp
@@ -2,7 +2,6 @@
 #define PYTHONIC_NUMPY_BITWISENOT_HPP
 
 #include "pythonic/utils/proxy.hpp"
-//#include "pythonic/types/ndarray.hpp"
 
 namespace pythonic {
 

--- a/pythran/pythonic/numpy/mod.hpp
+++ b/pythran/pythonic/numpy/mod.hpp
@@ -2,17 +2,20 @@
 #define PYTHONIC_NUMPY_MOD_HPP
 
 #include "pythonic/utils/proxy.hpp"
-#include "pythonic/types/ndarray.hpp"
+#include "pythonic/types/assignable.hpp"
 #include "pythonic/operator_/mod.hpp"
+
 
 namespace pythonic {
 
     namespace numpy {
-#define NUMPY_BINARY_FUNC_NAME mod
-#define NUMPY_BINARY_FUNC_SYM operator_::mod
-#include "pythonic/types/numpy_binary_expr.hpp"
 
-    }
+        /* this is still a numpy_expr, because operator::mod_ forwards to
+         * operator% which is correctly overloaded
+         */
+
+        using operator_::mod;
+        PROXY(pythonic::numpy, mod); }
 
 }
 

--- a/pythran/pythonic/operator_/mod.hpp
+++ b/pythran/pythonic/operator_/mod.hpp
@@ -8,12 +8,13 @@ namespace pythonic {
 
     namespace operator_ {
 
-        //SG: we have to deal with python modulo that always return a positive value
-        //but without using conditional because this function is also used for expression
-        //templates at the numpy level
         template <class A, class B>
-            auto mod(A const& a, B const& b) -> decltype(((a % b) + b) % b) {
-                return ((a % b) + b) % b;
+            auto mod(A const& a, B const& b)
+            -> typename std::enable_if<std::is_fundamental<A>::value and std::is_fundamental<B>::value,
+                                       decltype(a % b)>::type
+            {
+                auto t = a % b;
+                return t < 0 ? (t + b) : t;
             }
         inline double mod(double a, long b) {
             auto t = std::fmod(a, double(b));
@@ -23,12 +24,13 @@ namespace pythonic {
             auto t = std::fmod(a, b);
             return t < 0 ? (t + b) : t;
         }
-        template<class T>
-        inline auto mod(types::str const& s, T const& b)
-        -> decltype(s%b)
-        {
-            return s % b;
-        }
+        template<class A, class B>
+            auto mod(A const& a, B const& b) // for ndarrays
+            -> typename std::enable_if<not std::is_fundamental<A>::value or not std::is_fundamental<B>::value,
+                                       decltype(a%b)>::type
+            {
+                return a % b;
+            }
         PROXY(pythonic::operator_, mod);
     }
 

--- a/pythran/pythonic/types/numpy_binary_expr.hpp
+++ b/pythran/pythonic/types/numpy_binary_expr.hpp
@@ -1,4 +1,4 @@
-#ifndef NUMPY_BINARY_FUNC_NAME        
+#ifndef NUMPY_BINARY_FUNC_NAME
 #error NUMPY_BINARY_FUNC_NAME undefined
 #endif
 #ifndef NUMPY_BINARY_FUNC_SYM

--- a/pythran/pythonic/types/numpy_fexpr.hpp
+++ b/pythran/pythonic/types/numpy_fexpr.hpp
@@ -77,6 +77,38 @@ namespace pythonic {
                     std::copy(expr.begin(), expr.end(), begin());
                     return *this;
                 }
+                template<class E>
+                numpy_fexpr& operator+=(E const& expr) {
+                    return *(this) = *this + expr;
+                }
+                template<class E>
+                numpy_fexpr& operator-=(E const& expr) {
+                    return *(this) = *this - expr;
+                }
+                template<class E>
+                numpy_fexpr& operator*=(E const& expr) {
+                    return *(this) = *this * expr;
+                }
+                template<class E>
+                numpy_fexpr& operator/=(E const& expr) {
+                    return *(this) = *this / expr;
+                }
+                template<class E>
+                numpy_fexpr& operator&=(E const& expr) {
+                    return *(this) = *this & expr;
+                }
+                template<class E>
+                numpy_fexpr& operator|=(E const& expr) {
+                    return *(this) = *this | expr;
+                }
+                template<class E>
+                numpy_fexpr& operator>>=(E const& expr) {
+                    return *(this) = *this >> expr;
+                }
+                template<class E>
+                numpy_fexpr& operator<<=(E const& expr) {
+                    return *(this) = *this << expr;
+                }
 
                 const_iterator begin() const { return const_iterator(*this, 0); }
                 const_iterator end() const { return const_iterator(*this, shape[0]); }

--- a/pythran/pythonic/types/numpy_iexpr.hpp
+++ b/pythran/pythonic/types/numpy_iexpr.hpp
@@ -98,6 +98,12 @@ namespace pythonic {
                 iterator begin() { return iterator(*this, 0); }
                 iterator end() { return iterator(*this, shape[0]); }
 
+                dtype const * fbegin() const { return buffer; }
+                dtype const * fend() const { return buffer + size(); }
+
+                dtype * fbegin() { return buffer; }
+                dtype const * fend() { return buffer + size(); }
+
                 auto fast(long i) const -> decltype(numpy_iexpr_helper<value>::get(*this, i)) {
                     return numpy_iexpr_helper<value>::get(*this, i);
                 }

--- a/pythran/pythonic/types/numpy_operators.hpp
+++ b/pythran/pythonic/types/numpy_operators.hpp
@@ -7,7 +7,6 @@
 #include "pythonic/operator_/__xor__.hpp"
 #include "pythonic/operator_/div.hpp"
 #include "pythonic/operator_/eq.hpp"
-#include "pythonic/operator_/mod.hpp"
 #include "pythonic/operator_/gt.hpp"
 #include "pythonic/operator_/ge.hpp"
 #include "pythonic/operator_/lshift.hpp"
@@ -20,6 +19,7 @@
 #include "pythonic/operator_/pos.hpp"
 #include "pythonic/operator_/rshift.hpp"
 #include "pythonic/operator_/sub.hpp"
+#include "pythonic/numpy/mod.hpp"
 #include "pythonic/numpy/bitwise_not.hpp"
 
 namespace pythonic {
@@ -54,7 +54,7 @@ namespace pythonic {
 #include "pythonic/types/numpy_binary_op.hpp"
 
 #define NUMPY_BINARY_FUNC_NAME operator%
-#define NUMPY_BINARY_FUNC_SYM operator_::proxy::mod
+#define NUMPY_BINARY_FUNC_SYM numpy::proxy::mod
 #include "pythonic/types/numpy_binary_op.hpp"
 
 #define NUMPY_BINARY_FUNC_NAME operator>

--- a/pythran/tests/test_numpy.py
+++ b/pythran/tests/test_numpy.py
@@ -33,6 +33,37 @@ class TestNumpy(TestEnv):
                       numpy.arange(100).reshape((10, 10)),
                       numpy_augassign5=[numpy.array([numpy.array([int])])])
 
+
+    def test_numpy_faugassign0(self):
+        self.run_test('def numpy_faugassign0(a): a[a>5]+=1; return a',
+                      numpy.arange(100),
+                      numpy_faugassign0=[numpy.array([int])])
+
+    def test_numpy_faugassign1(self):
+        self.run_test('def numpy_faugassign1(a): a[a>3]*=2; return a',
+                      numpy.arange(100),
+                      numpy_faugassign1=[numpy.array([int])])
+
+    def test_numpy_faugassign2(self):
+        self.run_test('def numpy_faugassign2(a): a[a>30]-=2; return a',
+                      numpy.arange(100),
+                      numpy_faugassign2=[numpy.array([int])])
+
+    def test_numpy_faugassign3(self):
+        self.run_test('def numpy_faugassign3(a): a[a<40]/=2; return a',
+                      numpy.arange(100),
+                      numpy_faugassign3=[numpy.array([int])])
+
+    def test_numpy_faugassign4(self):
+        self.run_test('def numpy_faugassign4(a): a[a<4]|=2; return a',
+                      numpy.arange(100),
+                      numpy_faugassign4=[numpy.array([int])])
+
+    def test_numpy_faugassign5(self):
+        self.run_test('def numpy_faugassign5(a): a[a>8]&=2; return a',
+                      numpy.arange(100),
+                      numpy_faugassign5=[numpy.array([int])])
+
     def test_broadcast0(self):
         self.run_test('def numpy_broadcast0(a): a[0] = 1 ; return a',
                       numpy.arange(100).reshape((10, 10)),


### PR DESCRIPTION
### master
#### GCC

$ python -m timeit -c "from pi_buffon import pi_estimate; pi_estimate(2200000,[x/1000. for x in range(1000)],1000) "
10 loops, best of 3: 87.3 msec per loop

$ python -m timeit -c "from prime_decomposition import fac, test_decompose; fac(2**59 - 1)"
100 loops, best of 3: 14 msec per loop

$ python -m timeit -c "from prime_decomposition import fac, test_decompose; test_decompose(2**59 - 1)"
git checkout modulo10 loops, best of 3: 509 msec per loop
#### Clang

$ python -m timeit -c "from pi_buffon import pi_estimate; pi_estimate(2200000,[x/1000. for x in range(1000)],1000) "
10 loops, best of 3: 81.3 msec per loop
## This PR
#### GCC

$ python -m timeit -c "from pi_buffon import pi_estimate; pi_estimate(2200000,[x/1000. for x in range(1000)],1000) "
10 loops, best of 3: 44.7 msec per loop

$ python -m timeit -c "from prime_decomposition import fac, test_decompose; fac(2**59 - 1)"
100 loops, best of 3: 9.21 msec per loop

$ python -m timeit -c "from prime_decomposition import fac, test_decompose; test_decompose(2**59 - 1)"
10 loops, best of 3: 287 msec per loop
#### Clang

$ python -m timeit -c "from pi_buffon import pi_estimate; pi_estimate(2200000,[x/1000. for x in range(1000)],1000) "
10 loops, best of 3: 45 msec per loop
### Before changes in master c04330eb17e0f57d605dd1048e5c959bea1b02e7
#### GCC

$ python -m timeit -c "from pi_buffon import pi_estimate; pi_estimate(2200000,[x/1000. for x in range(1000)],1000) "
10 loops, best of 3: 45 msec per loop

$ python -m timeit -c "from prime_decomposition import fac, test_decompose; fac(2**59 - 1)"
100 loops, best of 3: 9.03 msec per loop

$ python -m timeit -c "from prime_decomposition import fac, test_decompose; test_decompose(2**59 - 1)"
10 loops, best of 3: 279 msec per loop
#### Clang

$ python -m timeit -c "from pi_buffon import pi_estimate; pi_estimate(2200000,[x/1000. for x in range(1000)],1000) "
10 loops, best of 3: 42.6 msec per loop
