### PR TITLE
Fix omp performance issue using a manual condition

### DIFF
--- a/pythran/pythonic/types/ndarray.hpp
+++ b/pythran/pythonic/types/ndarray.hpp
@@ -251,7 +251,7 @@ namespace pythonic {
                 /* from a  numpy expression */
                 template<class E>
                     void initialize_from_expr(E const & expr) {
-                        std::copy(expr.begin(), expr.end(), begin());
+                        utils::broadcast_copy(*this, expr, utils::int_<0>());
                     }
 
                 template<class Op, class Arg0, class Arg1>

--- a/pythran/toolchain.py
+++ b/pythran/toolchain.py
@@ -185,6 +185,7 @@ def generate_cxx(module_name, code, specs=None, optimizations=None):
         mod.add_to_preamble([Define("BOOST_SIMD_NO_STRICT_ALIASING", "1")])
         mod.add_to_preamble([Include("pythonic/core.hpp")])
         mod.add_to_preamble([Include("pythonic/python/core.hpp")])
+        mod.add_to_preamble([Line("#ifdef _OPENMP\n#include <omp.h>\n#endif")])
         mod.add_to_preamble(map(Include, _extract_specs_dependencies(specs)))
         mod.add_to_preamble(content.body)
         mod.add_to_init([
@@ -217,6 +218,12 @@ def generate_cxx(module_name, code, specs=None, optimizations=None):
                  'pythonic::types::%s>(&pythonic::translate_%s);\n'
                  '#endif' % (n.__name__.upper(), n.__name__, n.__name__)
                  ) for n in sorted_exceptions])
+
+        mod.add_to_init([
+            # make sure we get no nested parallelism that wreaks havoc in perf
+            Line('#ifdef _OPENMP\n'
+                 'omp_set_max_active_levels(1);\n'
+                 '#endif')])
 
         for function_name, signatures in specs.iteritems():
             internal_func_name = renamings.get(function_name,


### PR DESCRIPTION
Using a manual cut off prevent omp overhead. I run it on codespeed and we have the 75% faster for arc_dist but we don't have the 350% slower for wave_simulation (there is no speed down indeed).

The only perf issues are :
fibo : 25% slowdown (well, it doesn't use numpy so it is certainly noise)
wdist : 25% slowdown too (I have no explaination for this)
