### PR TITLE
README: Homebrew moved Boost.Python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ Mac OSX
 
 Using brew (http://brew.sh/)::
 
-    $> brew reinstall boost --with-python
+    $> brew install boost-python
     $> brew install gmp
     $> brew install cmake
 


### PR DESCRIPTION
Boost.Python moved to a separate `boost-python` package; installing boost `--with-python` is a no-op now.