### PR TITLE
Pythran file: Skip last directive if there is no eol

### DIFF
--- a/pythran/__init__.py
+++ b/pythran/__init__.py
@@ -40,5 +40,6 @@ from pythran.toolchain import (generate_cxx, compile_cxxfile, compile_cxxcode,
                                compile_pythrancode, compile_pythranfile,
                                test_compile)
 from pythran.spec import spec_parser
+from pythran.spec import load_specfile
 from pythran.dist import PythranExtension
 from pythran.version import __version__

--- a/pythran/spec.py
+++ b/pythran/spec.py
@@ -69,8 +69,8 @@ class SpecParser(object):
     # regexp to extract pythran specs from comments
     # the first part matches lines with a comment and the pythran keyword
     # the second part matches lines with comments following the pythran ones
-    FILTER = re.compile(r'^\s*#\s*pythran[^\n\r]*[\n\r]+'
-                        r'^(?:\s*#[^\n\r]*[\n\r]+)*', re.MULTILINE)
+    FILTER = re.compile(r'^\s*#\s*pythran[^\n\r]*'
+                        r'(?:[\n\r]+\s*#[^\n\r]*[\n\r]+)*', re.MULTILINE)
 
     def t_IDENTIFER(self, t):
         r'\#?[a-zA-Z_][a-zA-Z_0-9]*'

--- a/pythran/tests/cases/fannkuch.py
+++ b/pythran/tests/cases/fannkuch.py
@@ -1,6 +1,6 @@
 #imported from https://bitbucket.org/pypy/benchmarks/src/846fa56a282b0e8716309f891553e0af542d8800/own/fannkuch.py?at=default
 # the export line is in fannkuch.pythran
-#runas fannkuch(9)
+#runas fannkuch(9);fannkuch2(9)
 #bench fannkuch(9)
 
 def fannkuch(n):
@@ -42,3 +42,5 @@ def fannkuch(n):
         else:
             return max_flips
 
+def fannkuch2(n):
+    fannkuch(n)

--- a/pythran/tests/cases/fannkuch.pythran
+++ b/pythran/tests/cases/fannkuch.pythran
@@ -1,4 +1,4 @@
 # this is a comment
 export fannkuch(int)
 # this is another comment
-
+export fannkuch2(int)

--- a/pythran/tests/test_env.py
+++ b/pythran/tests/test_env.py
@@ -16,7 +16,7 @@ import unittest
 
 import pytest
 
-from pythran import compile_pythrancode, spec_parser, frontend
+from pythran import compile_pythrancode, spec_parser, load_specfile, frontend
 from pythran.config import have_gmp_support
 from pythran.backend import Python
 from pythran.middlend import refine
@@ -230,7 +230,7 @@ class TestEnv(unittest.TestCase):
 
             # Compile the code using pythran
             cxx_compiled = compile_pythrancode(
-                modname, code, None, extra_compile_args=self.PYTHRAN_CXX_FLAGS)
+                modname, code, interface, extra_compile_args=self.PYTHRAN_CXX_FLAGS)
 
             if not runas:
                 continue
@@ -375,7 +375,13 @@ class TestFromDir(TestEnv):
     def interface(name=None, file_=None):
         """ Return Pythran specs."""
         default_value = {name: []}
-        return spec_parser(open(file_).read()) if file_ else default_value
+
+        # Look for an extra spec file
+        spec_file = os.path.splitext(file_)[0] + '.pythran'
+        if os.path.isfile(spec_file):
+            return load_specfile(open(spec_file).read())
+        else:
+            return spec_parser(open(file_).read()) if file_ else default_value
 
     def __init__(self, *args, **kwargs):
         """ Dynamically add methods for unittests, second stage. """


### PR DESCRIPTION
Here multiples commits for expose and fix the issue.
The issue can't be triggered with the tests because we didn't take pythran file as directives source.
If there is no directive there is no test.
There is still a "WARNING:root:No pythran specification, no function will be exported" in the file /pythran/tests/cases/monte_carlo_pricer.py
(no pythran directive)