### PR TITLE
Uses object instead of None as node in CFG.

### DIFF
--- a/pythran/analyses/cfg.py
+++ b/pythran/analyses/cfg.py
@@ -14,6 +14,13 @@ class CFG(FunctionAnalysis):
     * the OUT nodes, to be linked with the IN nodes of the successor
     * the RAISE nodes, nodes that stop the control flow (exception/break/...)
     """
+
+    #: The sink node in the control flow graph.
+    #:
+    #: The predecessors of this node are those AST nodes that terminate
+    #: control flow without a return statement.
+    NIL = object()
+
     def __init__(self):
         self.result = nx.DiGraph()
         super(CFG, self).__init__()
@@ -27,11 +34,11 @@ class CFG(FunctionAnalysis):
             for curr in currs:
                 self.result.add_edge(curr, n)
             currs, _ = self.visit(n)
-        # add an edge to None for nodes that end the control flow
+        # add an edge to NIL for nodes that end the control flow
         # without a return
-        self.result.add_node(None)
+        self.result.add_node(CFG.NIL)
         for curr in currs:
-            self.result.add_edge(curr, None)
+            self.result.add_edge(curr, CFG.NIL)
 
     def visit_Pass(self, node):
         """OUT = node, RAISES = ()"""

--- a/pythran/transformations/normalize_return.py
+++ b/pythran/transformations/normalize_return.py
@@ -28,8 +28,10 @@ class NormalizeReturn(Transformation):
     def visit_FunctionDef(self, node):
         self.yield_points = self.passmanager.gather(YieldPoints, node)
         map(self.visit, node.body)
-        # Look for nodes that have no successors
-        for n in self.cfg.predecessors(None):
+        # Look for nodes that have no successors; the predecessors of
+        # the special NIL node are those AST nodes that end control flow
+        # without a return statement.
+        for n in self.cfg.predecessors(CFG.NIL):
             if not isinstance(n, (ast.Return, ast.Raise)):
                 self.update = True
                 if self.yield_points:


### PR DESCRIPTION
The *[Creating a graph][1]* section of the NetworkX documentation states, "Note: Python’s None object should not be used as a node as it determines whether optional function arguments have been assigned in many functions." For example, if I want to get the dictionary of node degrees, normally I would do `dict(G.degree())` but that causes an error due to the `None` node. This commit changes the sink node to be a special sentinel object, `NIL`.

[1]: http://networkx.readthedocs.io/en/latest/tutorial/tutorial.html#creating-a-graph