### PR TITLE
Fix numpy_gexpr initialization

### DIFF
--- a/pythran/pythonic/types/numpy_gexpr.hpp
+++ b/pythran/pythonic/types/numpy_gexpr.hpp
@@ -190,13 +190,12 @@ namespace pythonic {
                     fix_shape(arg); // This is specialized for numpy_gexpr only
                 }
 
-
                 template<class Argp, class... Sp>
-                numpy_gexpr(numpy_gexpr<Argp, Sp...> const &expr, Arg &&arg) : arg(std::forward<Arg>(arg)), buffer(arg.buffer) {
+                numpy_gexpr(numpy_gexpr<Argp, Sp...> const &expr, Arg arg) : arg(arg), buffer(arg.buffer) {
                   flat_copy<value>()(&shape[0], &expr.shape[1]);
                   flat_copy<value>()(&lower[0], &expr.lower[1]);
                   flat_copy<value>()(&step[0], &expr.step[1]);
-                  flat_copy<std::remove_reference<Arg>::type::value - value>()(&indices[0], &expr.indices[0]);
+                  flat_copy<Arg::value - value>()(&indices[0], &expr.indices[0]);
                 }
 
                 template<class G>

--- a/pythran/tests/cases/periodic_bc.py
+++ b/pythran/tests/cases/periodic_bc.py
@@ -1,0 +1,6 @@
+#pythran export periodic_bc(float [][][])
+#runas import numpy; r = numpy.arange(0., 27.).reshape((3,3,3)); periodic_bc(r)
+def periodic_bc(f):
+        f[:, 0, :] = f[:, -2, :]
+        return f
+


### PR DESCRIPTION
There was a confusion between universal references and R-value
references. Doing a raw copy is the best match I can find here.
