### PR TITLE
Fix for issue #687

### DIFF
--- a/pythran/config.py
+++ b/pythran/config.py
@@ -29,7 +29,7 @@ def init_cfg(sys_file, platform_file, user_file):
     for key in ('CC', 'CXX'):
         value = cfgp.get('compiler', key)
         if value:
-            os.environ[key] = value
+            os.environ[key] = str(value)
 
     for obsolete_section in ('user', 'sys'):
         if cfgp.has_section(obsolete_section):


### PR DESCRIPTION
It seems like environment variables have to be set as ASCII, while configparser reads them as unicode. I stumbled over this when simply importing `PythranExtension` was affecting Cython extensions as well.