### PR TITLE
add conda build

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,15 @@ Debian/Ubuntu
 		$> sudo apt-get update
 		$> sudo apt-get install pythran
 
+**or**
+
+1. Install ``conda``, following the instruction given in
+   http://conda.pydata.org/docs/install/quick.html
+
+2. Run::
+
+       $> conda install -c serge-sans-paille pythran
+
 Mac OSX
 =======
 


### PR DESCRIPTION
I am not sure if this https://github.com/serge-sans-paille/pythran/issues/350 is still valid, but I think install `pythran` from conda is the easiest way. 

I am myself not a fan of using 'sudo' since I am always working on shared cluster.