### PR TITLE
Add python-dev dependency to README.srt

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Debian/Ubuntu
    Pythran depends on a few Python modules and several C++ libraries. On a debian-like platform, run::
 
         $> sudo apt-get install libboost-python-dev libgmp-dev libboost-dev git cmake
-        $> sudo apt-get install python-ply python-networkx python-numpy
+        $> sudo apt-get install python-dev python-ply python-networkx python-numpy
 
 2. Use ``easy_install`` or ``pip``::
 


### PR DESCRIPTION
python-dev doesn't seem to be installed by libboost-python-dev, at least I had to install it after getting an error "pyconfig.h no such file or directory in wrap_python.py" when running pythran on a sample code.