### PR TITLE
Complete implementation of numpy.round and numpy.round_

### DIFF
--- a/pythran/pythonic/include/numpy/around.hpp
+++ b/pythran/pythonic/include/numpy/around.hpp
@@ -2,29 +2,35 @@
 #define PYTHONIC_INCLUDE_NUMPY_AROUND_HPP
 
 #include "pythonic/include/numpy/rint.hpp"
-#include <nt2/include/functions/pow.hpp>
+#include "pythonic/include/numpy/asarray.hpp"
 
 namespace pythonic
 {
 
   namespace numpy
   {
+    // fast path
+    template <class E>
+    auto around(E const &a) -> decltype(functor::rint{}(a));
 
     // generic floating point version, pure numpy_expr
     template <class E>
-    auto around(E const &a, long decimals = 0) -> typename std::enable_if<
-        !std::is_integral<typename E::dtype>::value,
-        decltype(functor::rint()(a *nt2::pow(typename E::dtype(10), decimals)) /
-                 nt2::pow(typename E::dtype(10), decimals))>::type;
+    auto around(E const &a, long decimals) -> typename std::enable_if<
+        !std::is_integral<typename types::dtype_of<E>::type>::value,
+        decltype(functor::rint{}(
+                     a *std::declval<typename types::dtype_of<E>::type>()) /
+                 std::declval<typename types::dtype_of<E>::type>())>::type;
 
     // the integer version is only relevant when decimals < 0
     template <class E>
-    auto around(E const &a, long decimals = 0) -> typename std::enable_if<
-        std::is_integral<typename E::dtype>::value,
-        decltype(a / (long)nt2::pow(typename E::dtype(10),
-                                    std::max(0L, -decimals)) *
-                 (long)nt2::pow(typename E::dtype(10),
-                                std::max(0L, -decimals)))>::type;
+    auto around(E const &a, long decimals) -> typename std::enable_if<
+        std::is_integral<typename types::dtype_of<E>::type>::value,
+        decltype((a / std::declval<typename types::dtype_of<E>::type>()) *
+                 std::declval<types::dtype_of<E>::type>())>::type;
+    // list version
+    template <class E>
+    auto around(types::list<E> const &a, long decimals)
+        -> decltype(around(functor::asarray{}(a), decimals));
 
     DECLARE_FUNCTOR(pythonic::numpy, around);
   }

--- a/pythran/pythonic/include/numpy/round.hpp
+++ b/pythran/pythonic/include/numpy/round.hpp
@@ -1,25 +1,14 @@
 #ifndef PYTHONIC_INCLUDE_NUMPY_ROUND_HPP
 #define PYTHONIC_INCLUDE_NUMPY_ROUND_HPP
 
-#include "pythonic/include/utils/functor.hpp"
-#include "pythonic/include/types/ndarray.hpp"
-#include "pythonic/include/utils/numpy_traits.hpp"
-#include <nt2/include/functions/iround2even.hpp>
+#include "pythonic/include/numpy/around.hpp"
 
 namespace pythonic
 {
 
   namespace numpy
   {
-    namespace wrapper
-    {
-      template <class T>
-      T round(T const &v);
-    }
-
-#define NUMPY_NARY_FUNC_NAME round
-#define NUMPY_NARY_FUNC_SYM wrapper::round
-#include "pythonic/include/types/numpy_nary_expr.hpp"
+    USING_FUNCTOR(round, around);
   }
 }
 

--- a/pythran/pythonic/include/numpy/round_.hpp
+++ b/pythran/pythonic/include/numpy/round_.hpp
@@ -1,25 +1,14 @@
-#ifndef PYTHONIC_INCLUDE_NUMPY_ROUND_HPP
-#define PYTHONIC_INCLUDE_NUMPY_ROUND_HPP
+#ifndef PYTHONIC_INCLUDE_NUMPY_ROUND__HPP
+#define PYTHONIC_INCLUDE_NUMPY_ROUND__HPP
 
-#include "pythonic/include/utils/functor.hpp"
-#include "pythonic/include/types/ndarray.hpp"
-#include "pythonic/include/utils/numpy_traits.hpp"
-#include <nt2/include/functions/iround2even.hpp>
+#include "pythonic/include/numpy/around.hpp"
 
 namespace pythonic
 {
 
   namespace numpy
   {
-    namespace wrapper
-    {
-      template <class T>
-      T round_(T const &v);
-    }
-
-#define NUMPY_NARY_FUNC_NAME round_
-#define NUMPY_NARY_FUNC_SYM wrapper::round_
-#include "pythonic/include/types/numpy_nary_expr.hpp"
+    USING_FUNCTOR(round_, around);
   }
 }
 

--- a/pythran/pythonic/include/utils/numpy_traits.hpp
+++ b/pythran/pythonic/include/utils/numpy_traits.hpp
@@ -101,6 +101,15 @@ namespace pythonic
     struct is_numexpr_arg<array<T, N>> {
       static constexpr bool value = true;
     };
+
+    template <class E>
+    struct dtype_of {
+      template <class T>
+      static typename T::dtype get(typename T::dtype *);
+      template <class T>
+      static T get(...);
+      using type = decltype(get<E>(nullptr));
+    };
   }
 }
 

--- a/pythran/pythonic/numpy/round.hpp
+++ b/pythran/pythonic/numpy/round.hpp
@@ -2,30 +2,6 @@
 #define PYTHONIC_NUMPY_ROUND_HPP
 
 #include "pythonic/include/numpy/round.hpp"
-
-#include "pythonic/utils/functor.hpp"
-#include "pythonic/types/ndarray.hpp"
-#include "pythonic/utils/numpy_traits.hpp"
-#include <nt2/include/functions/iround2even.hpp>
-
-namespace pythonic
-{
-
-  namespace numpy
-  {
-    namespace wrapper
-    {
-      template <class T>
-      T round(T const &v)
-      {
-        return nt2::iround2even(v);
-      }
-    }
-
-#define NUMPY_NARY_FUNC_NAME round
-#define NUMPY_NARY_FUNC_SYM wrapper::round
-#include "pythonic/types/numpy_nary_expr.hpp"
-  }
-}
+#include "pythonic/numpy/around.hpp"
 
 #endif

--- a/pythran/pythonic/numpy/round_.hpp
+++ b/pythran/pythonic/numpy/round_.hpp
@@ -1,31 +1,7 @@
-#ifndef PYTHONIC_NUMPY_ROUND_HPP
-#define PYTHONIC_NUMPY_ROUND_HPP
+#ifndef PYTHONIC_NUMPY_ROUND__HPP
+#define PYTHONIC_NUMPY_ROUND__HPP
 
 #include "pythonic/include/numpy/round_.hpp"
-
-#include "pythonic/utils/functor.hpp"
-#include "pythonic/types/ndarray.hpp"
-#include "pythonic/utils/numpy_traits.hpp"
-#include <nt2/include/functions/iround2even.hpp>
-
-namespace pythonic
-{
-
-  namespace numpy
-  {
-    namespace wrapper
-    {
-      template <class T>
-      T round_(T const &v)
-      {
-        return nt2::iround2even(v);
-      }
-    }
-
-#define NUMPY_NARY_FUNC_NAME round_
-#define NUMPY_NARY_FUNC_SYM wrapper::round_
-#include "pythonic/types/numpy_nary_expr.hpp"
-  }
-}
+#include "pythonic/numpy/around.hpp"
 
 #endif

--- a/pythran/pythonic/types/vectorizable_type.hpp
+++ b/pythran/pythonic/types/vectorizable_type.hpp
@@ -41,8 +41,6 @@ namespace pythonic
       struct mod;
       struct nan_to_num;
       struct rint;
-      struct round;
-      struct round_;
       struct signbit;
       struct where;
     }
@@ -67,8 +65,6 @@ namespace pythonic
           not std::is_same<O, numpy::functor::isnan>::value and
           not std::is_same<O, numpy::functor::isposinf>::value and
           not std::is_same<O, numpy::functor::rint>::value and
-          not std::is_same<O, numpy::functor::round>::value and
-          not std::is_same<O, numpy::functor::round_>::value and
           not std::is_same<O, numpy::functor::signbit>::value and
           // conditional processing doesn't permit SIMD
           not std::is_same<O, numpy::functor::nan_to_num>::value and

--- a/pythran/tests/cases/goodExpoMeasure.py
+++ b/pythran/tests/cases/goodExpoMeasure.py
@@ -1,0 +1,17 @@
+#runas import numpy as np; n = 20; a = np.arange(n*n*n).reshape((n,n,n)).astype(np.uint8); b = 2. ; goodExpoMeasure(a, b)
+#pythran export goodExpoMeasure(uint8[][][], float)
+import numpy
+def goodExpoMeasure(inRGB, sigma):
+    '''
+    Compute the good exposition image quality measure on 1 input image.
+    '''
+    R = inRGB[0,:,:].astype(numpy.float)
+    G = inRGB[1,:,:].astype(numpy.float)
+    B = inRGB[2,:,:].astype(numpy.float)
+    goodExpoR = numpy.exp(- ((R - 128)**2) / sigma)
+    goodExpoG = numpy.exp(- ((G - 128)**2) / sigma)
+    goodExpoB = numpy.exp(- ((B - 128)**2) / sigma)
+    goodExpo  = goodExpoR * goodExpoG * goodExpoB
+    goodExpo  = (numpy.round(goodExpo, 2) * (2**8-1)).astype(numpy.uint8)
+
+    return goodExpo


### PR DESCRIPTION
They are explicitly described as alias to numpy.around, so why did we
reimplemented both versions o_O