### PR TITLE
Fix bug when copying numpy expressions

### DIFF
--- a/pythran/pythonic/types/numpy_iexpr.hpp
+++ b/pythran/pythonic/types/numpy_iexpr.hpp
@@ -15,7 +15,8 @@ namespace pythonic
   {
 
     template <class Arg>
-    numpy_iexpr<Arg>::numpy_iexpr()
+    numpy_iexpr<Arg>::numpy_iexpr():
+      buffer(nullptr)
     {
     }
 
@@ -54,6 +55,7 @@ namespace pythonic
     template <class E>
     numpy_iexpr<Arg> &numpy_iexpr<Arg>::operator=(E const &expr)
     {
+      assert(buffer);
       return utils::broadcast_copy<numpy_iexpr &, E, value,
                                    value - utils::dim_of<E>::value,
                                    false /*NIY*/>(*this, expr);
@@ -62,6 +64,7 @@ namespace pythonic
     template <class Arg>
     numpy_iexpr<Arg> &numpy_iexpr<Arg>::operator=(numpy_iexpr<Arg> const &expr)
     {
+      assert(buffer);
       return utils::broadcast_copy<numpy_iexpr &, numpy_iexpr const &, value,
                                    value - utils::dim_of<numpy_iexpr>::value,
                                    false /*NIY*/>(*this, expr);


### PR DESCRIPTION
The move operator wasn't declared, so the case where we had:

numpy_gexpr e;
e = ...;

didn't work because the buffer member variable was set to an
uninitialized value.

Morever, add asserts in copy functions to ease futur debuggings!
