### PR TITLE
Feature/dump optimized python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,17 @@ website/license.txt
 pythran/nt2
 pythran/boost
 parsetab.py
+
+pythran.egg-info/*
+.eggs/*
+.pytest_cache/*
+pythran_test.*
+cli_foo*
+
+pythran/tests/cython/add.cpp
+pythran/tests/cython/diffuse.cpp
+
+pythran/tests/test_distutils/MANIFEST
+pythran/tests/test_distutils/a.cpp
+pythran/tests/test_distutils_packaged/MANIFEST
+pythran/tests/test_distutils_packaged/a.cpp

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,12 @@ pythran/tests/test_distutils/MANIFEST
 pythran/tests/test_distutils/a.cpp
 pythran/tests/test_distutils_packaged/MANIFEST
 pythran/tests/test_distutils_packaged/a.cpp
+
+docs/_build
+docs/AUTHORS.rst
+docs/Changelog.rst
+docs/LICENSE.rst
+docs/SUPPORT.rst
+docs/index.rst
+
+*~

--- a/docs/MANUAL.rst
+++ b/docs/MANUAL.rst
@@ -395,7 +395,6 @@ Alternatively, one can run the great::
 which runs a code analyzer that displays extra information concerning parallel ``map`` found in the code.
 
 
-
 Getting Pure C++
 ----------------
 
@@ -403,6 +402,17 @@ Pythran can be used to generate raw templated C++ code, without any Python
 glue. To do so use the ``-e`` switch. It will turn the Python code into C++
 code you can call from a C++ program. In that case there is **no** need for a
 particular Pythran specification.
+
+
+Read the optimized Python code
+------------------------------
+
+Curious Python developers might want to study how Pythran transforms their
+codes.  With the ``-P`` switch, Pythran just print the optimized Python code.
+Pythran does not care about PEP 8, so a Python formatter is often useful::
+
+  pythran -P arc_distance.py | yapf
+
 
 Customizing Your ``.pythranrc``
 -------------------------------

--- a/docs/MANUAL.rst
+++ b/docs/MANUAL.rst
@@ -408,8 +408,9 @@ Read the optimized Python code
 ------------------------------
 
 Curious Python developers might want to study how Pythran transforms their
-codes.  With the ``-P`` switch, Pythran just print the optimized Python code.
-Pythran does not care about PEP 8, so a Python formatter is often useful::
+codes.  With the ``-P`` switch, Pythran optimizes the Python code, prints the
+result and stops there.  Pythran does not care about PEP 8, so a Python
+formatter is often useful::
 
   pythran -P arc_distance.py | yapf
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,9 @@
+
+SPHINXBUILD   = sphinx-build
+BUILDDIR      = _build
+ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees .
+
+html:
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	@echo
+	@echo "Build finished.\nfile://"$(shell pwd)"/_build/html/index.html"

--- a/pythran/run.py
+++ b/pythran/run.py
@@ -58,6 +58,10 @@ def run():
     parser.add_argument('-o', dest='output_file', type=str,
                         help='path to generated file')
 
+    parser.add_argument('-P', dest='optimize_only', action='store_true',
+                        help='only run the high-level optimizer, '
+                        'do not compile')
+
     parser.add_argument('-E', dest='translate_only', action='store_true',
                         help='only run the translator, do not compile')
 
@@ -125,6 +129,10 @@ def run():
             raise SyntaxError("Unsupported file extension: '{0}'".format(ext))
 
         if ext == '.cpp':
+            if args.optimize_only:
+                raise ValueError("Do you really ask for Python-to-Python "
+                                 "on this C++ input file: '{0}'?".format(
+                                     args.input_file))
             if args.translate_only:
                 raise ValueError("Do you really ask for Python-to-C++ "
                                  "on this C++ input file: '{0}'?".format(
@@ -138,6 +146,7 @@ def run():
             pythran.compile_pythranfile(args.input_file,
                                         output_file=args.output_file,
                                         cpponly=args.translate_only,
+                                        pyonly=args.optimize_only,
                                         **compile_flags(args))
 
     except IOError as e:

--- a/pythran/tests/test_exception.py
+++ b/pythran/tests/test_exception.py
@@ -292,9 +292,21 @@ class TestException(TestEnv):
         self.run_test("def no_msg_exception_register():\n raise IndexError()", no_msg_exception_register=[], check_exception=True)
 
 for exception in exceptions:
+
+    # FIXME: new py3 exceptions
+    incompatible_py3 = (
+        'BlockingIOError', 'BrokenPipeError', 'ChildProcessError',
+        'ConnectionAbortedError', 'ConnectionError', 'ConnectionRefusedError',
+        'ConnectionResetError', 'FileExistsError', 'FileNotFoundError',
+        'InterruptedError', 'IsADirectoryError', 'ModuleNotFoundError',
+        'NotADirectoryError', 'PermissionError', 'ProcessLookupError',
+        'RecursionError', 'ResourceWarning', 'StopAsyncIteration',
+        'TimeoutError')
+
     # This one is not compatible with pytest
-    if str(exception) in ("AssertionError", "UnicodeDecodeError",
-                          "UnicodeEncodeError", "UnicodeTranslateError"):
+    if str(exception) in (
+            "AssertionError", "UnicodeDecodeError",
+            "UnicodeEncodeError", "UnicodeTranslateError") + incompatible_py3:
         continue
     args = exception_args[exception]
     code = 'def {exception}_register(): raise {exception}{args}'.format(**locals())

--- a/pythran/toolchain.py
+++ b/pythran/toolchain.py
@@ -3,7 +3,7 @@ This module contains all the stuff to make your way from python code to
 a dynamic library, see __init__.py for exported interfaces.
 '''
 
-from pythran.backend import Cxx
+from pythran.backend import Cxx, Python
 from pythran.config import cfg, make_extension
 from pythran.cxxgen import PythonModule, Define, Include, Line, Statement
 from pythran.cxxgen import FunctionBody, FunctionDeclaration, Value, Block
@@ -114,7 +114,39 @@ class HasArgument(ast.NodeVisitor):
                 return [arg.id for arg in n.args.args]
         return []
 
+
+def front_middle_end(module_name, code, specs=None, optimizations=None):
+    """Front-end and middle-end compilation steps"""
+    pm = PassManager(module_name)
+
+    # front end
+    ir, renamings, docstrings = frontend.parse(pm, code)
+
+    # middle-end
+    optimizations = (optimizations or
+                     cfg.get('pythran', 'optimizations').split())
+    optimizations = [_parse_optimization(opt) for opt in optimizations]
+    refine(pm, ir, optimizations)
+
+    return ir, renamings, docstrings, pm, optimizations
+
+
 # PUBLIC INTERFACE STARTS HERE
+
+
+def generate_py(module_name, code, specs=None, optimizations=None):
+    '''python + pythran spec -> py code
+
+    Prints and returns the optimized python code.
+
+    '''
+
+    ir, renamings, docstrings, pm, optimizations = front_middle_end(
+        module_name, code, specs, optimizations)
+
+    content = pm.dump(Python, ir)
+    print(content)
+    return content
 
 
 def generate_cxx(module_name, code, specs=None, optimizations=None):
@@ -126,16 +158,8 @@ def generate_cxx(module_name, code, specs=None, optimizations=None):
 
     '''
 
-    pm = PassManager(module_name)
-
-    # front end
-    ir, renamings, docstrings = frontend.parse(pm, code)
-
-    # middle-end
-    optimizations = (optimizations or
-                     cfg.get('pythran', 'optimizations').split())
-    optimizations = [_parse_optimization(opt) for opt in optimizations]
-    refine(pm, ir, optimizations)
+    ir, renamings, docstrings, pm, optimizations = front_middle_end(
+        module_name, code, specs, optimizations)
 
     # back-end
     content = pm.dump(Cxx, ir)
@@ -308,8 +332,8 @@ def compile_cxxfile(module_name, cxxfile, output_binary=None, **kwargs):
                            'build_ext',
                            '--build-lib', builddir,
                            '--build-temp', buildtmp,
-                           ]
-              )
+                          ]
+             )
     except SystemExit as e:
         raise CompileError(str(e))
 
@@ -348,8 +372,8 @@ def compile_cxxcode(module_name, cxxcode, output_binary=None, keep_temp=False,
 
 
 def compile_pythrancode(module_name, pythrancode, specs=None,
-                        opts=None, cpponly=False, output_file=None,
-                        **kwargs):
+                        opts=None, cpponly=False, pyonly=False,
+                        output_file=None, **kwargs):
     '''Pythran code (string) -> c++ code -> native module
     Returns the generated .so (or .cpp if `cpponly` is set to true).
 
@@ -359,6 +383,10 @@ def compile_pythrancode(module_name, pythrancode, specs=None,
     from pythran.spec import spec_parser
     if specs is None:
         specs = spec_parser(pythrancode)
+
+    if pyonly:
+        # Only generate the optimized python code
+        return generate_py(module_name, pythrancode, specs, opts)
 
     # Generate C++, get a PythonModule object
     module, error_checker = generate_cxx(module_name, pythrancode, specs, opts)
@@ -390,7 +418,7 @@ def compile_pythrancode(module_name, pythrancode, specs=None,
 
 
 def compile_pythranfile(file_path, output_file=None, module_name=None,
-                        cpponly=False, **kwargs):
+                        cpponly=False, pyonly=False, **kwargs):
     """
     Pythran file -> c++ file -> native module.
 
@@ -428,7 +456,7 @@ def compile_pythranfile(file_path, output_file=None, module_name=None,
 
     output_file = compile_pythrancode(module_name, open(file_path).read(),
                                       output_file=output_file,
-                                      cpponly=cpponly,
+                                      cpponly=cpponly, pyonly=pyonly,
                                       **kwargs)
 
     return output_file


### PR DESCRIPTION
Add a not very useful -P option to dump optimized Python code.

It is mainly to start to contribute and see how it works.

Serge, you told me that I could do something simpler by simply change the backend. I'm not sure to understand because I would have to use the Python backend in the function generate_cxx, which is maybe not so great.

I didn't find the tests for the command line. Should I add a test for this -P option? Where?
