### PR TITLE
Fix pow accuracy issue

### DIFF
--- a/pythran/pythonic/include/numpy/power.hpp
+++ b/pythran/pythonic/include/numpy/power.hpp
@@ -19,9 +19,12 @@ namespace pythonic
     namespace wrapper
     {
       template <class T0, class T1>
-      auto pow(T0 const &t0, T1 const &t1) -> decltype(boost::simd::pow(t0, t1))
+      auto pow(T0 const &t0, T1 const &t1) -> decltype(
+          boost::simd::pow((typename std::common_type<T0, T1>::type)t0,
+                           (typename std::common_type<T0, T1>::type)t1))
       {
-        return boost::simd::pow(t0, t1);
+        return boost::simd::pow((typename std::common_type<T0, T1>::type)t0,
+                                (typename std::common_type<T0, T1>::type)t1);
       }
       // See https://github.com/MetaScale/nt2/issues/794
       double pow(long const &n, double const &m)

--- a/pythran/tests/test_math.py
+++ b/pythran/tests/test_math.py
@@ -114,3 +114,29 @@ class TestMath(TestEnv):
 
     def test_isinf_(self):
         self.run_test("def isinf_(a):\n from math import isinf\n n=1\n while not isinf(a):\n  a=a*a\n  n+=1\n return isinf(a)", 2., isinf_=[float])
+
+    def test_pow_accuracy(self):
+        code = '''
+        from math import factorial
+        def pow_accuracy(N, i):
+            N = N ** i
+            p = 0.0000001 * 1.0
+
+            binomial_coef = 1. * factorial(N) / factorial(i) / factorial(N-i)
+            pp = binomial_coef * p**i * (1-p)**(N-i)
+            return pp'''
+        self.run_test(code,
+                      3, 2,
+                      pow_accuracy=[int, int])
+
+    def test_pow_array_accuracy(self):
+        code = '''
+        import numpy as np
+        def pow_array_accuracy(N, i):
+            p = np.arange(N) * 0.0000001
+
+            pp = p**i * (1-p)**(N-i)
+            return pp'''
+        self.run_test(code,
+                      3, 2,
+                      pow_array_accuracy=[int, int])


### PR DESCRIPTION
Probably due to boost::simd::pow implementation, fixed forcing the
operand type to the common one.

Fix #708