### PR TITLE
Fix modulo performance

### DIFF
--- a/pythran/pythonic/numpy/mod.hpp
+++ b/pythran/pythonic/numpy/mod.hpp
@@ -4,8 +4,21 @@
 #include "pythonic/utils/proxy.hpp"
 #include "pythonic/types/ndarray.hpp"
 #include "pythonic/operator_/mod.hpp"
+#include "pythonic/types/assignable.hpp"
 
 namespace pythonic {
+
+    namespace operator_ {
+        template<class A, class B>
+            auto mod(A const& a, B const& b)
+            -> typename std::enable_if<types::is_numexpr_arg<A>::value or types::is_numexpr_arg<B>::value,
+                                       typename assignable<decltype(a%b)>::type>::type
+            {
+                auto t = a % b;
+                t[t<0] = t[t<0] + b; // should be +=, but the patch is in parakeet-test-case
+                return t;
+            }
+    }
 
     namespace numpy {
 #define NUMPY_BINARY_FUNC_NAME mod

--- a/pythran/pythonic/operator_/mod.hpp
+++ b/pythran/pythonic/operator_/mod.hpp
@@ -12,8 +12,10 @@ namespace pythonic {
         //but without using conditional because this function is also used for expression
         //templates at the numpy level
         template <class A, class B>
-            auto mod(A const& a, B const& b) -> decltype(((a % b) + b) % b) {
-                return ((a % b) + b) % b;
+            auto mod(A const& a, B const& b)
+            -> typename std::enable_if<std::is_fundamental<A>::value, decltype(a % b)>::value {
+                auto t = a % b;
+                return t < 0 ? (t + b) : t;
             }
         inline double mod(double a, long b) {
             auto t = std::fmod(a, double(b));

--- a/pythran/pythonic/types/numpy_operators.hpp
+++ b/pythran/pythonic/types/numpy_operators.hpp
@@ -7,7 +7,7 @@
 #include "pythonic/operator_/__xor__.hpp"
 #include "pythonic/operator_/div.hpp"
 #include "pythonic/operator_/eq.hpp"
-#include "pythonic/operator_/mod.hpp"
+#include "pythonic/numpy/mod.hpp"
 #include "pythonic/operator_/gt.hpp"
 #include "pythonic/operator_/ge.hpp"
 #include "pythonic/operator_/lshift.hpp"
@@ -54,7 +54,7 @@ namespace pythonic {
 #include "pythonic/types/numpy_binary_op.hpp"
 
 #define NUMPY_BINARY_FUNC_NAME operator%
-#define NUMPY_BINARY_FUNC_SYM operator_::proxy::mod
+#define NUMPY_BINARY_FUNC_SYM numpy::proxy::mod
 #include "pythonic/types/numpy_binary_op.hpp"
 
 #define NUMPY_BINARY_FUNC_NAME operator>


### PR DESCRIPTION
### c04330eb17e0f57d605dd1048e5c959bea1b02e7
#### GCC

$ python -m timeit -c "from pi_buffon import pi_estimate; pi_estimate(2200000,[x/1000. for x in range(1000)],1000) "
10 loops, best of 3: 45 msec per loop
#### Clang

$ python -m timeit -c "from pi_buffon import pi_estimate; pi_estimate(2200000,[x/1000. for x in range(1000)],1000) "
10 loops, best of 3: 42.6 msec per loop
### master
#### GCC

$ python -m timeit -c "from pi_buffon import pi_estimate; pi_estimate(2200000,[x/1000. for x in range(1000)],1000) "
10 loops, best of 3: 87.3 msec per loop
#### Clang

$ python -m timeit -c "from pi_buffon import pi_estimate; pi_estimate(2200000,[x/1000. for x in range(1000)],1000) "
10 loops, best of 3: 81.3 msec per loop
## This PR
#### GCC

$ python -m timeit -c "from pi_buffon import pi_estimate; pi_estimate(2200000,[x/1000. for x in range(1000)],1000) "
10 loops, best of 3: 44.7 msec per loop
#### Clang

$ python -m timeit -c "from pi_buffon import pi_estimate; pi_estimate(2200000,[x/1000. for x in range(1000)],1000) "
10 loops, best of 3: 45 msec per loop
