### PR TITLE
Uses tuple second argument to isinstance

### DIFF
--- a/pythran/analyses/literals.py
+++ b/pythran/analyses/literals.py
@@ -19,8 +19,7 @@ class Literals(FunctionAnalysis):
         # list, dict, set and other are not considered as Literals as they have
         # a constructor which may be costly and they can be updated using
         # function call
-        basic_type = (ast.Num, ast.Lambda, ast.Str)
-        if any(isinstance(node.value, type) for type in basic_type):
+        if isinstance(node.value, (ast.Num, ast.Lambda, ast.Str)):
             targets_id = {target.id for target in node.targets
                           if isinstance(target, ast.Name)}
             self.result.update(targets_id)


### PR DESCRIPTION
According to the documentation for the built-in [`isinstance`][1] function, "If `classinfo` is a tuple of type objects (or recursively, other such tuples), return true if `object` is an instance of any of the types." This commit replaces custom `any` checking with this form of `isinstance`.

[1]: https://docs.python.org/3/library/functions.html#isinstance