### PR TITLE
Do not rely on nt2::pow when index is a known integer

### DIFF
--- a/pythran/optimizations/square.py
+++ b/pythran/optimizations/square.py
@@ -4,6 +4,7 @@ from pythran.passmanager import Transformation
 from pythran.analyses.ast_matcher import ASTMatcher, AST_any
 
 import ast
+import copy
 
 
 class Square(Transformation):
@@ -36,6 +37,7 @@ class Square(Transformation):
         Transformation.__init__(self)
 
     def replace(self, value):
+        self.update = self.need_import = True
         return ast.Call(ast.Attribute(ast.Name('numpy', ast.Load()),
                                       'square', ast.Load()),
                         [value], [], None, None)
@@ -48,18 +50,35 @@ class Square(Transformation):
             node.body.insert(0, importIt)
         return node
 
+    def expand_pow(self, node, n):
+        if n == 0:
+            return ast.Num(1)
+        elif n == 1:
+            return node
+        else:
+            node_square = self.replace(node)
+            node_pow = self.expand_pow(node_square, n >> 1)
+            if n & 1:
+                return ast.BinOp(node_pow, ast.Mult(), copy.deepcopy(node))
+            else:
+                return node_pow
+
     def visit_BinOp(self, node):
         self.generic_visit(node)
         if ASTMatcher(Square.POW_PATTERN).search(node):
-            self.update = self.need_import = True
             return self.replace(node.left)
+        elif isinstance(node.op, ast.Pow) and isinstance(node.right, ast.Num):
+            n = node.right.n
+            if int(n) == n and n > 0:
+                return self.expand_pow(node.left, n)
+            else:
+                return node
         else:
             return node
 
     def visit_Call(self, node):
         self.generic_visit(node)
         if ASTMatcher(Square.POWER_PATTERN).search(node):
-            self.update = self.need_import = True
             return self.replace(node.args[0])
         else:
             return node

--- a/pythran/pythonic/numpy/power.hpp
+++ b/pythran/pythonic/numpy/power.hpp
@@ -11,7 +11,6 @@
 namespace nt2 {
 // See https://github.com/MetaScale/nt2/issues/794
 double pow(long n, double m) { return pow(static_cast<double>(n), m); }
-long pow(long n, long m) { return std::pow(n, m); }
 }
 
 namespace pythonic {
@@ -19,6 +18,8 @@ namespace pythonic {
     namespace numpy {
 #define NUMPY_NARY_FUNC_NAME power
 #define NUMPY_NARY_FUNC_SYM nt2::pow
+// no need to adapt_type here, as it may turn a**2 into a**2.f
+#define NUMPY_NARY_RESHAPE_MODE reshape_type
 #include "pythonic/types/numpy_nary_expr.hpp"
     }
 }

--- a/pythran/tests/cases/ln.py
+++ b/pythran/tests/cases/ln.py
@@ -1,0 +1,6 @@
+#pythran export ln(float64[], float64[])
+#runas import numpy; a = numpy.arange(0, 1., 1./100); b = numpy.empty_like(a) ; ln(a,b)
+def ln(X, Y):
+    Y[:] = (X-1) - (X-1)**2 / 2 + (X-1)**3 / 3 - (X-1)**4 / 4 + (X-1)**5 / 5 - (X-1)**6 / 6 + (X-1)**7 / 7 - (X-1)**8 / 8 + (X-1)**9 / 9
+    return Y
+


### PR DESCRIPTION
Doing so makes it possible to achieve > x10 speedup while keeping numpy
correctness.