### PR TITLE
Loop unrolling threshold was too small

### DIFF
--- a/pythran/optimizations/loop_full_unrolling.py
+++ b/pythran/optimizations/loop_full_unrolling.py
@@ -29,7 +29,7 @@ class LoopFullUnrolling(Transformation):
     i += j
     '''
 
-    MAX_NODE_COUNT = 512
+    MAX_NODE_COUNT = 1024
 
     def visit_For(self, node):
         # first unroll children if needed or possible


### PR DESCRIPTION
it prevented unrolling on this simple example:

```
#pythran export conv(float[][], float[][])
import numpy as np
def conv(image, weights):
    result = np.zeros_like(image)
    for i in range(1, image.shape[0]-2):
        for j in range(1, image.shape[1]-2):
            for ii in range(-1,2,1):
                for jj in range(-1,2,1):
                    coef = weights[ii+1, jj+1]
                    result[i,j] += image[ii+i, jj+j] * coef
    return result
```
