### PR TITLE
Adding blas dependency for Debian in README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ build
 dist
 website/*.html
 website/license.txt
+pythran/nt2
+pythran/boost
+parsetab.py

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Debian/Ubuntu
 
    Pythran depends on a few Python modules and several C++ libraries. On a debian-like platform, run::
 
-        $> sudo apt-get install libboost-python-dev libgmp-dev libboost-dev cmake
+        $> sudo apt-get install libboost-python-dev libgmp-dev libboost-dev cmake libblas-dev
         $> sudo apt-get install python-dev python-ply python-networkx python-numpy
 
 2. Use ``easy_install`` or ``pip``::


### PR DESCRIPTION
It looks like installing numpy does not install blas on Debian testing. Can anybody else confirm?