### PR TITLE
Globals

### DIFF
--- a/doc/INTERNAL.rst
+++ b/doc/INTERNAL.rst
@@ -203,23 +203,24 @@ cases of Python programs::
     $> pythran internal_top_level_assign.py
     $> python -c 'import internal_top_level_assign'
     13
-    14
 
 Then let's test Python's flow control keywords: for, while, if-else:
 
 Loop statement at top-level::
 
-    $> printf 's=0\nfor i in range(10): print s' > internal_top_level_loop.py
+    $> printf 's=0\nfor i in range(2): print s' > internal_top_level_loop.py
     $> pythran internal_top_level_loop.py
     $> python -c 'import internal_top_level_loop'
-    45
+    0
+    0
 
 While statement at top-level::
 
     $> printf 'i=0\nwhile True:\n print i\n break\nprint i' > internal_top_level_while.py
     $> pythran internal_top_level_while.py
     $> python -c 'import internal_top_level_while'
-    10
+    0
+    0
 
 If-else statement at top-level::
 

--- a/doc/INTERNAL.rst
+++ b/doc/INTERNAL.rst
@@ -199,7 +199,7 @@ show that Pythran can compile it::
 Assignment and AugAssignment statements at top-level are one of the most common
 cases of Python programs::
 
-    $> printf 'a = 1 + (2 + 2) * 3\nprint a\na += 1\nprint a' > internal_top_level_assign.py
+    $> printf 'a = 1 + (2 + 2) * 3\nprint a' > internal_top_level_assign.py
     $> pythran internal_top_level_assign.py
     $> python -c 'import internal_top_level_assign'
     13
@@ -209,14 +209,14 @@ Then let's test Python's flow control keywords: for, while, if-else:
 
 Loop statement at top-level::
 
-    $> printf 's=0\nfor i in range(10):s+=i\nprint s' > internal_top_level_loop.py
+    $> printf 's=0\nfor i in range(10): print s' > internal_top_level_loop.py
     $> pythran internal_top_level_loop.py
     $> python -c 'import internal_top_level_loop'
     45
 
 While statement at top-level::
 
-    $> printf 'i=0\nwhile i<10:i+=1\nprint i' > internal_top_level_while.py
+    $> printf 'i=0\nwhile True:\n print i\n break\nprint i' > internal_top_level_while.py
     $> pythran internal_top_level_while.py
     $> python -c 'import internal_top_level_while'
     10

--- a/doc/TUTORIAL.rst
+++ b/doc/TUTORIAL.rst
@@ -27,8 +27,9 @@ target, a ``ast.Name`` with the identifier ``a``, of the literal value ``1``.
 
 Eventually, one needs to parse more complex codes, and things get a bit more cryptic, but you get the idea::
 
-  >>> fib_src = "def fib(n):"
-  >>> fib_src += "return n if n< 2 else fib(n-1) + fib(n-2)"
+  >>> fib_src = """
+  ... def fib(n):
+  ...     return n if n< 2 else fib(n-1) + fib(n-2)"""
   >>> tree = ast.parse(fib_src)
   >>> print ast.dump(tree)
   Module(body=[FunctionDef(name='fib', args=arguments(args=[Name(id='n', ctx=Param())], vararg=None, kwarg=None, defaults=[]), body=[Return(value=IfExp(test=Compare(left=Name(id='n', ctx=Load()), ops=[Lt()], comparators=[Num(n=2)]), body=Name(id='n', ctx=Load()), orelse=BinOp(left=Call(func=Name(id='fib', ctx=Load()), args=[BinOp(left=Name(id='n', ctx=Load()), op=Sub(), right=Num(n=1))], keywords=[], starargs=None, kwargs=None), op=Add(), right=Call(func=Name(id='fib', ctx=Load()), args=[BinOp(left=Name(id='n', ctx=Load()), op=Sub(), right=Num(n=2))], keywords=[], starargs=None, kwargs=None))))], decorator_list=[])])
@@ -153,10 +154,10 @@ __init__ function::
   >>> tree = ast.parse(code)
   >>> _ = pm.apply(transformations.ExtractTopLevelStmts, tree)
   >>> print pm.dump(backend.Python, tree)
+  a = 1
   def foo():
       return 2
   def __init__():
-      a = 1
       print a
       print (a + foo())
   __init__()

--- a/pythran/analyses/__init__.py
+++ b/pythran/analyses/__init__.py
@@ -30,6 +30,7 @@ from .is_assigned import IsAssigned
 from .lazyness_analysis import LazynessAnalysis
 from .literals import Literals
 from .local_declarations import LocalDeclarations
+from .local_decl import LocalDecl
 from .locals_analysis import Locals
 from .node_count import NodeCount
 from .optimizable_comprehension import OptimizableComprehension

--- a/pythran/analyses/global_declarations.py
+++ b/pythran/analyses/global_declarations.py
@@ -1,22 +1,46 @@
-"""
-GlobalDeclarations gathers top-level declarations
-"""
+""" GlobalDeclarations gathers top-level declarations. """
 
 from pythran.passmanager import ModuleAnalysis
 
 
 class GlobalDeclarations(ModuleAnalysis):
-    """Generates a function name -> function node binding"""
+
+    """ Gather all kind of identifier defined at global scope.
+
+    >>> import ast
+    >>> from pythran import passmanager
+    >>> from pythran.analyses import GlobalDeclarations
+    >>> node = ast.parse('''
+    ... import math
+    ... from math import cos
+    ... c = 12
+    ... def foo(a):
+    ...     b = a + 1''')
+    >>> pm = passmanager.PassManager("test")
+    >>> pm.gather(GlobalDeclarations, node).keys()
+    ['cos', 'foo', 'c', 'math']
+
+    """
+
     def __init__(self):
+        """ Result is an identifier with matching definition. """
         self.result = dict()
         super(GlobalDeclarations, self).__init__()
 
     def visit_Import(self, node):
+        """ Import module define a new variable name. """
         self.result.update((a.name, a) for a in node.names)
 
     def visit_ImportFrom(self, node):
+        """ Imported functions define a new variable name. """
         self.result.update((a.asname or a.name, a) for a in node.names)
 
     def visit_FunctionDef(self, node):
+        """ Function definition defined a new identifier. """
         self.result[node.name] = node
         # no generic visit here, so no diving into function body
+
+    def visit_Assign(self, node):
+        """ Assigned global variable define a new identifier. """
+        for target in node.targets:
+            self.result[target.id] = node

--- a/pythran/analyses/local_decl.py
+++ b/pythran/analyses/local_decl.py
@@ -1,0 +1,36 @@
+""" LocalDecl gathers declarations local to a node. """
+
+from pythran.passmanager import NodeAnalysis
+
+import ast
+
+
+class LocalDecl(NodeAnalysis):
+
+    """
+    Gathers all local identifiers from a node.
+
+    >>> import ast
+    >>> from pythran import passmanager, backend
+    >>> node = ast.parse('''
+    ... def foo(a):
+    ...     b = a + 1''')
+    >>> pm = passmanager.PassManager("test")
+    >>> pm.gather(LocalDecl, node)
+    set(['a', 'foo', 'b'])
+    """
+
+    def __init__(self):
+        """ Initialize empty set as the result. """
+        self.result = set()
+        super(LocalDecl, self).__init__()
+
+    def visit_Name(self, node):
+        """ Any node with Store or Param context is a new identifier. """
+        if isinstance(node.ctx, (ast.Store, ast.Param)):
+            self.result.add(node.id)
+
+    def visit_FunctionDef(self, node):
+        """ Function name is a possible identifier. """
+        self.result.add(node.name)
+        self.generic_visit(node)

--- a/pythran/backend.py
+++ b/pythran/backend.py
@@ -11,7 +11,7 @@ from pythran.analyses import YieldPoints, IsAssigned, ASTMatcher, AST_any
 from pythran.analyses import RangeValues, PureExpressions
 from pythran.cxxgen import Template, Include, Namespace, CompilationUnit
 from pythran.cxxgen import Statement, Block, AnnotatedStatement, Typedef
-from pythran.cxxgen import Value, FunctionDeclaration, EmptyStatement
+from pythran.cxxgen import Value, FunctionDeclaration, EmptyStatement, Static
 from pythran.cxxgen import FunctionBody, Line, ReturnStatement, Struct, Assign
 from pythran.cxxgen import For, While, TryExcept, ExceptHandler, If, AutoFor
 from pythran.cxxtypes import Assignable, DeclType, NamedType
@@ -588,7 +588,12 @@ pythonic::types::none_type>::type result_type;
                     Cxx.final_statement))
                 ])
         else:
-            stmt = ReturnStatement(self.visit(node.value))
+            value = self.visit(node.value)
+            if metadata.get(node, metadata.StaticReturn):
+                stmt = Block([Assign("static auto tmp_global", value),
+                              ReturnStatement("tmp_global")])
+            else:
+                stmt = ReturnStatement(value)
             return self.process_omp_attachements(node, stmt)
 
     def visit_Delete(self, _):

--- a/pythran/metadata.py
+++ b/pythran/metadata.py
@@ -9,15 +9,21 @@ from ast import AST  # so that metadata are walkable as regular ast nodes
 
 
 class Metadata(AST):
+
+    """ Base class to add information on a node to improve code generation. """
+
     def __init__(self):
-        super(Metadata, self).__init__()
+        """ Initialize content of these metadata. """
         self.data = list()
         self._fields = ('data',)
+        super(Metadata, self).__init__()
 
     def __iter__(self):
+        """ Enable iteration over every metadata informations. """
         return iter(self.data)
 
     def append(self, data):
+        """ Add a metadata information. """
         self.data.append(data)
 
 
@@ -31,6 +37,11 @@ class Comprehension(AST):
         super(Comprehension, self).__init__()
         if args:
             self.target = args[0]
+
+
+class StaticReturn(AST):
+
+    """ Metadata to mark return with a constant value. """
 
 
 def add(node, data):

--- a/pythran/middlend.py
+++ b/pythran/middlend.py
@@ -8,12 +8,14 @@ from pythran.transformations import (ExpandBuiltins, ExpandImports,
                                      NormalizeMethodCalls, NormalizeReturn,
                                      NormalizeTuples, RemoveComprehension,
                                      RemoveNestedFunctions, RemoveLambdas,
-                                     UnshadowParameters, RemoveNamedArguments)
+                                     UnshadowParameters, RemoveNamedArguments,
+                                     ExpandGlobals)
 
 
 def refine(pm, node, optimizations):
     """ Refine node in place until it matches pythran's expectations. """
     # Sanitize input
+    pm.apply(ExpandGlobals, node)
     pm.apply(ExpandImportAll, node)
     pm.apply(NormalizeTuples, node)
     pm.apply(ExpandBuiltins, node)

--- a/pythran/syntax.py
+++ b/pythran/syntax.py
@@ -54,7 +54,8 @@ class SyntaxChecker(ast.NodeVisitor):
                 continue
             else:
                 if not any(isinstance(n, getattr(ast, t))
-                           for t in ('FunctionDef', 'Import', 'ImportFrom',)):
+                           for t in ('FunctionDef', 'Import', 'ImportFrom',
+                                     'Assign')):
                     raise PythranSyntaxError(err, n)
         self.generic_visit(node)
 

--- a/pythran/syntax.py
+++ b/pythran/syntax.py
@@ -46,19 +46,6 @@ class SyntaxChecker(ast.NodeVisitor):
         for module in MODULES.itervalues():
             save_attribute(module)
 
-    def visit_Module(self, node):
-        err = ("Top level statements can only be strings, functions, comments"
-               " or imports")
-        for n in node.body:
-            if isinstance(n, ast.Expr) and isinstance(n.value, ast.Str):
-                continue
-            else:
-                if not any(isinstance(n, getattr(ast, t))
-                           for t in ('FunctionDef', 'Import', 'ImportFrom',
-                                     'Assign')):
-                    raise PythranSyntaxError(err, n)
-        self.generic_visit(node)
-
     def visit_Interactive(self, node):
         raise PythranSyntaxError("Interactive session not supported", node)
 

--- a/pythran/transformations/__init__.py
+++ b/pythran/transformations/__init__.py
@@ -12,6 +12,7 @@ import transformations.xxxxx
 
 
 from .expand_builtins import ExpandBuiltins
+from .expand_globals import ExpandGlobals
 from .expand_import_all import ExpandImportAll
 from .expand_imports import ExpandImports
 from .extract_top_level_stmts import ExtractTopLevelStmts

--- a/pythran/transformations/expand_globals.py
+++ b/pythran/transformations/expand_globals.py
@@ -6,6 +6,7 @@ It also turn globals assignment in function definition.
 
 from pythran.analyses import LocalDecl
 from pythran.passmanager import Transformation
+from pythran import metadata
 
 import ast
 
@@ -57,6 +58,7 @@ class ExpandGlobals(Transformation):
                         ast.FunctionDef(target.id,
                                         ast.arguments([], None, None, []),
                                         [ast.Return(value=cst_value)], []))
+                    metadata.add(module_body[-1].body[0], metadata.StaticReturn())
             else:
                 self.local_decl = self.passmanager.gather(LocalDecl, stmt,
                                                           self.ctx)

--- a/pythran/transformations/expand_globals.py
+++ b/pythran/transformations/expand_globals.py
@@ -1,0 +1,80 @@
+"""
+ExpandGlobals replaces globals variables by function call.
+
+It also turn globals assignment in function definition.
+"""
+
+from pythran.analyses import LocalDecl
+from pythran.passmanager import Transformation
+
+import ast
+
+
+class ExpandGlobals(Transformation):
+
+    """
+    Expands all builtins into full paths.
+
+    >>> import ast
+    >>> from pythran import passmanager, backend
+    >>> node = ast.parse('''
+    ... a = 1
+    ... def foo():
+    ...     return a''')
+    >>> pm = passmanager.PassManager("test")
+    >>> _, node = pm.apply(ExpandGlobals, node)
+    >>> print pm.dump(backend.Python, node)
+    def a():
+        return 1
+    def foo():
+        return a()
+    """
+
+    def __init__(self):
+        """ Initialize local declaration and constant name to expand. """
+        self.local_decl = set()
+        self.to_expand = set()
+        super(ExpandGlobals, self).__init__()
+
+    def visit_Module(self, node):
+        """Turn globals assignement to functionDef and visit function defs. """
+        module_body = list()
+        # Gather top level assigned variables.
+        for stmt in node.body:
+            if not isinstance(stmt, ast.Assign):
+                continue
+            for target in stmt.targets:
+                assert isinstance(target, ast.Name)
+                self.to_expand.add(target.id)
+
+        for stmt in node.body:
+            if isinstance(stmt, ast.Assign):
+                self.local_decl = set()
+                cst_value = self.visit(stmt.value)
+                for target in stmt.targets:
+                    assert isinstance(target, ast.Name)
+                    module_body.append(
+                        ast.FunctionDef(target.id,
+                                        ast.arguments([], None, None, []),
+                                        [ast.Return(value=cst_value)], []))
+            else:
+                self.local_decl = self.passmanager.gather(LocalDecl, stmt,
+                                                          self.ctx)
+                module_body.append(self.visit(stmt))
+
+        node.body = module_body
+        return node
+
+    def visit_Name(self, node):
+        """
+        Turn global variable used not shadows to function call.
+
+        We check it is a name from an assignement as import or functions use
+        should not be turn into call.
+        """
+        if (isinstance(node.ctx, ast.Load) and
+                node.id not in self.local_decl and
+                node.id in self.to_expand):
+            return ast.Call(func=node,
+                            args=[], keywords=[], starargs=None, kwargs=None)
+        return node


### PR DESCRIPTION
This one is ready for review.

* static variable for globals look useless as constant folding already expend these values.
* local_decl and local_declaration looks really similare. I didn't merge them because
they don't return the same type. We should be able to return only strings but it can't be done without modification in typing (and I am not sure it is a good idea...). If we return only ast.Name, we have to create dummy ast.Name (for function name for example) and it will also need modification in typing.
We could return a dict with both string_name and ast.Name but typing will have to handle dummy ast.Name (once again, we have to touch typing)