### PR TITLE
Clean gen

### DIFF
--- a/pythran/pythonic/include/types/empty_iterator.hpp
+++ b/pythran/pythonic/include/types/empty_iterator.hpp
@@ -1,6 +1,8 @@
 #ifndef PYTHONIC_INCLUDE_TYPES_EMPTY_ITERATOR_HPP
 #define PYTHONIC_INCLUDE_TYPES_EMPTY_ITERATOR_HPP
 
+#include <iterator>
+
 namespace pythonic
 {
 

--- a/pythran/pythonic/include/types/generator.hpp
+++ b/pythran/pythonic/include/types/generator.hpp
@@ -2,6 +2,7 @@
 #define PYTHONIC_INCLUDE_TYPES_GENERATOR_HPP
 
 #include <iterator>
+#include <cstddef>
 
 namespace pythonic
 {

--- a/pythran/pythonic/include/utils/shared_ref.hpp
+++ b/pythran/pythonic/include/utils/shared_ref.hpp
@@ -7,6 +7,9 @@
 #ifdef _OPENMP
 #include <atomic>
 #endif
+#ifdef ENABLE_PYTHON_MODULE
+#include <Python.h>
+#endif
 
 namespace pythonic
 {

--- a/pythran/pythonic/python/core.hpp
+++ b/pythran/pythonic/python/core.hpp
@@ -4,6 +4,8 @@
 #ifdef ENABLE_PYTHON_MODULE
 
 #include "Python.h"
+#include <type_traits>
+#include <utility>
 
 namespace pythonic
 {
@@ -12,6 +14,7 @@ namespace pythonic
 
   template <class T>
   struct from_python;
+
 }
 
 template <class T>

--- a/pythran/pythonic/python/core.hpp
+++ b/pythran/pythonic/python/core.hpp
@@ -14,7 +14,6 @@ namespace pythonic
 
   template <class T>
   struct from_python;
-
 }
 
 template <class T>

--- a/pythran/pythonic/python/exception_handler.hpp
+++ b/pythran/pythonic/python/exception_handler.hpp
@@ -1,0 +1,300 @@
+#ifndef PYTHONIC_PYTHON_EXCEPTION_HANDLER_HPP
+#define PYTHONIC_PYTHON_EXCEPTION_HANDLER_HPP
+
+#ifdef ENABLE_PYTHON_MODULE
+
+#include "Python.h"
+#include <utility>
+
+namespace pythonic
+{
+
+  // This function have to be include after every others exceptions to have
+  // correct exception macro defined.
+  template <class F>
+  PyObject *handle_python_exception(F &&f)
+  {
+    try {
+      return f();
+    }
+#ifdef PYTHONIC_BUILTIN_SYNTAXWARNING_HPP
+    catch (pythonic::types::SyntaxWarning &e) {
+      PyErr_SetString(PyExc_SyntaxWarning,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_RUNTIMEWARNING_HPP
+    catch (pythonic::types::RuntimeWarning &e) {
+      PyErr_SetString(PyExc_RuntimeWarning,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_DEPRECATIONWARNING_HPP
+    catch (pythonic::types::DeprecationWarning &e) {
+      PyErr_SetString(PyExc_DeprecationWarning,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_IMPORTWARNING_HPP
+    catch (pythonic::types::ImportWarning &e) {
+      PyErr_SetString(PyExc_ImportWarning,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_UNICODEWARNING_HPP
+    catch (pythonic::types::UnicodeWarning &e) {
+      PyErr_SetString(PyExc_UnicodeWarning,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_BYTESWARNING_HPP
+    catch (pythonic::types::BytesWarning &e) {
+      PyErr_SetString(PyExc_BytesWarning,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_USERWARNING_HPP
+    catch (pythonic::types::UserWarning &e) {
+      PyErr_SetString(PyExc_UserWarning,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_FUTUREWARNING_HPP
+    catch (pythonic::types::FutureWarning &e) {
+      PyErr_SetString(PyExc_FutureWarning,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_PENDINGDEPRECATIONWARNING_HPP
+    catch (pythonic::types::PendingDeprecationWarning &e) {
+      PyErr_SetString(PyExc_PendingDeprecationWarning,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_WARNING_HPP
+    catch (pythonic::types::Warning &e) {
+      PyErr_SetString(PyExc_Warning,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_UNICODEERROR_HPP
+    catch (pythonic::types::UnicodeError &e) {
+      PyErr_SetString(PyExc_UnicodeError,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_VALUEERROR_HPP
+    catch (pythonic::types::ValueError &e) {
+      PyErr_SetString(PyExc_ValueError,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_TYPEERROR_HPP
+    catch (pythonic::types::TypeError &e) {
+      PyErr_SetString(PyExc_TypeError,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_SYSTEMERROR_HPP
+    catch (pythonic::types::SystemError &e) {
+      PyErr_SetString(PyExc_SystemError,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_TABERROR_HPP
+    catch (pythonic::types::TabError &e) {
+      PyErr_SetString(PyExc_TabError,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_INDENTATIONERROR_HPP
+    catch (pythonic::types::IndentationError &e) {
+      PyErr_SetString(PyExc_IndentationError,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_SYNTAXERROR_HPP
+    catch (pythonic::types::SyntaxError &e) {
+      PyErr_SetString(PyExc_SyntaxError,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_NOTIMPLEMENTEDERROR_HPP
+    catch (pythonic::types::NotImplementedError &e) {
+      PyErr_SetString(PyExc_NotImplementedError,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_RUNTIMEERROR_HPP
+    catch (pythonic::types::RuntimeError &e) {
+      PyErr_SetString(PyExc_RuntimeError,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_REFERENCEERROR_HPP
+    catch (pythonic::types::ReferenceError &e) {
+      PyErr_SetString(PyExc_ReferenceError,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_UNBOUNDLOCALERROR_HPP
+    catch (pythonic::types::UnboundLocalError &e) {
+      PyErr_SetString(PyExc_UnboundLocalError,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_NAMEERROR_HPP
+    catch (pythonic::types::NameError &e) {
+      PyErr_SetString(PyExc_NameError,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_MEMORYERROR_HPP
+    catch (pythonic::types::MemoryError &e) {
+      PyErr_SetString(PyExc_MemoryError,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_KEYERROR_HPP
+    catch (pythonic::types::KeyError &e) {
+      PyErr_SetString(PyExc_KeyError,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_INDEXERROR_HPP
+    catch (pythonic::types::IndexError &e) {
+      PyErr_SetString(PyExc_IndexError,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_LOOKUPERROR_HPP
+    catch (pythonic::types::LookupError &e) {
+      PyErr_SetString(PyExc_LookupError,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_IMPORTERROR_HPP
+    catch (pythonic::types::ImportError &e) {
+      PyErr_SetString(PyExc_ImportError,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_EOFERROR_HPP
+    catch (pythonic::types::EOFError &e) {
+      PyErr_SetString(PyExc_EOFError,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_OSERROR_HPP
+    catch (pythonic::types::OSError &e) {
+      PyErr_SetString(PyExc_OSError,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_IOERROR_HPP
+    catch (pythonic::types::IOError &e) {
+      PyErr_SetString(PyExc_IOError,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_ENVIRONMENTERROR_HPP
+    catch (pythonic::types::EnvironmentError &e) {
+      PyErr_SetString(PyExc_EnvironmentError,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_ATTRIBUTEERROR_HPP
+    catch (pythonic::types::AttributeError &e) {
+      PyErr_SetString(PyExc_AttributeError,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_ASSERTIONERROR_HPP
+    catch (pythonic::types::AssertionError &e) {
+      PyErr_SetString(PyExc_AssertionError,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_ZERODIVISIONERROR_HPP
+    catch (pythonic::types::ZeroDivisionError &e) {
+      PyErr_SetString(PyExc_ZeroDivisionError,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_OVERFLOWERROR_HPP
+    catch (pythonic::types::OverflowError &e) {
+      PyErr_SetString(PyExc_OverflowError,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_FLOATINGPOINTERROR_HPP
+    catch (pythonic::types::FloatingPointError &e) {
+      PyErr_SetString(PyExc_FloatingPointError,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_ARITHMETICERROR_HPP
+    catch (pythonic::types::ArithmeticError &e) {
+      PyErr_SetString(PyExc_ArithmeticError,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_BUFFERERROR_HPP
+    catch (pythonic::types::BufferError &e) {
+      PyErr_SetString(PyExc_BufferError,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_STANDARDERROR_HPP
+    catch (pythonic::types::StandardError &e) {
+      PyErr_SetString(PyExc_StandardError,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_STOPITERATION_HPP
+    catch (pythonic::types::StopIteration &e) {
+      PyErr_SetString(PyExc_StopIteration,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_EXCEPTION_HPP
+    catch (pythonic::types::Exception &e) {
+      PyErr_SetString(PyExc_Exception,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_GENERATOREXIT_HPP
+    catch (pythonic::types::GeneratorExit &e) {
+      PyErr_SetString(PyExc_GeneratorExit,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_KEYBOARDINTERRUPT_HPP
+    catch (pythonic::types::KeyboardInterrupt &e) {
+      PyErr_SetString(PyExc_KeyboardInterrupt,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_SYSTEMEXIT_HPP
+    catch (pythonic::types::SystemExit &e) {
+      PyErr_SetString(PyExc_SystemExit,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+#ifdef PYTHONIC_BUILTIN_BASEEXCEPTION_HPP
+    catch (pythonic::types::BaseException &e) {
+      PyErr_SetString(PyExc_BaseException,
+                      pythonic::__builtin__::functor::str{}(e.args).c_str());
+    }
+#endif
+    catch (...) {
+      PyErr_SetString(PyExc_RuntimeError,
+                      "Something happened on the way to heaven");
+    }
+    return nullptr;
+  }
+}
+
+#endif
+
+#endif

--- a/pythran/tests/test_exception.py
+++ b/pythran/tests/test_exception.py
@@ -1,5 +1,105 @@
 from test_env import TestEnv
+import __builtin__
 import unittest
+
+exceptions = [i for i in dir(__builtin__)
+              if (isinstance(getattr(__builtin__, i), type) and
+                  issubclass(getattr(__builtin__, i),
+                             __builtin__.BaseException))]
+
+ALL_EXCEPTION_CODE = """
+def {tested_exception}_register(name):
+    if name == "BaseException":
+        raise BaseException('abc')
+    if name == "SystemExit":
+        raise SystemExit('a','b','c')
+    if name == "KeyboardInterrupt":
+        raise KeyboardInterrupt('a','b','c')
+    if name == "GeneratorExit":
+        raise GeneratorExit('a','b','c')
+    if name == "Exception":
+        raise Exception('a','b','c')
+    if name == "StopIteration":
+        raise StopIteration('a','b','c')
+    if name == "StandardError":
+        raise StandardError('a','b','c')
+    if name == "Warning":
+        raise Warning('a','b','c')
+    if name == "BytesWarning":
+        raise BytesWarning('a','b','c')
+    if name == "UnicodeWarning":
+        raise UnicodeWarning('a','b','c')
+    if name == "ImportWarning":
+        raise ImportWarning('a','b','c')
+    if name == "FutureWarning":
+        raise FutureWarning('a','b','c')
+    if name == "UserWarning":
+        raise UserWarning('a','b','c')
+    if name == "SyntaxWarning":
+        raise SyntaxWarning('a','b','c')
+    if name == "RuntimeWarning":
+        raise RuntimeWarning('a','b','c')
+    if name == "PendingDeprecationWarning":
+        raise PendingDeprecationWarning('a','b','c')
+    if name == "DeprecationWarning":
+        raise DeprecationWarning('a','b','c')
+    if name == "BufferError":
+        raise BufferError('a','b','c')
+    if name == "ArithmeticError":
+        raise ArithmeticError('a','b','c')
+    if name == "AssertionError":
+        raise AssertionError('a','b','c')
+    if name == "AttributeError":
+        raise AttributeError('a','b','c')
+    if name == "EnvironmentError":
+        raise EnvironmentError('a','b','c','d')
+    if name == "EOFError":
+        raise EOFError('a','b','c')
+    if name == "ImportError":
+        raise ImportError('a','b','c')
+    if name == "LookupError":
+        raise LookupError('a','b','c')
+    if name == "MemoryError":
+        raise MemoryError('a','b','c')
+    if name == "NameError":
+        raise NameError('a','b','c')
+    if name == "ReferenceError":
+        raise ReferenceError('a','b','c')
+    if name == "RuntimeError":
+        raise RuntimeError('a','b','c')
+    if name == "SyntaxError":
+        raise SyntaxError('a','b','c')
+    if name == "SystemError":
+        raise SystemError('a','b','c')
+    if name == "TypeError":
+        raise TypeError('a','b','c')
+    if name == "ValueError":
+        raise ValueError('a','b','c')
+    if name == "FloatingPointError":
+        raise FloatingPointError('a','b','c')
+    if name == "OverflowError":
+        raise OverflowError('a','b','c')
+    if name == "ZeroDivisionError":
+        raise ZeroDivisionError('a','b','c')
+    if name == "IOError":
+        raise IOError('a','b','c')
+    if name == "OSError":
+        raise OSError('a','b','c')
+    if name == "IndexError":
+        raise IndexError('a','b','c')
+    if name == "KeyError":
+        raise KeyError('a','b','c')
+    if name == "UnboundLocalError":
+        raise UnboundLocalError('a','b','c')
+    if name == "NotImplementedError":
+        raise NotImplementedError('a','b','c')
+    if name == "IndentationError":
+        raise IndentationError('a','b','c')
+    if name == "TabError":
+        raise TabError('a','b','c')
+    if name == "UnicodeError":
+        raise UnicodeError('a','b','c')
+"""
 
 class TestException(TestEnv):
 
@@ -195,73 +295,6 @@ class TestException(TestEnv):
 
 # test if exception translators are registered in pythran
 
-    def test_BaseException_register(self):
-        self.run_test("def BaseException_register(): raise BaseException('abc')", BaseException_register=[], check_exception=True)
-
-    def test_SystemExit_register(self):
-        self.run_test("def SystemExit_register():\n raise SystemExit('a','b','c')", SystemExit_register=[], check_exception=True)
-
-    def test_KeyboardInterrupt_register(self):
-        self.run_test("def KeyboardInterrupt_register():\n raise KeyboardInterrupt('a','b','c')", KeyboardInterrupt_register=[], check_exception=True)
-
-    def test_GeneratorExit_register(self):
-        self.run_test("def GeneratorExit_register():\n raise GeneratorExit('a','b','c')", GeneratorExit_register=[], check_exception=True)
-
-    def test_Exception_register(self):
-        self.run_test("def Exception_register():\n raise Exception('a','b','c')", Exception_register=[], check_exception=True)
-
-    def test_StopIteration_register(self):
-        self.run_test("def StopIteration_register():\n raise StopIteration('a','b','c')", StopIteration_register=[], check_exception=True)
-
-    def test_StandardError_register(self):
-        self.run_test("def StandardError_register():\n raise StandardError('a','b','c')", StandardError_register=[], check_exception=True)
-
-    def test_Warning_register(self):
-        self.run_test("def Warning_register():\n raise Warning('a','b','c')", Warning_register=[], check_exception=True)
-
-    def test_BytesWarning_register(self):
-        self.run_test("def BytesWarning_register():\n raise BytesWarning('a','b','c')", BytesWarning_register=[], check_exception=True)
-
-    def test_UnicodeWarning_register(self):
-        self.run_test("def UnicodeWarning_register():\n raise UnicodeWarning('a','b','c')", UnicodeWarning_register=[], check_exception=True)
-
-    def test_ImportWarning_register(self):
-        self.run_test("def ImportWarning_register():\n raise ImportWarning('a','b','c')", ImportWarning_register=[], check_exception=True)
-
-    def test_FutureWarning_register(self):
-        self.run_test("def FutureWarning_register():\n raise FutureWarning('a','b','c')", FutureWarning_register=[], check_exception=True)
-
-    def test_UserWarning_register(self):
-        self.run_test("def UserWarning_register():\n raise UserWarning('a','b','c')", UserWarning_register=[], check_exception=True)
-
-    def test_SyntaxWarning_register(self):
-        self.run_test("def SyntaxWarning_register():\n raise SyntaxWarning('a','b','c')", SyntaxWarning_register=[], check_exception=True)
-
-    def test_RuntimeWarning_register(self):
-        self.run_test("def RuntimeWarning_register():\n raise RuntimeWarning('a','b','c')", RuntimeWarning_register=[], check_exception=True)
-
-    def test_PendingDeprecationWarning_register(self):
-        self.run_test("def PendingDeprecationWarning_register():\n raise PendingDeprecationWarning('a','b','c')", PendingDeprecationWarning_register=[], check_exception=True)
-
-    def test_DeprecationWarning_register(self):
-        self.run_test("def DeprecationWarning_register():\n raise DeprecationWarning('a','b','c')", DeprecationWarning_register=[], check_exception=True)
-
-    def test_BufferError_register(self):
-        self.run_test("def BufferError_register():\n raise BufferError('a','b','c')", BufferError_register=[], check_exception=True)
-
-    def test_ArithmeticError_register(self):
-        self.run_test("def ArithmeticError_register():\n raise ArithmeticError('a','b','c')", ArithmeticError_register=[], check_exception=True)
-
-    @unittest.skip("incompatible with py.test")
-    def test_AssertionError_register(self):
-        self.run_test("def AssertionError_register():\n raise AssertionError('a','b','c')", AssertionError_register=[], check_exception=True)
-
-    def test_AttributeError_register(self):
-        self.run_test("def AttributeError_register():\n raise AttributeError('a','b','c')", AttributeError_register=[], check_exception=True)
-
-    def test_EnvironmentError4_register(self):
-        self.run_test("def EnvironmentError4_register():\n raise EnvironmentError('a','b','c','d')", EnvironmentError4_register=[], check_exception=True)
-
     def test_EnvironmentError3_register(self):
         self.run_test("def EnvironmentError3_register():\n raise EnvironmentError('a','b','c')", EnvironmentError3_register=[], check_exception=True)
 
@@ -270,75 +303,6 @@ class TestException(TestEnv):
 
     def test_EnvironmentError1_register(self):
         self.run_test("def EnvironmentError1_register():\n raise EnvironmentError('a')", EnvironmentError1_register=[], check_exception=True)
-
-    def test_EOFError_register(self):
-        self.run_test("def EOFError_register():\n raise EOFError('a','b','c')", EOFError_register=[], check_exception=True)
-
-    def test_ImportError_register(self):
-        self.run_test("def ImportError_register():\n raise ImportError('a','b','c')", ImportError_register=[], check_exception=True)
-
-    def test_LookupError_register(self):
-        self.run_test("def LookupError_register():\n raise LookupError('a','b','c')", LookupError_register=[], check_exception=True)
-
-    def test_MemoryError_register(self):
-        self.run_test("def MemoryError_register():\n raise MemoryError('a','b','c')", MemoryError_register=[], check_exception=True)
-
-    def test_NameError_register(self):
-        self.run_test("def NameError_register():\n raise NameError('a','b','c')", NameError_register=[], check_exception=True)
-
-    def test_ReferenceError_register(self):
-        self.run_test("def ReferenceError_register():\n raise ReferenceError('a','b','c')", ReferenceError_register=[], check_exception=True)
-
-    def test_RuntimeError_register(self):
-        self.run_test("def RuntimeError_register():\n raise RuntimeError('a','b','c')", RuntimeError_register=[], check_exception=True)
-
-    def test_SyntaxError_register(self):
-        self.run_test("def SyntaxError_register():\n raise SyntaxError('a','b','c')", SyntaxError_register=[], check_exception=True)
-
-    def test_SystemError_register(self):
-        self.run_test("def SystemError_register():\n raise SystemError('a','b','c')", SystemError_register=[], check_exception=True)
-
-    def test_TypeError_register(self):
-        self.run_test("def TypeError_register():\n raise TypeError('a','b','c')", TypeError_register=[], check_exception=True)
-
-    def test_ValueError_register(self):
-        self.run_test("def ValueError_register():\n raise ValueError('a','b','c')", ValueError_register=[], check_exception=True)
-
-    def test_FloatingPointError_register(self):
-        self.run_test("def FloatingPointError_register():\n raise FloatingPointError('a','b','c')", FloatingPointError_register=[], check_exception=True)
-
-    def test_OverflowError_register(self):
-        self.run_test("def OverflowError_register():\n raise OverflowError('a','b','c')", OverflowError_register=[], check_exception=True)
-
-    def test_ZeroDivisionError_register(self):
-        self.run_test("def ZeroDivisionError_register():\n raise ZeroDivisionError('a','b','c')", ZeroDivisionError_register=[], check_exception=True)
-
-    def test_IOError_register(self):
-        self.run_test("def IOError_register():\n raise IOError('a','b','c')", IOError_register=[], check_exception=True)
-
-    def test_OSError_register(self):
-        self.run_test("def OSError_register():\n raise OSError('a','b','c')", OSError_register=[], check_exception=True)
-
-    def test_IndexError_register(self):
-        self.run_test("def IndexError_register():\n raise IndexError('a','b','c')", IndexError_register=[], check_exception=True)
-
-    def test_KeyError_register(self):
-        self.run_test("def KeyError_register():\n raise KeyError('a','b','c')", KeyError_register=[], check_exception=True)
-
-    def test_UnboundLocalError_register(self):
-        self.run_test("def UnboundLocalError_register():\n raise UnboundLocalError('a','b','c')", UnboundLocalError_register=[], check_exception=True)
-
-    def test_NotImplementedError_register(self):
-        self.run_test("def NotImplementedError_register():\n raise NotImplementedError('a','b','c')", NotImplementedError_register=[], check_exception=True)
-
-    def test_IndentationError_register(self):
-        self.run_test("def IndentationError_register():\n raise IndentationError('a','b','c')", IndentationError_register=[], check_exception=True)
-
-    def test_TabError_register(self):
-        self.run_test("def TabError_register():\n raise TabError('a','b','c')", TabError_register=[], check_exception=True)
-
-    def test_UnicodeError_register(self):
-        self.run_test("def UnicodeError_register():\n raise UnicodeError('a','b','c')", UnicodeError_register=[], check_exception=True)
 
     def test_multiple_exception_register(self):
         self.run_test("def multiple_exception_register():\n raise OverflowError('a','b','c')", multiple_exception_register=[], check_exception=True)
@@ -372,3 +336,13 @@ class TestException(TestEnv):
 
     def test_no_msg_exception_register(self):
         self.run_test("def no_msg_exception_register():\n raise IndexError()", no_msg_exception_register=[], check_exception=True)
+
+for exception in exceptions:
+    # This one is not compatible with pytest
+    if str(exception) in ("AssertionError", "UnicodeDecodeError",
+                          "UnicodeEncodeError", "UnicodeTranslateError"):
+        continue
+    code = ALL_EXCEPTION_CODE.format(tested_exception=exception)
+    setattr(TestException, 'test_' + str(exception) + "_register",
+            eval("""lambda self: self.run_test('''{0}''', '{1}', {1}_register=[str], check_exception=True)""".format(code, exception)))
+

--- a/pythran/toolchain.py
+++ b/pythran/toolchain.py
@@ -165,16 +165,20 @@ def generate_cxx(module_name, code, specs=None, optimizations=None):
 
         mod = PythonModule(module_name, docstrings, metainfo)
         mod.add_to_preamble(Define("BOOST_SIMD_NO_STRICT_ALIASING", "1"))
-        mod.add_to_includes(Include("pythonic/core.hpp"),
-                            Include("pythonic/python/core.hpp"),
-                            # FIXME: only include these when needed
-                            Include("pythonic/types/bool.hpp"),
-                            Include("pythonic/types/int.hpp"),
-                            Line("#ifdef _OPENMP\n#include <omp.h>\n#endif")
-                            )
+        mod.add_to_includes(
+            Include("pythonic/core.hpp"),
+            Include("pythonic/python/core.hpp"),
+            # FIXME: only include these when needed
+            Include("pythonic/types/bool.hpp"),
+            Include("pythonic/types/int.hpp"),
+            Line("#ifdef _OPENMP\n#include <omp.h>\n#endif")
+        )
         mod.add_to_includes(*[Include(inc) for inc in
                               _extract_specs_dependencies(specs)])
         mod.add_to_includes(*content.body)
+        mod.add_to_includes(
+            Include("pythonic/python/exception_handler.hpp"),
+        )
 
         for function_name, signatures in specs.iteritems():
             internal_func_name = renamings.get(function_name,


### PR DESCRIPTION
I don't really know if it should be integrated or not.

I didn't like the long generation of the same exception handling every time. It makes generated code harder to read (It is not the purpose of generated code but it is easier when we debug) and longer.

But while I changed this, I remove some ordering code for exception handling. It means ordering will have to be done manually when we will add new Exceptions (it is bad) but we don't add a lot of exception (not in the last 4 years)