### PR TITLE
Nan comparison leads to an infinite loop in the optimization loop

### DIFF
--- a/pythran/analyses/ast_matcher.py
+++ b/pythran/analyses/ast_matcher.py
@@ -2,6 +2,7 @@
 
 from ast import AST, iter_fields, NodeVisitor, Dict, Set
 from itertools import permutations
+from math import isnan
 
 MAX_UNORDERED_LENGTH = 10
 
@@ -134,7 +135,14 @@ class Check(NodeVisitor):
         is_good_node = (isinstance(pattern_field, AST) and
                         Check(node_field,
                               self.placeholders).visit(pattern_field))
-        is_same = pattern_field == node_field
+
+        def strict_eq(f0, f1):
+            try:
+                return f0 == f1 or (isnan(f0) and isnan(f1))
+            except TypeError:
+                return f0 == f1
+
+        is_same = strict_eq(pattern_field, node_field)
         return is_good_list or is_good_node or is_same
 
     def generic_visit(self, pattern):

--- a/pythran/tests/test_optimizations.py
+++ b/pythran/tests/test_optimizations.py
@@ -3,6 +3,10 @@ from test_env import TestEnv
 
 class TestOptimization(TestEnv):
 
+    def test_constant_fold_nan(self):
+        code = "def constant_fold_nan(a): from numpy import nan; a[0] = nan; return a"
+        self.run_test(code, [1., 2.], constant_fold_nan=[[float]])
+
     def test_genexp(self):
         self.run_test("def test_genexp(n): return sum((x*x for x in xrange(n)))", 5, test_genexp=[int])
 


### PR DESCRIPTION
ast matcher could not match a NaN litteral as comparison between nan is
always false.

Fixes #401