### PR TITLE
encoded content of cell (type: str) to avoid hashlib error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ env:
     - PYTHON_VERSION=2 TESTCASE=pythran/tests/test_euler.py
 
     - PYTHON_VERSION=2 TESTCASE=pythran/tests/test_ipython.py
+    - PYTHON_VERSION=3 TESTCASE=pythran/tests/test_ipython.py
 
     - MODE=seq PYTHON_VERSION=2 TESTCASE=pythran/tests/test_exception.py
     - MODE=omp PYTHON_VERSION=2 TESTCASE=pythran/tests/test_exception.py

--- a/pythran/magic.py
+++ b/pythran/magic.py
@@ -66,7 +66,7 @@ class PythranMagics(Magics):
             kwargs.setdefault('extra_link_args', []).append(
                 '-fopenmp')
         m = hashlib.md5()
-        m.update(cell)
+        m.update(cell.encode('utf-8'))
         module_name = "pythranized_" + m.hexdigest()
         module_path = pythran.compile_pythrancode(module_name, cell, **kwargs)
         module = imp.load_dynamic(module_name, module_path)


### PR DESCRIPTION
Hi @serge-sans-paille 

As described during the pythran tutorial, pull request to fix the cell (type: str) encoding bug.

Best,
Florian