### PR TITLE
Add random.shuffle(seq)

### DIFF
--- a/pythran/pythonic/include/random/shuffle.hpp
+++ b/pythran/pythonic/include/random/shuffle.hpp
@@ -1,0 +1,21 @@
+#ifndef PYTHONIC_INCLUDE_RANDOM_SHUFFLE_HPP
+#define PYTHONIC_INCLUDE_RANDOM_SHUFFLE_HPP
+
+#include "pythonic/utils/proxy.hpp"
+#include "pythonic/random/random.hpp"
+
+namespace pythonic {
+
+    namespace random {
+        template <class T>
+        void shuffle(T & seq);
+        template <class T, class function>
+        void shuffle(T &seq, function && randf);
+        
+        PROXY_DECL(pythonic::random, shuffle)
+
+    }
+
+}
+
+#endif

--- a/pythran/pythonic/random/shuffle.hpp
+++ b/pythran/pythonic/random/shuffle.hpp
@@ -1,0 +1,48 @@
+#ifndef PYTHONIC_RANDOM_SHUFFLE_HPP
+#define PYTHONIC_RANDOM_SHUFFLE_HPP
+
+#include "pythonic/include/random/shuffle.hpp"
+
+#include "pythonic/utils/proxy.hpp"
+#include "pythonic/random/random.hpp"
+
+#include <limits>
+
+namespace pythonic {
+
+    namespace random {
+
+        template <class T>
+        void shuffle(T & seq) {
+            std::shuffle(seq.begin(), seq.end(), __random_generator);
+        }
+
+        namespace details {
+            template <class function>
+            struct URG {
+                URG(function && f) : randf(f) {}
+
+                typedef unsigned result_type;
+                result_type min() { return 0; }
+                /* -1 because of the floor() operation performed by the float->unsigned conversion */
+                result_type max() { return std::numeric_limits<result_type>::max() - 1;}
+                result_type operator()() {
+                    return randf() * std::numeric_limits<result_type>::max();
+                }
+
+                function randf;
+            };
+        }
+
+        template <class T, class function>
+        void shuffle(T & seq, function && randf) {    
+            std::shuffle(seq.begin(), seq.end(), details::URG<function>(std::forward<function>(randf)));
+        }
+
+        PROXY_IMPL(pythonic::random, shuffle)
+
+    }
+
+}
+
+#endif

--- a/pythran/tables.py
+++ b/pythran/tables.py
@@ -698,6 +698,7 @@ MODULES = {
         "expovariate": FunctionIntr(global_effects=True),
         "sample": FunctionIntr(global_effects=True),
         "choice": FunctionIntr(global_effects=True),
+        "shuffle": FunctionIntr(global_effects=True),
         },
     "omp": {
         "set_num_threads": FunctionIntr(global_effects=True),

--- a/pythran/tests/test_random.py
+++ b/pythran/tests/test_random.py
@@ -31,6 +31,15 @@ class TestRandom(TestEnv):
     def test_sample_(self):
         self.run_test("def sample_(n,k): from random import sample ; s = sum(sum(sample(range(n),k)) for x in range(n)) ; return abs(s/float(n*n)) < .05  ", 10**4, 4, sample_=[int, int])
 
+    def test_shuffle1(self):
+        self.run_test("def shuffle1(n): from random import shuffle ; r = range(n); shuffle(r); return len(r) == n and r != range(n) and sorted(r) == range(n)" , 10**4,  shuffle1=[int])
+
+    def test_shuffle2(self):
+        self.run_test("def shuffle2(n): from random import shuffle, random ; r = range(n); shuffle(r, lambda: 0); return len(r) == n and r != range(n)  and sorted(r) == range(n)" , 10**4,  shuffle2=[int])
+
+    def test_shuffle3(self):
+        self.run_test("def shuffle2(n): from random import shuffle, random ; r = range(n); shuffle(r, random); return len(r) == n and r != range(n)  and sorted(r) == range(n)" , 10**4,  shuffle2=[int])
+
     def test_choice(self):
         self.run_test("def choice_(n): from random import choice ; s= sum(choice(range(n)) for x in xrange(n)) ; return abs(s/n - n/2) < .05", 10**5,  choice_=[int])
 


### PR DESCRIPTION
I tried adding the other version, with a custom random number generator:

```cpp
    	template <class T, class function>
    	void shuffle(T & seq, function && randf) {
    		std::shuffle(seq.begin(), seq.end(), [&](int min, int max) -> int {
    			return (max - min) * randf() + min;
    		});
    	}
```

This works when calling it like that:

```python
import random
dests = range(64)

random.shuffle(dests, random.random)

print dests
```

but this fails:

```python
import random
dests = range(64)

def f():
    return 0.0

random.shuffle(dests, f)

print dests
```

So I didn't add the second version of `random.shuffle`.