### PR TITLE
Export native function pointer through __natives__

### DIFF
--- a/docs/INTERNAL.rst
+++ b/docs/INTERNAL.rst
@@ -263,3 +263,14 @@ Pythran preserves docstrings::
         - foo()
     function-level-docstring
     $> rm -f docstrings.*
+
+Integration with Scipy LowLevelCallable
+---------------------------------------
+
+Use pythran exported capsule to interact with SciPy's ``LowLevelCallable``::
+
+    $> printf '#pythran export capsule llc(float)\ndef llc(n):\n  return n + 1' > llc.py
+    $> pythran llc.py
+    $> python -c 'import llc; from scipy import LowLevelCallable, integrate; capsule = llc.llc; c = LowLevelCallable(capsule, signature=\"double (double)\"); print(integrate.quad(c, 0, 10))'
+    (60.0, 6.661338147750939e-13)
+    $> rm -f llc.*

--- a/docs/MANUAL.rst
+++ b/docs/MANUAL.rst
@@ -319,6 +319,19 @@ When distributing a Python application with Pythran modules, you can either:
     setup(...,
           ext_modules=[PythranExtension("mymodule", ["mymodule.py"])])
 
+Capsule Corp
+------------
+
+Instead of creating functions that can be used from Python code, Pythran can
+produce native functions to be used by other Python extension, using the
+``Capsule`` mechanism. To do so, just add the ``capsule`` keyword to the export
+line::
+
+    #pythran export capsule foo(double*, doule)
+
+Note that pointer types are only supported within the context of a capsule, as
+they don't match any real Python type.
+
 Advanced Usage
 --------------
 
@@ -496,9 +509,9 @@ F.A.Q.
 
 1. Supported compiler versions:
 
-   - `g++` version 4.9
+   - `g++` version 4.9 and above
 
-   - `clang++` version 3.5
+   - `clang++` version 3.5 and above
 
 Troubleshooting
 ---------------

--- a/pythran/pythonic/include/types/pointer.hpp
+++ b/pythran/pythonic/include/types/pointer.hpp
@@ -1,0 +1,67 @@
+#ifndef PYTHONIC_INCLUDE_TYPES_POINTER_HPP
+#define PYTHONIC_INCLUDE_TYPES_POINTER_HPP
+
+namespace pythonic
+{
+
+  namespace types
+  {
+
+    template <class T>
+    struct pointer {
+      T *data;
+
+      using reference = T &;
+      using const_reference = T const &;
+      using value_type = T;
+
+      reference operator[](long);
+      value_type operator[](long) const;
+      reference fast(long);
+      value_type fast(long) const;
+    };
+  }
+}
+
+namespace std
+{
+  template <size_t I, class T>
+  typename pythonic::types::pointer<T>::reference
+  get(pythonic::types::pointer<T> &t);
+
+  template <size_t I, class T>
+  typename pythonic::types::pointer<T>::value_type
+  get(pythonic::types::pointer<T> const &t);
+
+  template <size_t I, class T>
+  typename pythonic::types::pointer<T>::value_type
+  get(pythonic::types::pointer<T> &&t);
+
+  template <size_t I, class T>
+  struct tuple_element<I, pythonic::types::pointer<T>> {
+    typedef typename pythonic::types::pointer<T>::value_type type;
+  };
+}
+
+#ifdef ENABLE_PYTHON_MODULE
+
+#include "pythonic/python/core.hpp"
+
+namespace pythonic
+{
+
+  template <typename T>
+  struct to_python<types::pointer<T>> {
+    static PyObject *convert(types::pointer<T> const &v);
+  };
+
+  template <class T>
+  struct from_python<types::pointer<T>> {
+    static bool is_convertible(PyObject *obj);
+    static types::pointer<T> convert(PyObject *obj);
+  };
+}
+
+#endif
+
+#endif

--- a/pythran/pythonic/types/pointer.hpp
+++ b/pythran/pythonic/types/pointer.hpp
@@ -1,0 +1,87 @@
+#ifndef PYTHONIC_TYPES_SET_HPP
+#define PYTHONIC_TYPES_SET_HPP
+
+#include "pythonic/include/types/pointer.hpp"
+
+namespace pythonic
+{
+
+  namespace types
+  {
+
+    template <class T>
+    typename pointer<T>::reference pointer<T>::operator[](long i)
+    {
+      return data[i];
+    }
+
+    template <class T>
+    typename pointer<T>::value_type pointer<T>::operator[](long i) const
+    {
+      return data[i];
+    }
+
+    template <class T>
+    typename pointer<T>::reference pointer<T>::fast(long i)
+    {
+      return data[i];
+    }
+
+    template <class T>
+    typename pointer<T>::value_type pointer<T>::fast(long i) const
+    {
+      return data[i];
+    }
+  }
+}
+
+namespace std
+{
+  template <size_t I, class T>
+  typename pythonic::types::pointer<T>::reference
+  get(pythonic::types::pointer<T> &t)
+  {
+    return t[I];
+  }
+
+  template <size_t I, class T>
+  typename pythonic::types::pointer<T>::value_type
+  get(pythonic::types::pointer<T> const &t)
+  {
+    return t[I];
+  }
+
+  template <size_t I, class T>
+  typename pythonic::types::pointer<T>::value_type
+  get(pythonic::types::pointer<T> &&t)
+  {
+    return t[I];
+  }
+}
+
+#ifdef ENABLE_PYTHON_MODULE
+
+namespace pythonic
+{
+
+  template <typename T>
+  PyObject *to_python<types::pointer<T>>::convert(types::pointer<T> const &v)
+  {
+    return nullptr;
+  }
+
+  template <class T>
+  bool from_python<types::pointer<T>>::is_convertible(PyObject *obj)
+  {
+    return false;
+  }
+  template <class T>
+  types::pointer<T> from_python<types::pointer<T>>::convert(PyObject *obj)
+  {
+    return {nullptr};
+  }
+}
+
+#endif
+
+#endif

--- a/pythran/pythonic/types/str.hpp
+++ b/pythran/pythonic/types/str.hpp
@@ -711,7 +711,7 @@ namespace std
 #define PyString_FromStringAndSize PyUnicode_FromStringAndSize
 #endif
 #ifndef PyString_Check
-#define PyString_Check PyUnicode_IS_ASCII
+#define PyString_Check(x) PyUnicode_Check(x) && PyUnicode_IS_COMPACT_ASCII(x)
 #endif
 #ifndef PyString_AS_STRING
 #define PyString_AS_STRING (char *) _PyUnicode_COMPACT_DATA

--- a/pythran/pythran-linux.cfg
+++ b/pythran/pythran-linux.cfg
@@ -4,7 +4,7 @@ undefs=
 include_dirs=
 libs=gmp gmpxx
 library_dirs=
-cflags=-std=c++11 -fno-math-errno -w -fvisibility=hidden
+cflags=-std=c++11 -fno-math-errno -w -fvisibility=hidden -fno-wrapv
 ldflags=-fvisibility=hidden -Wl,-strip-all
 blas=blas
 CC=

--- a/pythran/pythran-linux2.cfg
+++ b/pythran/pythran-linux2.cfg
@@ -4,7 +4,7 @@ undefs=
 include_dirs=
 libs=gmp gmpxx
 library_dirs=
-cflags=-std=c++11 -fno-math-errno -w -fvisibility=hidden
+cflags=-std=c++11 -fno-math-errno -w -fvisibility=hidden -fno-wrapv
 ldflags=-fvisibility=hidden -Wl,-strip-all
 blas=blas
 CC=

--- a/pythran/syntax.py
+++ b/pythran/syntax.py
@@ -182,8 +182,8 @@ def check_specs(mod, specs, renamings, types):
     from pythran.types.tog import unify, clone, tr
     from pythran.types.tog import Function, TypeVariable, InferenceError
 
-    specs = {renamings.get(k, k): v for k, v in specs.items()}
-    for fname, signatures in specs.items():
+    functions = {renamings.get(k, k): v for k, v in specs.functions.items()}
+    for fname, signatures in functions.items():
         try:
             ftype = types[fname]
         except KeyError:

--- a/pythran/tests/test_env.py
+++ b/pythran/tests/test_env.py
@@ -22,6 +22,7 @@ from pythran.backend import Python
 from pythran.middlend import refine
 from pythran.passmanager import PassManager
 from pythran.toolchain import _parse_optimization
+from pythran.spec import Spec
 
 
 def may_convert_2_to_3(code):
@@ -375,14 +376,15 @@ class TestFromDir(TestEnv):
     @staticmethod
     def interface(name=None, file_=None):
         """ Return Pythran specs."""
-        default_value = {name: []}
 
         # Look for an extra spec file
         spec_file = os.path.splitext(file_)[0] + '.pythran'
         if os.path.isfile(spec_file):
             return load_specfile(open(spec_file).read())
+        elif file_ is None:
+            return Spec({name: []})
         else:
-            return spec_parser(open(file_).read()) if file_ else default_value
+            return spec_parser(open(file_).read())
 
     def __init__(self, *args, **kwargs):
         """ Dynamically add methods for unittests, second stage. """
@@ -455,7 +457,7 @@ class TestFromDir(TestEnv):
         for filepath in target.files:
             # Module name is file name and external interface is default value
             name, _ = os.path.splitext(os.path.basename(filepath))
-            specs = target.interface(name, filepath)
+            specs = target.interface(name, filepath).functions
             with open(filepath) as runas_fd:
                 runas_list = [line for line in runas_fd.readlines()
                               if any(line.startswith(marker) for

--- a/pythran/tests/test_numpy_ufunc_unary.py
+++ b/pythran/tests/test_numpy_ufunc_unary.py
@@ -55,11 +55,11 @@ for module, functions in unary_func_by_module.items():
 
         for test_suffix, (input, pythran_input_type) \
                 in test_inputs_by_type[input_type].items():
-            func_name = "{}_{}{}".format(module.replace('.', '_'), f,
+            func_name = "numpy_ufunc_unary_{}_{}{}".format(module.replace('.', '_'), f,
                                          test_suffix)
             setattr(
                 TestNumpyUFuncUnary,
-                'test_{}'.format(func_name),
+                'test_numpy_ufunc_unary_{}'.format(func_name),
                 eval(
                     """
                     lambda self: self.run_test(

--- a/pythran/tests/test_openmp.py
+++ b/pythran/tests/test_openmp.py
@@ -4,6 +4,7 @@ from test_env import TestFromDir
 import os
 import pythran
 from pythran.syntax import PythranSyntaxError
+from pythran.spec import Spec
 
 class TestOpenMP(TestFromDir):
     path = os.path.join(os.path.dirname(__file__), "openmp")
@@ -17,7 +18,7 @@ class TestOpenMPLegacy(TestFromDir):
 
     @staticmethod
     def interface(name, file=None):
-        return {name: []}
+        return Spec({name: []})
 
 # only activate OpenMP tests if the underlying compiler supports OpenMP
 try:

--- a/pythran/tests/test_spec_parser.py
+++ b/pythran/tests/test_spec_parser.py
@@ -117,8 +117,8 @@ def foo(i): return
 #      pythran export foo(float)
 def bar(i): return
             '''
-        self.assertEquals(len(pythran.spec_parser(code)), 1)
-        self.assertEquals(len(pythran.spec_parser(code)['foo']), 2)
+        self.assertEquals(len(pythran.spec_parser(code).functions), 1)
+        self.assertEquals(len(pythran.spec_parser(code).functions['foo']), 2)
 
     def test_var_export0(self):
         code = '''

--- a/pythran/types/conversion.py
+++ b/pythran/types/conversion.py
@@ -4,7 +4,7 @@ import sys
 
 from numpy import int8, int16, int32, int64, uint8, uint16, uint32
 from numpy import float64, float32, complex64, complex128, uint64
-from pythran.typing import List, Dict, Set, Tuple, NDArray, NDArray
+from pythran.typing import List, Dict, Set, Tuple, NDArray, NDArray, Pointer
 
 PYTYPE_TO_CTYPE_TABLE = {
     complex: 'std::complex<double>',
@@ -66,6 +66,10 @@ def pytype_to_ctype(t):
             return 'pythonic::types::numpy_gexpr<{0},{1}>'.format(arr, slices)
         else:
             return arr
+    elif isinstance(t, Pointer):
+        return 'pythonic::types::pointer<{0}>'.format(
+            pytype_to_ctype(t.__args__[0])
+        )
     elif t in PYTYPE_TO_CTYPE_TABLE:
         return PYTYPE_TO_CTYPE_TABLE[t]
     else:
@@ -97,6 +101,9 @@ def pytype_to_pretty_type(t):
             return '{0}{1}'.format(dtype, '[::]' * ndim)
         else:
             return arr
+    elif isinstance(t, Pointer):
+        dtype = pytype_to_pretty_type(t.__args__[0])
+        return '{}*'.format(dtype)
     elif t in PYTYPE_TO_CTYPE_TABLE:
         return t.__name__
     else:

--- a/pythran/types/tog.py
+++ b/pythran/types/tog.py
@@ -453,6 +453,9 @@ def tr(t):
         elif isinstance(t, typing.NDArray):
             return Array(rec_tr(t.__args__[0], env), len(t.__args__[1:]))
 
+        elif isinstance(t, typing.Pointer):
+            return Array(rec_tr(t.__args__[0], env), 1)
+
         elif isinstance(t, typing.Union):
             return MultiType([rec_tr(ut, env) for ut in t.__args__])
 

--- a/pythran/types/type_dependencies.py
+++ b/pythran/types/type_dependencies.py
@@ -11,7 +11,7 @@ from pythran.errors import PythranInternalError
 from pythran.passmanager import ModuleAnalysis
 from pythran.types.conversion import PYTYPE_TO_CTYPE_TABLE
 from pythran.utils import get_variable
-from pythran.typing import List, Set, Dict, NDArray, Tuple
+from pythran.typing import List, Set, Dict, NDArray, Tuple, Pointer
 
 
 def pytype_to_deps_hpp(t):
@@ -33,6 +33,8 @@ def pytype_to_deps_hpp(t):
         if t.__args__[1].start == -1:
             out.add('numpy_texpr.hpp')
         return out.union(pytype_to_deps_hpp(t.__args__[0]))
+    elif isinstance(t, Pointer):
+        return {'pointer.hpp'}.union(pytype_to_deps_hpp(t.__args__[0]))
     elif t in PYTYPE_TO_CTYPE_TABLE:
         return {'{}.hpp'.format(t.__name__)}
     else:

--- a/pythran/typing.py
+++ b/pythran/typing.py
@@ -61,6 +61,12 @@ class NDArrayMeta(type):
         return NDArray(item)
 
 
+class PointerMeta(type):
+
+    def __getitem__(cls, item):
+        return Pointer(item)
+
+
 class Type(type):
 
     def __new__(cls, args):
@@ -112,6 +118,10 @@ class Optional(with_metaclass(OptionalMeta, Type)):
 
 
 class NDArray(with_metaclass(NDArrayMeta, Type)):
+    pass
+
+
+class Pointer(with_metaclass(PointerMeta, Type)):
     pass
 
 


### PR DESCRIPTION
This can be used by third-party library like scipy.LowLevelCallable to
avoid conversion costs.