### PR TITLE
Support binary operations between different complex types

### DIFF
--- a/pythran/pythonic/include/types/complex.hpp
+++ b/pythran/pythonic/include/types/complex.hpp
@@ -39,6 +39,20 @@ struct __combined<std::complex<double>, indexable<K>> {
 
 /* } */
 
+#define STD_COMPLEX_IMPLICT_OPERATOR_CAST(op)                                  \
+  template <class T, class U>                                                  \
+  auto operator op(std::complex<T> const &lhs, std::complex<U> const &rhs)     \
+      ->std::complex<typename std::common_type<T, U>::type>                    \
+  {                                                                            \
+    using ctype = std::complex<typename std::common_type<T, U>::type>;         \
+    return ctype{lhs} + ctype{rhs};                                            \
+  }
+
+STD_COMPLEX_IMPLICT_OPERATOR_CAST(+)
+STD_COMPLEX_IMPLICT_OPERATOR_CAST(-)
+STD_COMPLEX_IMPLICT_OPERATOR_CAST(*)
+STD_COMPLEX_IMPLICT_OPERATOR_CAST(/ )
+
 #ifdef ENABLE_PYTHON_MODULE
 
 #include "pythonic/python/core.hpp"

--- a/pythran/tests/test_complex.py
+++ b/pythran/tests/test_complex.py
@@ -63,3 +63,13 @@ class TestComplex(TestEnv):
         self.run_test('def test_complex_array_real_imag(e): return e.real + e.imag',
                       np.array([[3.,2.,4.]], dtype=complex),
                       test_complex_array_real_imag=[NDArray[complex, :, :]])
+
+    def test_complex_sum_different_types(self):
+        self.run_test('def test_complex_different_types(a,b): return a + b',
+                      np.array([[3 + 2j]],dtype=np.complex64),np.array([[8 + 1j]],dtype=np.complex128),
+                      test_complex_different_types=[NDArray[np.complex64, :, :],NDArray[np.complex128, :, :]])
+
+    def test_complex_sum_same_types(self):
+        self.run_test('def test_complex_same_types(a): return a + a',
+                      np.array([[3 + 2j]],dtype=np.complex64),
+                      test_complex_same_types=[NDArray[np.complex64, :, :]])


### PR DESCRIPTION
For instance, support std::comple<double> + std::complex<long double> by
casting the first operand to a std::complex<long double>.
