### PR TITLE
Fix enumerate over an ndarray corner case

### DIFF
--- a/pythran/pythonic/__builtin__/enumerate.hpp
+++ b/pythran/pythonic/__builtin__/enumerate.hpp
@@ -30,8 +30,9 @@ namespace pythonic
       }
 
       template <class Iterator>
-      auto enumerate_iterator<Iterator>::operator*()
-          -> decltype(std::make_tuple(value, *iter))
+      typename enumerate_iterator_base<Iterator>::value_type
+          enumerate_iterator<Iterator>::
+          operator*()
       {
         return std::make_tuple(value, *iter);
       }
@@ -76,19 +77,15 @@ namespace pythonic
       }
 
       /// details::enumerate implementation
-
       template <class Iterable>
       enumerate<Iterable>::enumerate()
       {
       }
 
-      // FIXME : Here is a possible dangling reference.
-      // enumerate_iterator take seq.begin while the reference is kept with
-      // another seq.
       template <class Iterable>
       enumerate<Iterable>::enumerate(Iterable seq, long first)
-          : enumerate_iterator<typename Iterable::iterator>(seq.begin(), first),
-            seq(seq), end_iter(seq.end(), -1)
+          : Iterable(seq), iterator(Iterable::begin(), first),
+            end_iter(Iterable::end(), -1)
       {
       }
 
@@ -119,7 +116,6 @@ namespace pythonic
         typename std::remove_reference<Iterable>::type>::type>
     enumerate(Iterable &&seq, long first)
     {
-      // FIXME: Here we forward seq while enumerate signature required a copy
       return {std::forward<Iterable>(seq), first};
     }
 

--- a/pythran/pythonic/include/itertools/imap.hpp
+++ b/pythran/pythonic/include/itertools/imap.hpp
@@ -38,9 +38,7 @@ namespace pythonic
       struct imap_iterator
           : std::iterator<
                 typename utils::iterator_min<typename Iters::iterator...>::type,
-                typename imap_res<Operator, Iters...>::type, ptrdiff_t,
-                typename imap_res<Operator, Iters...>::type *,
-                typename imap_res<Operator, Iters...>::type /* no ref */> {
+                typename imap_res<Operator, Iters...>::type> {
 
         std::tuple<typename Iters::iterator...> it;
         Operator _op;

--- a/pythran/pythonic/include/types/nditerator.hpp
+++ b/pythran/pythonic/include/types/nditerator.hpp
@@ -12,15 +12,9 @@ namespace pythonic
      */
     template <class E>
     struct nditerator
-        : public std::iterator<
-              std::random_access_iterator_tag,
-              typename std::remove_reference<decltype(
-                  std::declval<E &>().fast(0))>::type,
-              ptrdiff_t, typename std::remove_reference<decltype(
-                             std::declval<E &>().fast(0))>::type *,
-              typename std::remove_reference<decltype(std::declval<E &>().fast(
-                  0))>::type /* no ref here, because we return a proxy object */
-              > {
+        : public std::iterator<std::random_access_iterator_tag,
+                               typename std::remove_reference<decltype(
+                                   std::declval<E &>().fast(0))>::type> {
       E &data;
       long index;
       nditerator(E &data, long index);

--- a/pythran/tests/cases/check_mask.py
+++ b/pythran/tests/cases/check_mask.py
@@ -1,0 +1,12 @@
+#pythran export check_mask(bool[][], bool[])
+#runas import numpy as np; db = np.array([[0,1,1,0], [1,0,1,1], [1,1,1,1]], dtype=bool); out = np.zeros(3,dtype=bool); check_mask(db, out)
+#from http://stackoverflow.com/questions/34500913/numba-slower-for-numpy-bitwise-and-on-boolean-arrays
+import numpy as np
+def check_mask(db, out, mask=[1, 0, 1]):
+    for idx, line in enumerate(db):
+        target, vector = line[0], line[1:]
+        if (mask == np.bitwise_and(mask, vector)).all():
+            if target == 1:
+                out[idx] = 1
+    return out
+


### PR DESCRIPTION
As pointer out by a FIXME, the enumerate object was eventually holding a
dangling reference.

As a side effect remove an old iterator::reference artifact.

Added a test case from stack overflow pointing out the issue!