### PR TITLE
Do not disable deprecated Numpy API when compiling from Cython

### DIFF
--- a/pythran/pythonic/include/types/ndarray.hpp
+++ b/pythran/pythonic/include/types/ndarray.hpp
@@ -49,7 +49,11 @@
 #include <numeric>
 
 #ifdef ENABLE_PYTHON_MODULE
+// Cython still uses the deprecated API, so we can't set this macro in this
+// case!
+#ifndef CYTHON_ABI
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#endif
 #include "numpy/arrayobject.h"
 #endif
 

--- a/pythran/pythonic/types/ndarray.hpp
+++ b/pythran/pythonic/types/ndarray.hpp
@@ -56,11 +56,6 @@
 #include <initializer_list>
 #include <numeric>
 
-#ifdef ENABLE_PYTHON_MODULE
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
-#include "numpy/arrayobject.h"
-#endif
-
 namespace pythonic
 {
 


### PR DESCRIPTION
Cython still uses deprecated Numpy APIs!