### PR TITLE
Import-free setuptools integration

### DIFF
--- a/doc/MANUAL.rst
+++ b/doc/MANUAL.rst
@@ -278,12 +278,12 @@ When distributing a Python application with Pythran modules, you can either:
 
 * declare the module as a regular Python module. After all, they are 100% Python compatible.
 
-* declare them as a ``PythranExtension`` and Pythran will compile them::
+* declare them as an ``Extension`` in ``pythran_modules`` and Pythran will compile them::
 
-    from distutils.core import setup
-    from pythran.dist import PythranExtension
+    from distutils.core import setup, Extension
     setup(...,
-          ext_modules=[PythranExtension("mymodule", ["mymodule.py"])])
+          setup_requires=['pythran'],
+          pythran_modules=[Extension("mymodule", ["mymodule.py"])])
 
 Advanced Usage
 --------------

--- a/pythran/dist.py
+++ b/pythran/dist.py
@@ -21,41 +21,58 @@ class PythranExtension(Extension):
     The compilation process ends up in a native Python module.
     '''
     def __init__(self, name, sources, *args, **kwargs):
-        # the goal is to rely on original Extension
-        # to do so we convert the .py to .cpp with pythran
-        # and register the .cpp in place of the .py
-        # That's stage 0, and it's enough if you get the source
-        # from github and `python setup.py install it`
-        #
-        # *But* if you want to distribute the source through
-        # `python setup.py sdist` then the .py no longer exists
-        # and only the .cpp is distributed. That's stage 1
 
-        cxx_sources = []
-        for source in sources:
-            base, _ = os.path.splitext(source)
-            output_file = base + '.cpp'  # target name
+        Extension.__init__(self, name, sources, *args, **kwargs)
+        pythranize(self)
 
-            # stage 0 when we have the .py
-            if os.path.exists(source):
-                stage = 0
-            # stage 1 otherwise. `.cpp' should already be there
-            # as generated upon stage 0
+
+def pythranize(ext):
+    # the goal is to rely on original Extension
+    # to do so we convert the .py to .cpp with pythran
+    # and register the .cpp in place of the .py
+    # That's stage 0, and it's enough if you get the source
+    # from github and `python setup.py install it`
+    #
+    # *But* if you want to distribute the source through
+    # `python setup.py sdist` then the .py no longer exists
+    # and only the .cpp is distributed. That's stage 1
+    cxx_sources = []
+    for source in ext.sources:
+        base, _ = os.path.splitext(source)
+        output_file = base + '.cpp'  # target name
+
+        # stage 0 when we have the .py
+        if os.path.exists(source):
+            stage = 0
+        # stage 1 otherwise. `.cpp' should already be there
+        # as generated upon stage 0
+        else:
+            assert os.path.exists(output_file)
+            stage = 1
+            source = output_file
+
+        # stage-dependant processing
+        if stage == 0:
+            # get the last name in the path
+            if '.' in ext.name:
+                module_name = os.path.splitext(ext.name)[-1][1:]
             else:
-                assert os.path.exists(output_file)
-                stage = 1
-                source = output_file
+                module_name = ext.name
+            tc.compile_pythranfile(source, output_file,
+                                   module_name, cpponly=True)
+        cxx_sources.append(output_file)
 
-            # stage-dependant processing
-            if stage == 0:
-                # get the last name in the path
-                if '.' in name:
-                    module_name = os.path.splitext(name)[-1][1:]
-                else:
-                    module_name = name
-                tc.compile_pythranfile(source, output_file,
-                                       module_name, cpponly=True)
-            cxx_sources.append(output_file)
+    ext.sources = cxx_sources
 
-        kwargs.update(cfg.make_extension())
-        Extension.__init__(self, name, cxx_sources, *args, **kwargs)
+    for key, value in cfg.make_extension().items():
+        setattr(ext, key, value)
+    return ext
+
+
+def pythran_modules(dist, attr, value):
+    assert attr == 'pythran_modules'
+
+    if not dist.ext_modules:
+        dist.ext_modules = []
+
+    dist.ext_modules += [pythranize(v) for v in value]

--- a/pythran/tests/test_distutils/setup.py
+++ b/pythran/tests/test_distutils/setup.py
@@ -1,9 +1,8 @@
 from distutils.core import setup, Extension
-from pythran import PythranExtension
 
-module1 = PythranExtension('demo', sources = ['a.py'])
+module1 = Extension('demo', sources = ['a.py'])
 
 setup(name = 'demo',
       version = '1.0',
       description = 'This is a demo package',
-      ext_modules = [module1])
+      pythran_modules = [module1])

--- a/pythran/tests/test_distutils_packaged/setup.py
+++ b/pythran/tests/test_distutils_packaged/setup.py
@@ -1,8 +1,7 @@
 from distutils.core import setup, Extension
-from pythran import PythranExtension
 
 setup(name = 'demo2',
       version = '1.0',
       description = 'This is another demo package',
       packages = ['demo2'],
-      ext_modules = [PythranExtension('demo2.a', sources = ['a.py'])])
+      pythran_modules = [Extension('demo2.a', sources = ['a.py'])])

--- a/setup.py
+++ b/setup.py
@@ -196,6 +196,9 @@ setup(name='pythran',
       install_requires=open('requirements.txt').read().splitlines(),
       entry_points={'console_scripts': ['pythran = pythran.run:run',
                                         'pythran-config = pythran.config:run'],
+                    'distutils.setup_keywords': [
+                        "pythran_modules = pythran.dist:pythran_modules"
+                    ],
                     },
       tests_require=['pytest', 'pytest-pep8'],
       test_suite="pythran/test",


### PR DESCRIPTION
This pull request implements an import free setuptools integration, [inspired by CFFI](http://cffi.readthedocs.io/en/latest/cdef.html#distutils-setuptools).

Regard the following example `setup.py`:

```
import setuptools
from pythran.dist import PythranExtension

if __name__ == "__main__":
    setuptools.setup(
        name='matmul',
        version='0.1',
        packages=setuptools.find_packages(exclude=['tests']),

        install_requires=[
            'numpy>=1.6',
            'scipy>=0.9',
            'pythran',
        ],

        zip_safe=False,
        ext_modules=[PythranExtension('matmul', ['matmul.py'])]
    )
```

because of the requirement to `import` `pythran` into `setup.py`, it cannot be installed using `pip` if `pythran` wasn't installed first.

However `setuptools` allows libraries to define their own keyword arguments, in this case `pythran_modules`.

```
import setuptools
from distutils.core import Extension

if __name__ == "__main__":
    setuptools.setup(
        name='matmul',
        version='0.1',
        packages=setuptools.find_packages(exclude=['tests']),

        setup_requires=[
            'pythran'
        ],
        install_requires=[
            'numpy>=1.6',
            'scipy>=0.9',
            'pythran',
        ],

        zip_safe=False,
        pythran_modules=[Extension('matmul', ['matmul.py'])],
    )
```

The keyword argument will be ignored if it is not defined and `pythran` will be installed as per `setup_requires`. After that is done, the installation continues and `matmul.py` will be compiled by pythran.

Unfortunately, for this to work we need to modify `Extension` after it has been created. Before we could use `PythranExtension` which modified its content before calling the `Extension` constructor.

Now, this behaviour is turned on its head using a `pythranize()` function, which modifies an already existing `Extension` and quickly compiles its sources before continuing.
