### PR TITLE
Fix subtle performance issue with vectorisation & broadcasting

### DIFF
--- a/pythran/pythonic/include/types/list.hpp
+++ b/pythran/pythonic/include/types/list.hpp
@@ -225,8 +225,11 @@ namespace pythonic
 // element access
 #ifdef USE_BOOST_SIMD
       using simd_iterator = const_simd_nditerator<list>;
-      simd_iterator vbegin() const;
-      simd_iterator vend() const;
+      using simd_iterator_nobroadcast = simd_iterator;
+      template <class vectorizer>
+      simd_iterator vbegin(vectorizer) const;
+      template <class vectorizer>
+      simd_iterator vend(vectorizer) const;
       auto load(long i) const
           -> decltype(boost::simd::load<boost::simd::pack<T>>((*this->data),
                                                               i));

--- a/pythran/pythonic/include/types/ndarray.hpp
+++ b/pythran/pythonic/include/types/ndarray.hpp
@@ -344,8 +344,11 @@ namespace pythonic
 
 #ifdef USE_BOOST_SIMD
       using simd_iterator = const_simd_nditerator<ndarray>;
-      simd_iterator vbegin() const;
-      simd_iterator vend() const;
+      using simd_iterator_nobroadcast = simd_iterator;
+      template <class vectorizer>
+      simd_iterator vbegin(vectorizer) const;
+      template <class vectorizer>
+      simd_iterator vend(vectorizer) const;
       auto load(long i) const
           -> decltype(boost::simd::load<boost::simd::pack<T>>(buffer, i));
 

--- a/pythran/pythonic/include/types/numpy_broadcast.hpp
+++ b/pythran/pythonic/include/types/numpy_broadcast.hpp
@@ -92,8 +92,11 @@ namespace pythonic
       T const &fast(long i) const;
 #ifdef USE_BOOST_SIMD
       using simd_iterator = const_simd_nditerator<broadcasted>;
-      simd_iterator vbegin() const;
-      simd_iterator vend() const;
+      using simd_iterator_nobroadcast = simd_iterator;
+      template <class vectorizer>
+      simd_iterator vbegin(vectorizer) const;
+      template <class vectorizer>
+      simd_iterator vend(vectorizer) const;
       template <class I> // template to prevent automatic instantiation, but the
       // declaration is still needed
       void load(I) const;
@@ -238,11 +241,14 @@ namespace pythonic
       }
 #ifdef USE_BOOST_SIMD
       using simd_iterator = const_broadcast_iterator<decltype(_base._splated)>;
-      simd_iterator vbegin() const
+      using simd_iterator_nobroadcast = simd_iterator;
+      template <class vectorizer>
+      simd_iterator vbegin(vectorizer) const
       {
         return {_base._splated};
       }
-      simd_iterator vend() const
+      template <class vectorizer>
+      simd_iterator vend(vectorizer) const
       {
         return {_base._splated};
       }

--- a/pythran/pythonic/include/types/numpy_fexpr.hpp
+++ b/pythran/pythonic/include/types/numpy_fexpr.hpp
@@ -100,8 +100,11 @@ namespace pythonic
       dtype &fast(long i);
 #ifdef USE_BOOST_SIMD
       using simd_iterator = const_simd_nditerator<numpy_fexpr>;
-      simd_iterator vbegin() const;
-      simd_iterator vend() const;
+      using simd_iterator_nobroadcast = simd_iterator;
+      template <class vectorizer>
+      simd_iterator vbegin(vectorizer) const;
+      template <class vectorizer>
+      simd_iterator vend(vectorizer) const;
       template <class I> // template to prevent automatic instantiation when the
       // type is not vectorizable
       void load(I) const;

--- a/pythran/pythonic/include/types/numpy_gexpr.hpp
+++ b/pythran/pythonic/include/types/numpy_gexpr.hpp
@@ -504,8 +504,11 @@ namespace pythonic
 
 #ifdef USE_BOOST_SIMD
       using simd_iterator = const_simd_nditerator<numpy_gexpr>;
-      simd_iterator vbegin() const;
-      simd_iterator vend() const;
+      using simd_iterator_nobroadcast = simd_iterator;
+      template <class vectorizer>
+      simd_iterator vbegin(vectorizer) const;
+      template <class vectorizer>
+      simd_iterator vend(vectorizer) const;
       template <class I>
       auto load(I i) const
           -> decltype(boost::simd::load<boost::simd::pack<dtype>>(this->buffer,

--- a/pythran/pythonic/include/types/numpy_iexpr.hpp
+++ b/pythran/pythonic/include/types/numpy_iexpr.hpp
@@ -146,8 +146,11 @@ namespace pythonic
 
 #ifdef USE_BOOST_SIMD
       using simd_iterator = const_simd_nditerator<numpy_iexpr>;
-      simd_iterator vbegin() const;
-      simd_iterator vend() const;
+      using simd_iterator_nobroadcast = simd_iterator;
+      template <class vectorizer>
+      simd_iterator vbegin(vectorizer) const;
+      template <class vectorizer>
+      simd_iterator vend(vectorizer) const;
       template <class I>
       auto load(I i) const
           -> decltype(boost::simd::load<boost::simd::pack<dtype>>(this->buffer,

--- a/pythran/pythonic/include/types/numpy_texpr.hpp
+++ b/pythran/pythonic/include/types/numpy_texpr.hpp
@@ -67,8 +67,11 @@ namespace pythonic
 
 #ifdef USE_BOOST_SIMD
       using simd_iterator = const_simd_nditerator<numpy_texpr_2>;
-      simd_iterator vbegin() const;
-      simd_iterator vend() const;
+      using simd_iterator_nobroadcast = simd_iterator;
+      template <class vectorizer>
+      simd_iterator vbegin(vectorizer) const;
+      template <class vectorizer>
+      simd_iterator vend(vectorizer) const;
       template <class I>
       void load(I) const;
 #endif

--- a/pythran/pythonic/include/types/tuple.hpp
+++ b/pythran/pythonic/include/types/tuple.hpp
@@ -154,8 +154,11 @@ namespace pythonic
       constexpr const_reference fast(long n) const noexcept;
 #ifdef USE_BOOST_SIMD
       using simd_iterator = const_simd_nditerator<array>;
-      simd_iterator vbegin() const;
-      simd_iterator vend() const;
+      using simd_iterator_nobroadcast = simd_iterator;
+      template <class vectorizer>
+      simd_iterator vbegin(vectorizer) const;
+      template <class vectorizer>
+      simd_iterator vend(vectorizer) const;
       auto load(long i) const
           -> decltype(boost::simd::load<boost::simd::pack<T>>(&buffer[0], i));
 

--- a/pythran/pythonic/include/types/vectorizable_type.hpp
+++ b/pythran/pythonic/include/types/vectorizable_type.hpp
@@ -5,6 +5,42 @@ namespace pythonic
 {
   namespace types
   {
+    /* types used during vectorization specialization
+     */
+    struct novectorizer {
+    };
+    struct vectorize {
+    };
+    struct vectorizer {
+      template <class E>
+      static auto vbegin(E &&expr)
+          -> decltype(std::forward<E>(expr).vbegin(vectorize{}))
+      {
+        return std::forward<E>(expr).vbegin(vectorize{});
+      }
+      template <class E>
+      static auto vend(E &&expr)
+          -> decltype(std::forward<E>(expr).vend(vectorize{}))
+      {
+        return std::forward<E>(expr).vend(vectorize{});
+      }
+    };
+    struct vectorize_nobroadcast {
+    };
+    struct vectorizer_nobroadcast {
+      template <class E>
+      static auto vbegin(E &&expr)
+          -> decltype(std::forward<E>(expr).vbegin(vectorize_nobroadcast{}))
+      {
+        return std::forward<E>(expr).vbegin(vectorize_nobroadcast{});
+      }
+      template <class E>
+      static auto vend(E &&expr)
+          -> decltype(std::forward<E>(expr).vend(vectorize_nobroadcast{}))
+      {
+        return std::forward<E>(expr).vend(vectorize_nobroadcast{});
+      }
+    };
 
     template <class T>
     struct is_vectorizable {
@@ -28,6 +64,23 @@ namespace pythonic
 
     template <class O>
     struct is_vector_op;
+
+    template <class Op, class... Args>
+    struct numpy_expr;
+  }
+
+  namespace utils
+  {
+    template <class Op, class... Args>
+    bool no_broadcast(types::numpy_expr<Op, Args...> const &arg)
+    {
+      return arg.no_broadcast();
+    }
+    template <class Arg>
+    constexpr bool no_broadcast(Arg const &arg)
+    {
+      return true;
+    }
   }
 }
 #endif

--- a/pythran/pythonic/include/utils/broadcast_copy.hpp
+++ b/pythran/pythonic/include/utils/broadcast_copy.hpp
@@ -49,84 +49,8 @@ namespace pythonic
 
 #undef SPECIALIZE_DIM_OF
 
-    /* helper for specialization of the broadcasting, vectorizing copy operator
-     * due to expression templates, this may also triggers a lot of
-     *computations!
-     *
-     * ``vector_form'' is set to true if the operation can be done using
-     *Boost.SIMD
-     *
-     * the call operator has four template parameters:
-     *
-     * template <class E, class F, size_t N>
-     * void operator()(E &&self, F const &other, utils::int_<N>, utils::int_<M>)
-     *
-     * ``E'' is the type of the object to which the data are copied
-     *
-     * ``F'' is the type of the object from which the data are copied
-     *
-     * ``N'' is the depth of the loop nest. When it reaches ``1'', we have a raw
-     *loop
-     *       that may be vectorizable
-     *
-     * ``D'' is the delta between the number of dimensions of E and F. When set
-     *to a
-     *       value greater than ``0'', some broadcasting is needed
-     */
-    template <bool vector_form, size_t N, size_t D>
-    struct _broadcast_copy {
-      template <class E, class F>
-      void operator()(E &&self, F const &other);
-    };
-    template <bool vector_form, size_t N>
-    struct _broadcast_copy<vector_form, N, 0> {
-      template <class E, class F>
-      void operator()(E &&self, F const &other);
-    };
-
-#ifdef USE_BOOST_SIMD
-    // specialize for SIMD only if available
-    // otherwise use the std::copy fallback
-    template <>
-    struct _broadcast_copy<true, 1, 0> {
-      template <class E, class F>
-      void operator()(E &&self, F const &other);
-    };
-#endif
-
     template <class E, class F, size_t N, size_t D, bool vector_form>
     E &broadcast_copy(E &self, F const &other);
-
-    // ``D'' is not ``0'' so we should broadcast
-    template <class Op, bool vector_form, size_t N, size_t D>
-    struct _broadcast_update {
-      template <class E, class F>
-      void operator()(E &&self, F const &other);
-    };
-
-    template <class Op, bool vector_form, size_t N>
-    struct _broadcast_update<Op, vector_form, N, 0> {
-      template <class E, class F>
-      void operator()(E &&self, F const &other);
-
-      template <class E, class F0, class F1>
-      void operator()(E &&self, types::broadcast<F0, F1> const &other);
-      template <class E, class F>
-      void operator()(E &&self, types::broadcasted<F> const &other);
-    };
-
-#ifdef USE_BOOST_SIMD
-    // specialize for SIMD only if available
-    template <class Op>
-    struct _broadcast_update<Op, true, 1, 0> {
-      template <class E, class F>
-      void operator()(E &&self, F const &other);
-      template <class E, class F0, class F1>
-      void operator()(E &&self, types::broadcast<F0, F1> const &other);
-      template <class E, class F>
-      void operator()(E &&self, types::broadcasted<F> const &other);
-    };
-#endif
 
     template <class Op, class E, class F, size_t N, size_t D, bool vector_form>
     E &broadcast_update(E &self, F const &other);

--- a/pythran/pythonic/types/list.hpp
+++ b/pythran/pythonic/types/list.hpp
@@ -364,13 +364,15 @@ namespace pythonic
 // element access
 #ifdef USE_BOOST_SIMD
     template <class T>
-    typename list<T>::simd_iterator list<T>::vbegin() const
+    template <class vectorizer>
+    typename list<T>::simd_iterator list<T>::vbegin(vectorizer) const
     {
       return {*this, 0};
     }
 
     template <class T>
-    typename list<T>::simd_iterator list<T>::vend() const
+    template <class vectorizer>
+    typename list<T>::simd_iterator list<T>::vend(vectorizer) const
     {
       using vector_type = typename boost::simd::pack<dtype>;
       static const std::size_t vector_size = vector_type::static_size;

--- a/pythran/pythonic/types/ndarray.hpp
+++ b/pythran/pythonic/types/ndarray.hpp
@@ -529,18 +529,22 @@ namespace pythonic
 
 #ifdef USE_BOOST_SIMD
     template <class T, size_t N>
-    typename ndarray<T, N>::simd_iterator ndarray<T, N>::vbegin() const
+    template <class vectorizer>
+    typename ndarray<T, N>::simd_iterator
+        ndarray<T, N>::vbegin(vectorizer) const
     {
       return {*this, 0};
     }
 
     template <class T, size_t N>
-    typename ndarray<T, N>::simd_iterator ndarray<T, N>::vend() const
+    template <class vectorizer>
+    typename ndarray<T, N>::simd_iterator ndarray<T, N>::vend(vectorizer) const
     {
       using vector_type = typename boost::simd::pack<dtype>;
       static const std::size_t vector_size = vector_type::static_size;
       return {*this, long(_shape[0] / vector_size * vector_size)};
     }
+
     template <class T, size_t N>
     auto ndarray<T, N>::load(long i) const
         -> decltype(boost::simd::load<boost::simd::pack<T>>(buffer, i))

--- a/pythran/pythonic/types/numpy_broadcast.hpp
+++ b/pythran/pythonic/types/numpy_broadcast.hpp
@@ -43,13 +43,17 @@ namespace pythonic
 
 #ifdef USE_BOOST_SIMD
     template <class T>
-    typename broadcasted<T>::simd_iterator broadcasted<T>::vbegin() const
+    template <class vectorizer>
+    typename broadcasted<T>::simd_iterator
+        broadcasted<T>::vbegin(vectorizer) const
     {
       return {*this, 0};
     }
 
     template <class T>
-    typename broadcasted<T>::simd_iterator broadcasted<T>::vend() const
+    template <class vectorizer>
+    typename broadcasted<T>::simd_iterator
+        broadcasted<T>::vend(vectorizer) const
     {
       return {*this, 0}; // should not happen anyway
     }

--- a/pythran/pythonic/types/numpy_fexpr.hpp
+++ b/pythran/pythonic/types/numpy_fexpr.hpp
@@ -175,15 +175,17 @@ namespace pythonic
 
 #ifdef USE_BOOST_SIMD
     template <class Arg, class F>
+    template <class vectorizer>
     typename numpy_fexpr<Arg, F>::simd_iterator
-    numpy_fexpr<Arg, F>::vbegin() const
+        numpy_fexpr<Arg, F>::vbegin(vectorizer) const
     {
       return {*this, 0};
     }
 
     template <class Arg, class F>
+    template <class vectorizer>
     typename numpy_fexpr<Arg, F>::simd_iterator
-    numpy_fexpr<Arg, F>::vend() const
+        numpy_fexpr<Arg, F>::vend(vectorizer) const
     {
       using vector_type = typename boost::simd::pack<dtype>;
       static const std::size_t vector_size = vector_type::static_size;

--- a/pythran/pythonic/types/numpy_gexpr.hpp
+++ b/pythran/pythonic/types/numpy_gexpr.hpp
@@ -647,20 +647,23 @@ namespace pythonic
 
 #ifdef USE_BOOST_SIMD
     template <class Arg, class... S>
+    template <class vectorizer>
     typename numpy_gexpr<Arg, S...>::simd_iterator
-    numpy_gexpr<Arg, S...>::vbegin() const
+        numpy_gexpr<Arg, S...>::vbegin(vectorizer) const
     {
       return {*this, 0};
     }
 
     template <class Arg, class... S>
+    template <class vectorizer>
     typename numpy_gexpr<Arg, S...>::simd_iterator
-    numpy_gexpr<Arg, S...>::vend() const
+        numpy_gexpr<Arg, S...>::vend(vectorizer) const
     {
       using vector_type = typename boost::simd::pack<dtype>;
       static const std::size_t vector_size = vector_type::static_size;
       return {*this, long(_shape[0] / vector_size * vector_size)};
     }
+
     template <class Arg, class... S>
     template <class I>
     auto numpy_gexpr<Arg, S...>::load(I i) const

--- a/pythran/pythonic/types/numpy_iexpr.hpp
+++ b/pythran/pythonic/types/numpy_iexpr.hpp
@@ -218,13 +218,17 @@ namespace pythonic
 
 #ifdef USE_BOOST_SIMD
     template <class Arg>
-    typename numpy_iexpr<Arg>::simd_iterator numpy_iexpr<Arg>::vbegin() const
+    template <class vectorizer>
+    typename numpy_iexpr<Arg>::simd_iterator
+        numpy_iexpr<Arg>::vbegin(vectorizer) const
     {
       return {*this, 0};
     }
 
     template <class Arg>
-    typename numpy_iexpr<Arg>::simd_iterator numpy_iexpr<Arg>::vend() const
+    template <class vectorizer>
+    typename numpy_iexpr<Arg>::simd_iterator
+        numpy_iexpr<Arg>::vend(vectorizer) const
     {
       using vector_type = typename boost::simd::pack<dtype>;
       static const std::size_t vector_size = vector_type::static_size;

--- a/pythran/pythonic/types/numpy_texpr.hpp
+++ b/pythran/pythonic/types/numpy_texpr.hpp
@@ -76,13 +76,17 @@ namespace pythonic
 
 #ifdef USE_BOOST_SIMD
     template <class E>
-    typename numpy_texpr_2<E>::simd_iterator numpy_texpr_2<E>::vbegin() const
+    template <class vectorizer>
+    typename numpy_texpr_2<E>::simd_iterator
+        numpy_texpr_2<E>::vbegin(vectorizer) const
     {
       return {*this, 0};
     }
 
     template <class E>
-    typename numpy_texpr_2<E>::simd_iterator numpy_texpr_2<E>::vend() const
+    template <class vectorizer>
+    typename numpy_texpr_2<E>::simd_iterator
+        numpy_texpr_2<E>::vend(vectorizer) const
     {
       return {*this, 0}; // not vectorizable anyway
     }

--- a/pythran/pythonic/types/tuple.hpp
+++ b/pythran/pythonic/types/tuple.hpp
@@ -262,13 +262,15 @@ namespace pythonic
 
 #ifdef USE_BOOST_SIMD
     template <class T, size_t N>
-    typename array<T, N>::simd_iterator array<T, N>::vbegin() const
+    template <class vectorizer>
+    typename array<T, N>::simd_iterator array<T, N>::vbegin(vectorizer) const
     {
       return {*this, 0};
     }
 
     template <class T, size_t N>
-    typename array<T, N>::simd_iterator array<T, N>::vend() const
+    template <class vectorizer>
+    typename array<T, N>::simd_iterator array<T, N>::vend(vectorizer) const
     {
       using vector_type = typename boost::simd::pack<dtype>;
       static const std::size_t vector_size = vector_type::static_size;

--- a/pythran/pythonic/utils/broadcast_copy.hpp
+++ b/pythran/pythonic/utils/broadcast_copy.hpp
@@ -21,78 +21,108 @@ namespace pythonic
   namespace utils
   {
 
-    template <bool vector_form, size_t N>
-    template <class E, class F>
-    void _broadcast_copy<vector_form, N, 0>::operator()(E &&self,
-                                                        F const &other)
-    {
-      long self_size = std::distance(self.begin(), self.end()),
-           other_size = std::distance(other.begin(), other.end());
-      if (other_size > 0) // empty array sometimes happen when filtering
-      {
-#ifdef _OPENMP
-        if (other_size >= PYTHRAN_OPENMP_MIN_ITERATION_COUNT) {
-          auto siter = self.begin();
-          auto oiter = other.begin();
-#pragma omp parallel for
-          for (long i = 0; i < other_size; ++i)
-            *(siter + i) = *(oiter + i);
-        } else
-#endif
-          std::copy(other.begin(), other.end(), self.begin());
+    /* helper for specialization of the broadcasting, vectorizing copy operator
+     * due to expression templates, this may also triggers a lot of
+     *computations!
+     *
+     * ``vector_form'' is set to true if the operation can be done using
+     *Boost.SIMD
+     *
+     * the call operator has four template parameters:
+     *
+     * template <class E, class F, size_t N>
+     * void operator()(E &&self, F const &other, utils::int_<N>, utils::int_<M>)
+     *
+     * ``E'' is the type of the object to which the data are copied
+     *
+     * ``F'' is the type of the object from which the data are copied
+     *
+     * ``N'' is the depth of the loop nest. When it reaches ``1'', we have a raw
+     *loop
+     *       that may be vectorizable
+     *
+     * ``D'' is the delta between the number of dimensions of E and F. When set
+     *to a
+     *       value greater than ``0'', some broadcasting is needed
+     */
 
-        // eventually repeat the pattern
-        size_t n = self_size / other_size;
+    template <typename vector_form, size_t N, size_t D>
+    struct _broadcast_copy;
+
+    template <size_t N, class vectorizer>
+    struct _broadcast_copy<vectorizer, N, 0> {
+      template <class E, class F>
+      void operator()(E &&self, F const &other)
+      {
+        long self_size = std::distance(self.begin(), self.end()),
+             other_size = std::distance(other.begin(), other.end());
+        if (other_size > 0) // empty array sometimes happen when filtering
+        {
 #ifdef _OPENMP
-        if (n >= PYTHRAN_OPENMP_MIN_ITERATION_COUNT)
+          if (other_size >= PYTHRAN_OPENMP_MIN_ITERATION_COUNT) {
+            auto siter = self.begin();
+            auto oiter = other.begin();
 #pragma omp parallel for
-          for (size_t i = 1; i < n; ++i)
-            std::copy_n(self.begin(), other_size,
-                        self.begin() + i * other_size);
-        else
+            for (long i = 0; i < other_size; ++i)
+              *(siter + i) = *(oiter + i);
+          } else
 #endif
-          for (size_t i = 1; i < n; ++i)
-            std::copy_n(self.begin(), other_size,
-                        self.begin() + i * other_size);
+            std::copy(other.begin(), other.end(), self.begin());
+
+          // eventually repeat the pattern
+          size_t n = self_size / other_size;
+#ifdef _OPENMP
+          if (n >= PYTHRAN_OPENMP_MIN_ITERATION_COUNT)
+#pragma omp parallel for
+            for (size_t i = 1; i < n; ++i)
+              std::copy_n(self.begin(), other_size,
+                          self.begin() + i * other_size);
+          else
+#endif
+            for (size_t i = 1; i < n; ++i)
+              std::copy_n(self.begin(), other_size,
+                          self.begin() + i * other_size);
+        }
       }
-    }
+    };
 
     // ``D'' is not ``0'' so we should broadcast
-    template <bool vector_form, size_t N, size_t D>
-    template <class E, class F>
-    void _broadcast_copy<vector_form, N, D>::operator()(E &&self,
-                                                        F const &other)
-    {
-      auto sfirst = self.begin();
-      auto siter = sfirst;
-      *sfirst = other;
+    template <class vectorizer, size_t N, size_t D>
+    struct _broadcast_copy {
+      template <class E, class F>
+      void operator()(E &&self, F const &other)
+      {
+        auto sfirst = self.begin();
+        auto siter = sfirst;
+        *sfirst = other;
 #ifdef _OPENMP
-      long n = self.shape()[0];
-      if (n >= PYTHRAN_OPENMP_MIN_ITERATION_COUNT)
+        long n = self.shape()[0];
+        if (n >= PYTHRAN_OPENMP_MIN_ITERATION_COUNT)
 #pragma omp parallel for
-        for (long i = 1; i < n; ++i)
-          *(siter + i) = *sfirst;
-      else
+          for (long i = 1; i < n; ++i)
+            *(siter + i) = *sfirst;
+        else
 #endif
-        std::fill(self.begin() + 1, self.end(), *sfirst);
-    }
+          std::fill(self.begin() + 1, self.end(), *sfirst);
+      }
+    };
 
 #ifdef USE_BOOST_SIMD
     // specialize for SIMD only if available
     // otherwise use the std::copy fallback
-    template <class E, class F>
-    void _broadcast_copy<true, 1, 0>::operator()(E &&self, F const &other)
+    template <class vectorizer, class E, class F>
+    void vbroadcast_copy(E &&self, F const &other)
     {
       using T = typename F::dtype;
       using vT = typename boost::simd::pack<T>;
       long self_size = std::distance(self.begin(), self.end()),
            other_size = std::distance(other.begin(), other.end());
-
       if (other_size > 0) // empty array sometimes happen when filtering
       {
         static const std::size_t vN = vT::static_size;
-        auto oiter = other.vbegin();
-        const long bound = std::distance(other.vbegin(), other.vend());
+        auto oiter = vectorizer::vbegin(other);
+        const long bound =
+            std::distance(vectorizer::vbegin(other), vectorizer::vend(other));
 
 #ifdef _OPENMP
         if (bound >= PYTHRAN_OPENMP_MIN_ITERATION_COUNT)
@@ -127,90 +157,127 @@ namespace pythonic
       }
     }
 
+    template <>
+    struct _broadcast_copy<types::vectorizer, 1, 0> {
+      template <class E, class F>
+      void operator()(E &&self, F const &other)
+      {
+        return vbroadcast_copy<types::vectorizer>(std::forward<E>(self), other);
+      }
+    };
+    template <>
+    struct _broadcast_copy<types::vectorizer_nobroadcast, 1, 0> {
+      template <class E, class F>
+      void operator()(E &&self, F const &other)
+      {
+        return vbroadcast_copy<types::vectorizer_nobroadcast>(
+            std::forward<E>(self), other);
+      }
+    };
+
 #endif
+    template <class E, class F, size_t N, size_t D, bool vector_form>
+    struct broadcast_copy_dispatcher;
+
+    template <class E, class F, size_t N, size_t D>
+    struct broadcast_copy_dispatcher<E, F, N, D, false> {
+      void operator()(E &self, F const &other)
+      {
+        _broadcast_copy<types::novectorizer, N, D>{}(self, other);
+      }
+    };
+    template <class E, class F, size_t N, size_t D>
+    struct broadcast_copy_dispatcher<E, F, N, D, true> {
+      void operator()(E &self, F const &other)
+      {
+        if (utils::no_broadcast(other))
+          _broadcast_copy<types::vectorizer_nobroadcast, N, D>{}(self, other);
+        else
+          _broadcast_copy<types::vectorizer, N, D>{}(self, other);
+      }
+    };
 
     template <class E, class F, size_t N, size_t D, bool vector_form>
     E &broadcast_copy(E &self, F const &other)
     {
-      _broadcast_copy<vector_form, N, D>{}(self, other);
+      broadcast_copy_dispatcher<E, F, N, D, vector_form>{}(self, other);
       return self;
     }
 
     /* update
      */
-
     // ``D'' is not ``0'' so we should broadcast
-    template <class Op, bool vector_form, size_t N, size_t D>
-    template <class E, class F>
-    void _broadcast_update<Op, vector_form, N, D>::operator()(E &&self,
-                                                              F const &other)
-    {
-      long n = self.shape()[0];
-      auto siter = self.begin();
-#ifdef _OPENMP
-      if (n >= PYTHRAN_OPENMP_MIN_ITERATION_COUNT)
-#pragma omp parallel for
-        for (long i = 0; i < n; ++i)
-          Op{}(*(siter + i), other);
-      else
-#endif
-        for (long i = 0; i < n; ++i)
-          Op{}(*(siter + i), other);
-    }
+    template <class Op, typename vector_form, size_t N, size_t D>
+    struct _broadcast_update {
 
-    template <class Op, bool vector_form, size_t N>
-    template <class E, class F>
-    void _broadcast_update<Op, vector_form, N, 0>::operator()(E &&self,
-                                                              F const &other)
-    {
-      long other_size = std::distance(other.begin(), other.end());
-      if (other_size > 0) // empty array sometimes happen when filtering
+      template <class E, class F>
+      void operator()(E &&self, F const &other)
       {
+        long n = self.shape()[0];
         auto siter = self.begin();
-        auto oiter = other.begin();
 #ifdef _OPENMP
-        if (other_size >= PYTHRAN_OPENMP_MIN_ITERATION_COUNT)
+        if (n >= PYTHRAN_OPENMP_MIN_ITERATION_COUNT)
 #pragma omp parallel for
-          for (long i = 0; i < other_size; ++i)
-            Op{}(*(siter + i), *(oiter + i));
+          for (long i = 0; i < n; ++i)
+            Op{}(*(siter + i), other);
         else
 #endif
-            if (other_size == 1) {
-          auto value = *oiter;
-          for (auto send = self.end(); siter != send; ++siter)
-            Op{}(*siter, value);
-        } else
-          for (auto send = self.end(); siter != send; siter += other_size)
-            std::transform(siter, siter + other_size, oiter, siter, Op{});
+          for (long i = 0; i < n; ++i)
+            Op{}(*(siter + i), other);
       }
-    }
+    };
 
-    template <class Op, bool vector_form, size_t N>
-    template <class E, class F0, class F1>
-    void _broadcast_update<Op, vector_form, N, 0>::
-    operator()(E &&self, types::broadcast<F0, F1> const &other)
-    {
-      auto value = *other.begin();
-      for (auto siter = self.begin(), send = self.end(); siter != send; ++siter)
-        Op{}(*siter, value);
-    }
+    template <class Op, size_t N, class vector_form>
+    struct _broadcast_update<Op, vector_form, N, 0> {
+      template <class E, class F>
+      void operator()(E &&self, F const &other)
+      {
+        long other_size = std::distance(other.begin(), other.end());
+        if (other_size > 0) // empty array sometimes happen when filtering
+        {
+          auto siter = self.begin();
+          auto oiter = other.begin();
+#ifdef _OPENMP
+          if (other_size >= PYTHRAN_OPENMP_MIN_ITERATION_COUNT)
+#pragma omp parallel for
+            for (long i = 0; i < other_size; ++i)
+              Op{}(*(siter + i), *(oiter + i));
+          else
+#endif
+              if (other_size == 1) {
+            auto value = *oiter;
+            for (auto send = self.end(); siter != send; ++siter)
+              Op{}(*siter, value);
+          } else
+            for (auto send = self.end(); siter != send; siter += other_size)
+              std::transform(siter, siter + other_size, oiter, siter, Op{});
+        }
+      }
 
-    template <class Op, bool vector_form, size_t N>
-    template <class E, class F>
-    void _broadcast_update<Op, vector_form, N, 0>::
-    operator()(E &&self, types::broadcasted<F> const &other)
-    {
-      auto value = *other.end();
-      for (auto siter = self.begin(), send = self.end(); siter != send; ++siter)
-        Op{}(*siter, value);
-    }
+      template <class E, class F0, class F1>
+      void operator()(E &&self, types::broadcast<F0, F1> const &other)
+      {
+        auto value = *other.begin();
+        for (auto siter = self.begin(), send = self.end(); siter != send;
+             ++siter)
+          Op{}(*siter, value);
+      }
+
+      template <class E, class F>
+      void operator()(E &&self, types::broadcasted<F> const &other)
+      {
+        auto value = *other.end();
+        for (auto siter = self.begin(), send = self.end(); siter != send;
+             ++siter)
+          Op{}(*siter, value);
+      }
+    };
 
 #ifdef USE_BOOST_SIMD
     // specialize for SIMD only if available
     // otherwise use the std::copy fallback
-    template <class Op>
-    template <class E, class F>
-    void _broadcast_update<Op, true, 1, 0>::operator()(E &&self, F const &other)
+    template <class Op, class vectorizer, class E, class F>
+    void vbroadcast_update(E &&self, F const &other)
     {
       using T = typename F::dtype;
       using vT = typename boost::simd::pack<T>;
@@ -220,8 +287,9 @@ namespace pythonic
       if (other_size > 0) // empty array sometimes happen when filtering
       {
         static const std::size_t vN = vT::static_size;
-        auto oiter = other.vbegin();
-        const long bound = std::distance(other.vbegin(), other.vend());
+        auto oiter = vectorizer::vbegin(other);
+        const long bound =
+            std::distance(vectorizer::vbegin(other), vectorizer::vend(other));
 
 #ifdef _OPENMP
         if (bound >= PYTHRAN_OPENMP_MIN_ITERATION_COUNT)
@@ -242,32 +310,68 @@ namespace pythonic
         }
       }
     }
-    template <class Op>
-    template <class E, class F0, class F1>
-    void _broadcast_update<Op, true, 1, 0>::
-    operator()(E &&self, types::broadcast<F0, F1> const &other)
+
+    template <class Op, class vectorizer, class E, class F0, class F1>
+    void vbroadcast_update(E &&self, types::broadcast<F0, F1> const &other)
     {
       auto value = *other.begin();
       for (auto siter = self.begin(), send = self.end(); siter != send; ++siter)
         Op{}(*siter, value);
     }
 
-    template <class Op>
-    template <class E, class F>
-    void _broadcast_update<Op, true, 1, 0>::
-    operator()(E &&self, types::broadcasted<F> const &other)
+    template <class Op, class vectorizer, class E, class F>
+    void vbroadcast_update(E &&self, types::broadcasted<F> const &other)
     {
       auto value = *other.end();
       for (auto siter = self.begin(), send = self.end(); siter != send; ++siter)
         Op{}(*siter, value);
     }
 
+    template <class Op>
+    struct _broadcast_update<Op, types::vectorizer, 1, 0> {
+      template <class... Args>
+      void operator()(Args &&... args)
+      {
+        vbroadcast_update<Op, types::vectorizer>(std::forward<Args>(args)...);
+      }
+    };
+    template <class Op>
+    struct _broadcast_update<Op, types::vectorizer_nobroadcast, 1, 0> {
+      template <class... Args>
+      void operator()(Args &&... args)
+      {
+        vbroadcast_update<Op, types::vectorizer_nobroadcast>(
+            std::forward<Args>(args)...);
+      }
+    };
+
 #endif
+    template <class Op, bool vector_form, class E, class F, size_t N, size_t D>
+    struct broadcast_update_dispatcher;
+
+    template <class Op, class E, class F, size_t N, size_t D>
+    struct broadcast_update_dispatcher<Op, false, E, F, N, D> {
+      void operator()(E &self, F const &other)
+      {
+        _broadcast_update<Op, types::novectorizer, N, D>{}(self, other);
+      }
+    };
+    template <class Op, class E, class F, size_t N, size_t D>
+    struct broadcast_update_dispatcher<Op, true, E, F, N, D> {
+      void operator()(E &self, F const &other)
+      {
+        if (utils::no_broadcast(other))
+          _broadcast_update<Op, types::vectorizer_nobroadcast, N, D>{}(self,
+                                                                       other);
+        else
+          _broadcast_update<Op, types::vectorizer, N, D>{}(self, other);
+      }
+    };
 
     template <class Op, class E, class F, size_t N, size_t D, bool vector_form>
     E &broadcast_update(E &self, F const &other)
     {
-      _broadcast_update<Op, vector_form, N, D>{}(self, other);
+      broadcast_update_dispatcher<Op, vector_form, E, F, N, D>{}(self, other);
       return self;
     }
   }


### PR DESCRIPTION
The issue is that to achieve broadcasting, we need a dynamic test in the
inner expression template loop. No way around I could find.

So let's add a preliminary check on the ET, and if the ET appear to
*not* need any broadcasting, then another vectorization loop, condition
free, is selected at runtime (which means both version are actually
compiled).