### PR TITLE
Simplify spec declaration through the or operator

### DIFF
--- a/doc/MANUAL.rst
+++ b/doc/MANUAL.rst
@@ -220,6 +220,17 @@ In a similar manner to the Python import statement, it's possible to chain the e
 
     #pythran export var_name0, var_name1, function_name(argument_type0)
 
+If you want to specify multiple overloads, instead of listing them, you can use the ``or`` operator to list the alteranives, as in::
+
+    #pythran export function_name(type0 or type1, type2, type3 or type4)
+
+which is exactly equivalent to::
+
+    #pythran export function_name(type0, type2, type3)
+    #pythran export function_name(type0, type2, type4)
+    #pythran export function_name(type1, type2, type3)
+    #pythran export function_name(type1, type2, type4)
+
 Easy enough, isn't it?
 
 

--- a/pythran/tests/cases/multitype.py
+++ b/pythran/tests/cases/multitype.py
@@ -1,0 +1,19 @@
+#pythran export square(int or float)
+#runas square(200)
+#runas square(200.200)
+
+def square(n):
+    return n*n
+
+#pythran export mul([int or float] list, int)
+#runas mul([1], 2)
+#runas mul([1.5], 2)
+
+#pythran export mul(int or float list, int or bool)
+#runas mul(1, 2)
+#runas mul([1.5], 2)
+#runas mul(1, True)
+#runas mul([1.5], False)
+
+def mul(x, y):
+    return x * y


### PR DESCRIPTION
Make it possible to declare union type to declare multiple overload in a
convenient manner.

Original idea from Yann Diorcet, revisited by serge-sans-paille.