### PR TITLE
Manage inspect.getargspec API change between 2.7 and 3.6.1

### DIFF
--- a/pythran/tables.py
+++ b/pythran/tables.py
@@ -27,6 +27,9 @@ if sys.version_info.major == 3:
     sys.modules['__builtin__'].long = long
     import functools
     sys.modules['__builtin__'].reduce = functools.reduce
+    getargspec = inspect.getfullargspec
+else:
+    getargspec = inspect.getargspec
 
 logger = logging.getLogger("pythran")
 
@@ -4405,7 +4408,7 @@ def save_arguments(module_name, elements):
             try:
                 themodule = __import__(".".join(module_name))
                 obj = getattr(themodule, elem)
-                spec = inspect.getargspec(obj)
+                spec = getargspec(obj)
                 assert not signature.args.args
 
                 signature.args.args


### PR DESCRIPTION
Fix #653