### PR TITLE
Python code cleaning

### DIFF
--- a/pythran/analyses/ast_matcher.py
+++ b/pythran/analyses/ast_matcher.py
@@ -88,7 +88,7 @@ class Check(NodeVisitor):
             return True
 
     @staticmethod
-    def visit_AST_any(pattern):
+    def visit_AST_any(_):
         """ Every node match with it. """
         return True
 

--- a/pythran/analyses/cfg.py
+++ b/pythran/analyses/cfg.py
@@ -42,7 +42,7 @@ class CFG(FunctionAnalysis):
     visit_Expr = visit_Print = visit_ImportFrom = visit_Pass
     visit_Yield = visit_Delete = visit_Pass
 
-    def visit_Return(self, node):
+    def visit_Return(self, _):
         """OUT = (), RAISES = ()"""
         return (), ()
 
@@ -61,9 +61,9 @@ class CFG(FunctionAnalysis):
                 self.result.add_edge(curr, n)
             currs, nraises = self.visit(n)
             for nraise in nraises:
-                if type(nraise) is ast.Break:
+                if isinstance(nraise, ast.Break):
                     break_currs += (nraise,)
-                elif type(nraise) is ast.Continue:
+                elif isinstance(nraise, ast.Continue):
                     self.result.add_edge(nraise, node)
                 else:
                     raises += (nraise,)
@@ -133,7 +133,7 @@ class CFG(FunctionAnalysis):
                 self.result.add_edge(curr, n)
             currs, nraises = self.visit(n)
             for nraise in nraises:
-                if type(nraise) is ast.Raise:
+                if isinstance(nraise, ast.Raise):
                     for handler in node.handlers:
                         self.result.add_edge(nraise, handler)
                 else:

--- a/pythran/analyses/constant_expressions.py
+++ b/pythran/analyses/constant_expressions.py
@@ -99,7 +99,7 @@ class ConstantExpressions(NodeAnalysis):
     visit_Tuple = visit_List
     visit_Set = visit_List
 
-    def visit_Slice(self, node):
+    def visit_Slice(self, _):
         # ultra-conservative, indeed
         return False
 

--- a/pythran/analyses/dependencies.py
+++ b/pythran/analyses/dependencies.py
@@ -68,16 +68,16 @@ class Dependencies(ModuleAnalysis):
         self.result.add(('utils', 'yield'))
         self.generic_visit(node)
 
-    def visit_Mod(self, node):
+    def visit_Mod(self, _):
         self.result.add(('operator_', 'mod'))
 
-    def visit_FloorDiv(self, node):
+    def visit_FloorDiv(self, _):
         self.result.add(('operator_', 'floordiv'))
 
     def visit_Num(self, node):
-        if type(node.n) is complex:
+        if isinstance(node.n, complex):
             self.result.add(('types', 'complex'))
-        elif type(node.n) is long:
+        elif isinstance(node.n, long):
             self.result.add(('types', 'long'))
         elif math.isnan(node.n):
             self.result.add(('numpy', 'nan'))

--- a/pythran/analyses/global_effects.py
+++ b/pythran/analyses/global_effects.py
@@ -78,7 +78,7 @@ class GlobalEffects(ModuleAnalysis):
         assert self.current_function in self.result
         self.generic_visit(node)
 
-    def visit_Print(self, node):
+    def visit_Print(self, _):
         self.current_function.global_effect = True
 
     def visit_Call(self, node):

--- a/pythran/analyses/has_break.py
+++ b/pythran/analyses/has_break.py
@@ -11,8 +11,8 @@ class HasBreak(NodeAnalysis):
         self.result = False
         super(HasBreak, self).__init__()
 
-    def visit_For(self, node):
+    def visit_For(self, _):
         return
 
-    def visit_Break(self, node):
+    def visit_Break(self, _):
         self.result = True

--- a/pythran/analyses/has_continue.py
+++ b/pythran/analyses/has_continue.py
@@ -11,8 +11,8 @@ class HasContinue(NodeAnalysis):
         self.result = False
         super(HasContinue, self).__init__()
 
-    def visit_For(self, node):
+    def visit_For(self, _):
         return
 
-    def visit_Continue(self, node):
+    def visit_Continue(self, _):
         self.result = True

--- a/pythran/analyses/ordered_global_declarations.py
+++ b/pythran/analyses/ordered_global_declarations.py
@@ -36,7 +36,7 @@ class OrderedGlobalDeclarations(ModuleAnalysis):
         new_count = 0
         # iteratively propagate weights
         while new_count != old_count:
-            for k, v in self.result.iteritems():
+            for v in self.result.itervalues():
                 [v.update(self.result[f]) for f in list(v)]
             old_count = new_count
             new_count = reduce(lambda acc, s: acc + len(s),

--- a/pythran/analyses/potential_iterator.py
+++ b/pythran/analyses/potential_iterator.py
@@ -20,17 +20,17 @@ class PotentialIterator(NodeAnalysis):
         self.generic_visit(node)
 
     def visit_Compare(self, node):
-        if type(node.ops[0]) in [ast.In, ast.NotIn]:
+        if isinstance(node.ops[0], (ast.In, ast.NotIn)):
             self.result.update(node.comparators)
         self.generic_visit(node)
 
     def visit_Call(self, node):
         for i, arg in enumerate(node.args):
 
-            def isReadOnce(f):
+            def isReadOnce(f, i):
                 return (f in self.argument_read_once and
                         self.argument_read_once[f][i] <= 1)
-            if all(isReadOnce(alias)
+            if all(isReadOnce(alias, i)
                    for alias in self.aliases[node.func].aliases):
                 self.result.add(arg)
         self.generic_visit(node)

--- a/pythran/analyses/range_values.py
+++ b/pythran/analyses/range_values.py
@@ -251,7 +251,7 @@ class RangeValues(FunctionAnalysis):
                      max(orelse_res.high, body_res.high))
 
     @staticmethod
-    def visit_Compare(node):
+    def visit_Compare(_):
         """ Boolean are possible index.
 
         >>> import ast

--- a/pythran/analyses/use_def_chain.py
+++ b/pythran/analyses/use_def_chain.py
@@ -43,19 +43,17 @@ class UseDefChain(FunctionAnalysis):
 
     def add_loop_edges(self, prev_node):
         self.merge_dict_set(self.continue_, self.current_node)
-        for id in self.continue_:
-            if id in self.result:
-                graph = self.result[id]
+        for nid in self.continue_:
+            if nid in self.result:
+                graph = self.result[nid]
             else:
-                graph = self.use_only[id]
-            if id in prev_node and prev_node[id] != self.continue_[id]:
-                entering_node = [i for j in prev_node[id]
+                graph = self.use_only[nid]
+            if nid in prev_node and prev_node[nid] != self.continue_[nid]:
+                entering_node = [i for j in prev_node[nid]
                                  for i in graph.successors_iter(j)]
             else:
-                def cond(x):
-                    return graph.in_degree(x) == 0
-                entering_node = filter(cond, graph)
-            graph.add_edges_from(product(self.continue_[id],
+                entering_node = [n for n in graph if graph.in_degree(n) == 0]
+            graph.add_edges_from(product(self.continue_[nid],
                                  entering_node))
         self.continue_ = dict()
 

--- a/pythran/analyses/use_omp.py
+++ b/pythran/analyses/use_omp.py
@@ -11,5 +11,5 @@ class UseOMP(FunctionAnalysis):
         self.result = False
         super(UseOMP, self).__init__()
 
-    def visit_OMPDirective(self, node):
+    def visit_OMPDirective(self, _):
         self.result = True

--- a/pythran/config.py
+++ b/pythran/config.py
@@ -1,4 +1,5 @@
 try:
+    # python3 vs. python2
     import configparser
 except:
     import ConfigParser as configparser
@@ -20,22 +21,22 @@ def init_cfg(sys_file, platform_file, user_file):
     user_config_path = os.path.expanduser(
         os.path.join(user_config_dir, user_file))
 
-    cfg = configparser.SafeConfigParser()
+    cfgp = configparser.SafeConfigParser()
     for required in (sys_config_path, platform_config_path):
-        cfg.readfp(open(required))
-    cfg.read([user_config_path])
+        cfgp.readfp(open(required))
+    cfgp.read([user_config_path])
 
     for key in ('CC', 'CXX'):
-        value = cfg.get('compiler', key)
+        value = cfgp.get('compiler', key)
         if value:
             os.environ[key] = value
 
     for obsolete_section in ('user', 'sys'):
-        if cfg.has_section(obsolete_section):
-            logger.warn("Your pythranrc has an obsolete `{}' section".format(
-                obsolete_section))
+        if cfgp.has_section(obsolete_section):
+            logger.warn("Your pythranrc has an obsolete `%s' section",
+                        obsolete_section)
 
-    return cfg
+    return cfgp
 
 
 def make_extension(**extra):

--- a/pythran/conversion.py
+++ b/pythran/conversion.py
@@ -90,11 +90,11 @@ def to_ast(value):
                      types.FunctionType, types.TypeType, types.XRangeType,
                      numpy.ufunc, type(list.append), types.FileType,
                      BaseException, types.GeneratorType) + tuple(itertools_t)
-    if type(value) in (int, long, float, complex):
-        return ast.Num(value)
-    elif isinstance(value, (types.NoneType, bool)):
+    if isinstance(value, (types.NoneType, bool)):
         return ast.Attribute(ast.Name('__builtin__', ast.Load()),
                              str(value), ast.Load())
+    elif isinstance(value, (int, long, float, complex)):
+        return ast.Num(value)
     elif isinstance(value, str):
         return ast.Str(value)
     elif isinstance(value, (list, tuple, set, dict, numpy.ndarray)):

--- a/pythran/dist.py
+++ b/pythran/dist.py
@@ -20,7 +20,7 @@ class PythranExtension(Extension):
 
     The compilation process ends up in a native Python module.
     '''
-    def __init__(self, name, sources, **kwargs):
+    def __init__(self, name, sources):
         # the goal is to rely on original Extension
         # to do so we convert the .py to .cpp with pythran
         # and register the .cpp in place of the .py
@@ -33,7 +33,7 @@ class PythranExtension(Extension):
 
         cxx_sources = []
         for source in sources:
-            base, ext = os.path.splitext(source)
+            base, _ = os.path.splitext(source)
             output_file = base + '.cpp'  # target name
 
             # stage 0 when we have the .py
@@ -44,7 +44,6 @@ class PythranExtension(Extension):
             else:
                 assert os.path.exists(output_file)
                 stage = 1
-                ext = '.cpp'
                 source = output_file
 
             # stage-dependant processing

--- a/pythran/metadata.py
+++ b/pythran/metadata.py
@@ -10,6 +10,7 @@ from ast import AST  # so that metadata are walkable as regular ast nodes
 
 class Metadata(AST):
     def __init__(self):
+        super(Metadata, self).__init__()
         self.data = list()
         self._fields = ('data',)
 
@@ -27,6 +28,7 @@ class Lazy(AST):
 
 class Comprehension(AST):
     def __init__(self, *args):  # no positional argument to be deep copyable
+        super(Comprehension, self).__init__()
         if args:
             self.target = args[0]
 

--- a/pythran/openmp.py
+++ b/pythran/openmp.py
@@ -69,6 +69,7 @@ class OMPDirective(AST):
     '''
 
     def __init__(self, *args):  # no positional argument to be deep copyable
+        super(OMPDirective, self).__init__()
         if not args:
             return
 
@@ -82,7 +83,7 @@ class OMPDirective(AST):
             curr_index = 0
             in_reserved_context = False
             while curr_index < len(s):
-                m = re.match('^([a-zA-Z_]\w*)', s[curr_index:])
+                m = re.match(r'^([a-zA-Z_]\w*)', s[curr_index:])
                 if m:
                     word = m.group(0)
                     curr_index += len(word)
@@ -131,7 +132,7 @@ class GatherOMPData(Transformation):
         Transformation.__init__(self)
         # Remap self.visit_XXXX() to self.attach_data() generic method
         for s in GatherOMPData.statements:
-            setattr(self, "visit_" + s, lambda node_: self.attach_data(node_))
+            setattr(self, "visit_" + s, self.attach_data)
         self.current = list()
 
     def isompdirective(self, node):

--- a/pythran/optimizations/constant_folding.py
+++ b/pythran/optimizations/constant_folding.py
@@ -7,7 +7,6 @@ from pythran.conversion import to_ast, ConversionError, ToNotEval
 from pythran.analyses.ast_matcher import DamnTooLongPattern
 
 import ast
-import numpy
 
 
 class ConstantFolding(Transformation):

--- a/pythran/optimizations/forward_substitution.py
+++ b/pythran/optimizations/forward_substitution.py
@@ -80,15 +80,15 @@ class ForwardSubstitution(Transformation):
                  self.lazyness_analysis[name] == 1) or
                     (self.lazyness_analysis[name] != float('inf') and
                      name in self.literals)):
-                def get(action):
+                def get(udgraph, action):
                     """ Return list of used/def variables. """
                     return [udgraph.node[n]['name'] for n in udgraph.nodes()
                             if udgraph.node[n]['action'] == action]
-                U = get("U")
-                D = get("D")
+                U = get(udgraph, "U")
+                D = get(udgraph, "D")
                 # we can't forward if multiple definition for a variable are
                 # possible or if this variable is a parameter from a function
-                if (len(D) == 1 and len(get("UD")) == 0 and
+                if (len(D) == 1 and len(get(udgraph, "UD")) == 0 and
                         not isinstance(D[0].ctx, ast.Param)):
                     node = _LazyRemover(self.ctx, U, D[0]).visit(node)
                     self.update = True

--- a/pythran/optimizations/loop_full_unrolling.py
+++ b/pythran/optimizations/loop_full_unrolling.py
@@ -43,7 +43,7 @@ class LoopFullUnrolling(Transformation):
         # do not unroll too much to prevent code growth
         node_count = self.passmanager.gather(NodeCount, node, self.ctx)
 
-        if type(node.iter) is ast.List:
+        if isinstance(node.iter, ast.List):
             isvalid = not(has_omp or has_break or has_cont)
             total_count = node_count * len(node.iter.elts)
             issmall = total_count < LoopFullUnrolling.MAX_NODE_COUNT

--- a/pythran/range.py
+++ b/pythran/range.py
@@ -1,4 +1,4 @@
-""" Module with faicilities to represente range values. """
+""" Module with facilities to represent range values. """
 
 from math import isinf
 import ast
@@ -59,17 +59,17 @@ def range_values(args):
             return (args[0].low, args[1].high)
 
 
-def bool_values(args):
+def bool_values(_):
     """ Return boolean value return range. """
     return Range(0, 1)
 
 
-def cmp_values(args):
+def cmp_values(_):
     """ Return Possible range for cmp function. """
     return Range(-1, 1)
 
 
-def positive_values(args):
+def positive_values(_):
     """ Return positive range with an upper bound. """
     return Range(0, float("inf"))
 
@@ -84,7 +84,7 @@ def min_values(args):
     return Range(min([x.low for x in args]), min([x.high for x in args]))
 
 
-def ord_values(args):
+def ord_values(_):
     """ Return possible range for ord function. """
     return Range(0, 255)
 
@@ -163,7 +163,7 @@ def combine_floordiv(range1, range2):
     return Range(numpy.min(res), numpy.max(res))
 
 
-def combine_unknown(range1, range2):
+def combine_unknown(*_):
     """
     Combiner for operation with unknown range result.
 

--- a/pythran/run.py
+++ b/pythran/run.py
@@ -3,7 +3,6 @@
 """ Script to run Pythran file compilation with specified g++ like flags. """
 
 import argparse
-import distutils.sysconfig
 import logging
 import os
 import sys

--- a/pythran/spec.py
+++ b/pythran/spec.py
@@ -4,10 +4,6 @@ This module provides a dummy parser for pythran annotations.
 '''
 
 from numpy import array, ndarray
-from numpy import complex64, complex128
-from numpy import float32, float64
-from numpy import int8, int16, int32, int64
-from numpy import uint8, uint16, uint32, uint64
 
 import os.path
 import ply.lex as lex
@@ -150,6 +146,12 @@ class SpecParser:
                 | FLOAT64
                 | COMPLEX64
                 | COMPLEX128'''
+        # these imports are used indirectly by the eval
+        from numpy import complex64, complex128
+        from numpy import float32, float64
+        from numpy import int8, int16, int32, int64
+        from numpy import uint8, uint16, uint32, uint64
+
         p[0] = eval(p[1])
 
     def p_error(self, p):
@@ -160,7 +162,7 @@ class SpecParser:
             err.filename = self.input_file
         raise err
 
-    def __init__(self, **kwargs):
+    def __init__(self):
         self.lexer = lex.lex(module=self, debug=0)
         self.parser = yacc.yacc(module=self,
                                 debug=0,
@@ -223,5 +225,5 @@ def expand_specs(specs):
     return all_specs
 
 
-def spec_parser(input):
-    return SpecParser()(input)
+def spec_parser(path):
+    return SpecParser()(path)

--- a/pythran/syntax.py
+++ b/pythran/syntax.py
@@ -68,7 +68,7 @@ class SyntaxChecker(ast.NodeVisitor):
         raise PythranSyntaxError(
             "Suites are specific to Jython and not supported", node)
 
-    def visit_ClassDef(self, node):
+    def visit_ClassDef(self, _):
         raise PythranSyntaxError("Classes not supported")
 
     def visit_Print(self, node):
@@ -77,7 +77,7 @@ class SyntaxChecker(ast.NodeVisitor):
             raise PythranSyntaxError(
                 "Printing to a specific stream not supported", node.dest)
 
-    def visit_With(self, node):
+    def visit_With(self, _):
         raise PythranSyntaxError("With statements not supported")
 
     def visit_Call(self, node):

--- a/pythran/transformations/expand_imports.py
+++ b/pythran/transformations/expand_imports.py
@@ -1,7 +1,6 @@
 """ ExpandImports replaces imports by their full paths. """
 
 from pythran.passmanager import Transformation
-from pythran.tables import namespace
 from pythran.utils import path_to_attr
 
 import ast

--- a/pythran/transformations/extract_top_level_stmts.py
+++ b/pythran/transformations/extract_top_level_stmts.py
@@ -15,7 +15,7 @@ class ExtractTopLevelStmts(Transformation):
         module_body = list()
         init_body = list()
         for stmt in node.body:
-            if type(stmt) in ExtractTopLevelStmts.TYPEDEFS:
+            if isinstance(stmt, ExtractTopLevelStmts.TYPEDEFS):
                 module_body.append(stmt)
             else:
                 init_body.append(stmt)

--- a/pythran/transformations/handle_import.py
+++ b/pythran/transformations/handle_import.py
@@ -159,7 +159,7 @@ class ImportedModule(object):
             # Not main module, parse now the imported module
             self.is_main_module = False
             imported_module = importlib.import_module(name)
-            self.node = ast.parse(inspect.getsource(eval("imported_module")))
+            self.node = ast.parse(inspect.getsource(imported_module))
             assert isinstance(self.node, ast.Module)
 
         # Recursively add filename information to all nodes, for debug msg
@@ -271,7 +271,7 @@ class BuiltinModule(object):
         self.exported_functions = dict()
         self.dependent_modules = dict()
 
-    def call_function(self, registry, func_name):
+    def call_function(self, _, func_name):
         # There was a direct call to a function from this builtin. It means it
         # was imported in the caller module in the form: from builtin import
         # foo. We need to add such node to be imported
@@ -282,7 +282,7 @@ class BuiltinModule(object):
         self.exported_functions[func_name] = importFrom
         return func_name
 
-    def import_function(self, registry, func_name):
+    def import_function(self, _, func_name):
         # We could check if the function is supported by Pythran here...
         return func_name
 

--- a/pythran/transformations/normalize_method_calls.py
+++ b/pythran/transformations/normalize_method_calls.py
@@ -77,13 +77,14 @@ class NormalizeMethodCalls(Transformation):
     def visit_Attribute(self, node):
         node = self.generic_visit(node)
         # storing in an attribute -> not a getattr
-        if type(node.ctx) is not ast.Load:
+        if not isinstance(node.ctx, ast.Load):
             return node
         # method name -> not a getattr
         elif node.attr in methods:
             return node
         # imported module -> not a getattr
-        elif type(node.value) is ast.Name and node.value.id in self.imports:
+        elif (isinstance(node.value, ast.Name) and
+              node.value.id in self.imports):
             if node.attr not in MODULES[node.value.id]:
                 msg = ("`" + node.attr + "' is not a member of " +
                        node.value.id + " or Pythran does not support it")

--- a/pythran/transformations/normalize_return.py
+++ b/pythran/transformations/normalize_return.py
@@ -30,7 +30,7 @@ class NormalizeReturn(Transformation):
         map(self.visit, node.body)
         # Look for nodes that have no successors
         for n in self.cfg.predecessors(None):
-            if type(n) not in (ast.Return, ast.Raise):
+            if not isinstance(n, (ast.Return, ast.Raise)):
                 if self.yield_points:
                     node.body.append(ast.Return(None))
                 else:

--- a/pythran/transformations/normalize_tuples.py
+++ b/pythran/transformations/normalize_tuples.py
@@ -64,7 +64,7 @@ class NormalizeTuples(Transformation):
         elif isinstance(node, ast.Tuple) or isinstance(node, ast.List):
             [self.traverse_tuples(n, state + (i,), renamings)
              for i, n in enumerate(node.elts)]
-        elif type(node) in (ast.Subscript, ast.Attribute):
+        elif isinstance(node, (ast.Subscript, ast.Attribute)):
             if state:
                 renamings[node] = state
         else:

--- a/pythran/transformations/remove_named_arguments.py
+++ b/pythran/transformations/remove_named_arguments.py
@@ -67,7 +67,7 @@ class RemoveNamedArguments(Transformation):
                 for func_alias in aliases:
                     if func_alias is None:  # aliasing computation failed
                         pass
-                    elif type(func_alias) is ast.Call:  # nested function
+                    elif isinstance(func_alias, ast.Call):  # nested function
                         # func_alias looks like functools.partial(foo, a)
                         # so we reorder using alias for 'foo'
                         offset = len(func_alias.args) - 1

--- a/pythran/types/reorder.py
+++ b/pythran/types/reorder.py
@@ -76,7 +76,7 @@ class Reorder(Transformation):
                 self.ordered_global_declarations)
             newdef = [f for f in newdef if isinstance(f, ast.FunctionDef)]
         except nx.exception.NetworkXUnfeasible:
-            raise PythranSyntaxError("Infinite function recursion", stmt)
+            raise PythranSyntaxError("Infinite function recursion")
 
         assert set(newdef) == set(olddef), "A function have been lost..."
         node.body = newbody + newdef


### PR DESCRIPTION
Some are serious:
- Use partial functions instead of lambdas referencing iterators in loop
  (that's probably a bug)
- Do not use list or sets as default parameters (that may lead to a bug)

Some are minors:
- Remove useless import
- Remove unused variables
- Remove lambda when the lambda body could be used instead

Some are cosmetic:
- Rename unused parameters
- Use isinstance instead of type