### PR TITLE
Add test annotation for test tuning

### DIFF
--- a/doc/DEVGUIDE.rst
+++ b/doc/DEVGUIDE.rst
@@ -92,30 +92,30 @@ validation suite is run through the command::
 
     $> python setup.py test
 
-It can be tested using the `py.test <http://pytest.org/latest/>` package::
+It is tested using the `pytest <http://pytest.org/latest/>` package::
 
     $> apt-get install python-pytest
 
-To run it faster you may use the `pytest` extension `xdist` from debian package
+To run it faster we use the `pytest` extension `xdist` from debian package
 `python-pytest-xdist` , the test suite will run using all
-available cores. Otherwise it might run **very** slowly, something line four
+available cores. Otherwise it might run **very** slowly, something like four
 hours on a decent laptop :'(.
 
-``pep8`` is checked using the `py.test` extension ``pytest-pep8``. It can be
+``pep8`` is checked using the `pytest` extension ``pytest-pep8``. It can be
 installed using::
 
     $> sudo pip install pytest-pep8
 
-Note that it is still possible to use the ``unittest`` module directly, for
+Note that it is still possible to use the ``pytest`` module directly, for
 instance to pass a subset of the test suite::
 
-    $> PYTHONPATH=.:pythran/tests:$PYTHONPATH python -m unittest test_math
+    $> PYTHONPATH=. pytest -n 8 pythran/tests/test_list.py
 
-runs all the tests found in ``pythran/tests/test_math.py``. The command::
+runs all the tests found in ``pythran/tests/test_list.py``.
 
-    $> PYTHONPATH=. py.test -n 8 pythran/tests/test_list.py
+Only compiler tests can be check using test filtering::
 
-does almost the same with ``py.test``.
+   $> PYTHONPATH=. pytest -n 8 pythran/tests -m "not module"
 
 There are two kinds of tests in ``pythran``:
 

--- a/pythran/tests/test_bisect.py
+++ b/pythran/tests/test_bisect.py
@@ -1,6 +1,8 @@
 import unittest
 from test_env import TestEnv
 
+
+@TestEnv.module
 class TestBisect(TestEnv):
 
     def test_bisect_left0(self):

--- a/pythran/tests/test_env.py
+++ b/pythran/tests/test_env.py
@@ -12,6 +12,7 @@ import sys
 from numpy import ndarray
 import numpy.testing as npt
 import ast
+import pytest
 
 
 class TestEnv(unittest.TestCase):
@@ -19,6 +20,7 @@ class TestEnv(unittest.TestCase):
     Test environment to validate a pythran execution against python
     """
 
+    module = pytest.mark.module
     # default options used for the c++ compiler
     PYTHRAN_CXX_FLAGS = ['-O0', '-fopenmp',
                          '-Wall', '-Wno-unknown-pragmas']

--- a/pythran/tests/test_exception.py
+++ b/pythran/tests/test_exception.py
@@ -361,7 +361,7 @@ class TestException(TestEnv):
     def test_str2_exception_register(self):
         self.run_test("def str2_exception_():\n raise EnvironmentError('a','b')", str2_exception_=[], check_exception=True)
 
-    def test_str3_exception_register(self), check_exception=True:
+    def test_str3_exception_register(self):
         self.run_test("def str3_exception_():\n raise EnvironmentError('a','b','c')", str3_exception_=[], check_exception=True)
 
     def test_str4_exception_register(self):

--- a/pythran/tests/test_itertools.py
+++ b/pythran/tests/test_itertools.py
@@ -1,6 +1,8 @@
 import unittest
 from test_env import TestEnv
 
+
+@TestEnv.module
 class TestItertools(TestEnv):
 
     def test_imap(self):
@@ -20,40 +22,40 @@ class TestItertools(TestEnv):
 
     def test_imap_none(self):
         self.run_test("""
-def imap_none(l0): 
+def imap_none(l0):
     from itertools import imap
     t= 0
-    for a in imap(None, l0) : 
+    for a in imap(None, l0) :
         t += a[0]
     return t
 """, [0,1,2], imap_none=[[int]])
 
     def test_imap_none2(self):
         self.run_test("""
-def imap_none2(l0): 
+def imap_none2(l0):
     from itertools import imap
-    t=0 
-    for a in imap(None, l0, l0) : 
+    t=0
+    for a in imap(None, l0, l0) :
         t += sum(a)
     return t
 """, [0,1,2], imap_none2=[[int]])
 
     def test_imap_none_on_generators(self):
         self.run_test("""
-def imap_none_g(l0): 
+def imap_none_g(l0):
     from itertools import imap
     t= 0
-    for a in imap(None, (y for x in l0 for y in xrange(x))) : 
+    for a in imap(None, (y for x in l0 for y in xrange(x))) :
         t += a[0]
     return t
 """, [0,1,2], imap_none_g=[[int]])
 
     def test_imap_none2_on_generators(self):
         self.run_test("""
-def imap_none2_g(l0): 
+def imap_none2_g(l0):
     from itertools import imap
-    t=0 
-    for a in imap(None, (z for x in l0 for z in xrange(x)), (z for y in l0 for z in xrange(y))) : 
+    t=0
+    for a in imap(None, (z for x in l0 for z in xrange(x)), (z for y in l0 for z in xrange(y))) :
         t += sum(a)
     return t
 """, [0,1,2], imap_none2_g=[[int]])
@@ -69,8 +71,8 @@ def imap_none2_g(l0):
 
     def test_ifilter_none(self):
         self.run_test("""
-def ifiltern_(l0): 
-  from itertools import ifilter; 
+def ifiltern_(l0):
+  from itertools import ifilter;
   s = 0
   for b in (ifilter(None, l0)):
     s += 1

--- a/pythran/tests/test_math.py
+++ b/pythran/tests/test_math.py
@@ -1,5 +1,7 @@
 from test_env import TestEnv
 
+
+@TestEnv.module
 class TestMath(TestEnv):
 
     def test_cos_(self):

--- a/pythran/tests/test_numpy.py
+++ b/pythran/tests/test_numpy.py
@@ -2,6 +2,8 @@ import unittest
 from test_env import TestEnv
 import numpy
 
+
+@TestEnv.module
 class TestNumpy(TestEnv):
     def test_numpy_augassign0(self):
         self.run_test('def numpy_augassign0(a): a+=1; return a',

--- a/pythran/tests/test_operator.py
+++ b/pythran/tests/test_operator.py
@@ -1,6 +1,8 @@
 import unittest
 from test_env import TestEnv
 
+
+@TestEnv.module
 class TestOperator(TestEnv):
 
     def test_lt(self):
@@ -312,7 +314,7 @@ class TestOperator(TestEnv):
 
     def test_indexOf(self):
         self.run_test("def indexOf(a,b):\n from operator import indexOf\n return indexOf(a,b)", [4,3,2,1], 4, indexOf=[[int],int])
-         
+
     def test_itemgetter(self):
         self.run_test("def itemgetter(i,a):\n from operator import itemgetter\n g = itemgetter(i)\n return g(a)", 2, [4,3,2,1], itemgetter=[int,[int]])
 

--- a/pythran/tests/test_os.py
+++ b/pythran/tests/test_os.py
@@ -1,5 +1,7 @@
 from test_env import TestEnv
 
+
+@TestEnv.module
 class TestOs(TestEnv):
 
     def test_os_path(self):

--- a/pythran/tests/test_random.py
+++ b/pythran/tests/test_random.py
@@ -1,5 +1,7 @@
 from test_env import TestEnv
 
+
+@TestEnv.module
 class TestRandom(TestEnv):
 
     def test_random_(self):

--- a/pythran/tests/test_simd.py
+++ b/pythran/tests/test_simd.py
@@ -2,6 +2,8 @@ from test_env import TestEnv
 import test_numpy
 import test_cases
 
+
+@TestEnv.module
 class TestSimd(test_numpy.TestNumpy, test_cases.TestCases):
 
     PYTHRAN_CXX_FLAGS = TestEnv.PYTHRAN_CXX_FLAGS + ['-DUSE_BOOST_SIMD', '-march=native']

--- a/pythran/tests/test_time.py
+++ b/pythran/tests/test_time.py
@@ -1,5 +1,7 @@
 from test_env import TestEnv
 
+
+@TestEnv.module
 class TestTime(TestEnv):
 
     def test_time_and_sleep(self):


### PR DESCRIPTION
- Thanks to pytest mark, we can select tests with -m module (to execute
- only module annotate class) and -m not module (to execute only not
- annotate class)
