### PR TITLE
Add missing import for exceptions

### DIFF
--- a/pythran/analyses/aliases.py
+++ b/pythran/analyses/aliases.py
@@ -8,6 +8,7 @@ import pythran.metadata as md
 from pythran.passmanager import ModuleAnalysis
 from pythran.syntax import PythranSyntaxError
 from pythran.tables import functions, methods, modules
+from pythran.syntax import PythranSyntaxError
 
 
 class Aliases(ModuleAnalysis):

--- a/pythran/analyses/lazyness_analysis.py
+++ b/pythran/analyses/lazyness_analysis.py
@@ -9,6 +9,7 @@ from pure_expressions import PureExpressions
 import pythran.metadata as md
 import pythran.openmp as openmp
 from pythran.passmanager import FunctionAnalysis
+from pythran.syntax import PythranSyntaxError
 
 
 class LazynessAnalysis(FunctionAnalysis):

--- a/pythran/analyses/use_def_chain.py
+++ b/pythran/analyses/use_def_chain.py
@@ -8,6 +8,7 @@ from globals_analysis import Globals
 from imported_ids import ImportedIds
 import pythran.metadata as md
 from pythran.passmanager import FunctionAnalysis
+from pythran.syntax import PythranSyntaxError
 
 
 class UseDefChain(FunctionAnalysis):

--- a/pythran/transformations/expand_builtins.py
+++ b/pythran/transformations/expand_builtins.py
@@ -5,6 +5,7 @@ import ast
 from pythran.analyses import Globals, Locals
 from pythran.passmanager import Transformation
 from pythran.tables import modules
+from pythran.syntax import PythranSyntaxError
 
 
 class ExpandBuiltins(Transformation):


### PR DESCRIPTION
This is not part of the validation and was broken during passes
splitting.
