### PR TITLE
Fix ndarray contiguous type checking

### DIFF
--- a/doc/TUTORIAL.rst
+++ b/doc/TUTORIAL.rst
@@ -192,8 +192,8 @@ One can also computes the state of ``globals()``::
   >>> code = 'import math\n'
   >>> code += 'def foo(a): b = math.cos(a) ; return [b] * 3'
   >>> tree = ast.parse(code)
-  >>> pm.gather(analyses.Globals, tree)
-  set(['foo', '__dispatch__', '__builtin__', 'math'])
+  >>> sorted(list(pm.gather(analyses.Globals, tree)))
+  ['__builtin__', '__dispatch__', 'foo', 'math']
 
 One can also compute the state of ``locals()`` at any point of the program::
 

--- a/pythran/pythonic/types/ndarray.hpp
+++ b/pythran/pythonic/types/ndarray.hpp
@@ -1361,7 +1361,9 @@ namespace pythonic
       current_stride *= dims[i];
     }
     // this is supposed to be a texpr
-    if (PyArray_FLAGS(arr) & NPY_ARRAY_F_CONTIGUOUS && N > 1)
+    if ((PyArray_FLAGS(arr) & NPY_ARRAY_F_CONTIGUOUS) && 
+        ((PyArray_FLAGS(arr) & NPY_ARRAY_C_CONTIGUOUS) == 0) &&
+        (N > 1))
       return false;
     else
       return true;

--- a/pythran/tests/cases/diffusion_pure_python.py
+++ b/pythran/tests/cases/diffusion_pure_python.py
@@ -1,7 +1,7 @@
 # Reference: http://continuum.io/blog/the-python-and-the-complied-python
 #pythran export diffusePurePython(float [][], float [][], int)
-#runas import numpy as np;lx,ly=(2**7,2**7);u=np.zeros([lx,ly],dtype=np.double);u[lx/2,ly/2]=1000.0;tempU=np.zeros([lx,ly],dtype=np.double);diffusePurePython(u,tempU,500)
-#bench import numpy as np;lx,ly=(2**6,2**6);u=np.zeros([lx,ly],dtype=np.double);u[lx/2,ly/2]=1000.0;tempU=np.zeros([lx,ly],dtype=np.double);diffusePurePython(u,tempU,55)
+#runas import numpy as np;lx,ly=(2**7,2**7);u=np.zeros([lx,ly],dtype=np.double);u[int(lx/2),int(ly/2)]=1000.0;tempU=np.zeros([lx,ly],dtype=np.double);diffusePurePython(u,tempU,500)
+#bench import numpy as np;lx,ly=(2**6,2**6);u=np.zeros([lx,ly],dtype=np.double);u[int(lx/2),int(ly/2)]=1000.0;tempU=np.zeros([lx,ly],dtype=np.double);diffusePurePython(u,tempU,55)
 
 import numpy as np
 

--- a/pythran/tests/cases/grayscott.py
+++ b/pythran/tests/cases/grayscott.py
@@ -10,8 +10,9 @@ def GrayScott(counts, Du, Dv, F, k):
 
     r = 20
     u[:] = 1.0
-    U[n/2-r:n/2+r,n/2-r:n/2+r] = 0.50
-    V[n/2-r:n/2+r,n/2-r:n/2+r] = 0.25
+    nd2 = int(n/2)
+    U[nd2-r:nd2+r,nd2-r:nd2+r] = 0.50
+    V[nd2-r:nd2+r,nd2-r:nd2+r] = 0.25
     # commented out because non-reproductible
     if 0:
         u += 0.15*np.random.random((n,n))

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,4 +5,4 @@ test=pytest
 pep8ignore = 
     pythran/tests/*.py ALL
     papers/* ALL
-addopts=--pep8
+addopts=


### PR DESCRIPTION
For instance, nd.array([[1]]) has C_CONTIGUOUS *and* F_CONTIGUOUS at
True. This is actually right because the memory representation is the
same with both conventions.