### PR TITLE
Conserve memory order during numpy.copy and upon return

### DIFF
--- a/pythran/pythonic/include/numpy/copy.hpp
+++ b/pythran/pythonic/include/numpy/copy.hpp
@@ -32,6 +32,11 @@ namespace numpy
   template <class T, size_t N>
   types::ndarray<T, N> copy(types::ndarray<T, N> const &a);
 
+  // transposed ndarray case
+  template <class T, size_t N>
+  types::numpy_texpr<types::ndarray<T, N>>
+  copy(types::numpy_texpr<types::ndarray<T, N>> const &a);
+
   DECLARE_FUNCTOR(pythonic::numpy, copy);
 }
 PYTHONIC_NS_END

--- a/pythran/pythonic/include/types/numpy_gexpr.hpp
+++ b/pythran/pythonic/include/types/numpy_gexpr.hpp
@@ -489,6 +489,16 @@ namespace types
 
     numpy_gexpr &operator/=(numpy_gexpr const &expr);
 
+    template <class E>
+    numpy_gexpr &operator|=(E const &expr);
+
+    numpy_gexpr &operator|=(numpy_gexpr const &expr);
+
+    template <class E>
+    numpy_gexpr &operator&=(E const &expr);
+
+    numpy_gexpr &operator&=(numpy_gexpr const &expr);
+
     const_iterator begin() const;
     const_iterator end() const;
 

--- a/pythran/pythonic/include/types/numpy_texpr.hpp
+++ b/pythran/pythonic/include/types/numpy_texpr.hpp
@@ -162,6 +162,23 @@ namespace types
     {
       return *this;
     }
+    template <class Expr>
+    numpy_texpr_2 &operator=(Expr const &expr);
+
+    template <class Op, class Expr>
+    numpy_texpr_2 &update_(Expr const &expr);
+    template <class Expr>
+    numpy_texpr_2 &operator+=(Expr const &expr);
+    template <class Expr>
+    numpy_texpr_2 &operator-=(Expr const &expr);
+    template <class Expr>
+    numpy_texpr_2 &operator*=(Expr const &expr);
+    template <class Expr>
+    numpy_texpr_2 &operator/=(Expr const &expr);
+    template <class Expr>
+    numpy_texpr_2 &operator&=(Expr const &expr);
+    template <class Expr>
+    numpy_texpr_2 &operator|=(Expr const &expr);
   };
 
   // only implemented for N = 2
@@ -170,8 +187,9 @@ namespace types
     numpy_texpr();
     numpy_texpr(numpy_texpr const &) = default;
     numpy_texpr(numpy_texpr &&) = default;
-
     numpy_texpr(ndarray<T, 2> const &arg);
+
+    using numpy_texpr_2<ndarray<T, 2>>::operator=;
   };
 
   template <class E, class... S>
@@ -180,19 +198,20 @@ namespace types
     numpy_texpr();
     numpy_texpr(numpy_texpr const &) = default;
     numpy_texpr(numpy_texpr &&) = default;
-
     numpy_texpr(numpy_gexpr<E, S...> const &arg);
+
+    using numpy_texpr_2<numpy_gexpr<E, S...>>::operator=;
   };
 }
 
 template <class Arg>
 struct assignable<types::numpy_texpr<Arg>> {
-  using type = types::ndarray<typename Arg::dtype, Arg::value>;
+  using type = types::numpy_texpr<typename assignable<Arg>::type>;
 };
 
-template <class T>
-struct returnable<types::numpy_texpr<types::ndarray<T, 2>>> {
-  using type = types::numpy_texpr<types::ndarray<T, 2>>;
+template <class Arg>
+struct returnable<types::numpy_texpr<Arg>> {
+  using type = types::numpy_texpr<typename returnable<Arg>::type>;
 };
 
 template <class Arg>

--- a/pythran/pythonic/numpy/copy.hpp
+++ b/pythran/pythonic/numpy/copy.hpp
@@ -46,6 +46,14 @@ namespace numpy
     return a.copy();
   }
 
+  // transposed ndarray case
+  template <class T, size_t N>
+  types::numpy_texpr<types::ndarray<T, N>>
+  copy(types::numpy_texpr<types::ndarray<T, N>> const &a)
+  {
+    return a.arg.copy();
+  }
+
   DEFINE_FUNCTOR(pythonic::numpy, copy);
 }
 PYTHONIC_NS_END

--- a/pythran/pythonic/numpy/var.hpp
+++ b/pythran/pythonic/numpy/var.hpp
@@ -12,6 +12,7 @@
 #include "pythonic/numpy/mean.hpp"
 #include "pythonic/numpy/reshape.hpp"
 #include "pythonic/numpy/sum.hpp"
+#include "pythonic/numpy/empty_like.hpp"
 
 #include <algorithm>
 
@@ -69,7 +70,7 @@ namespace numpy
       shp[axis] = 1;
       auto mp = m.reshape(shp);
 
-      typename assignable<E>::type t{expr_shape, __builtin__::None};
+      auto t = empty_like(expr);
       _enlarge_copy_minus(t, expr, mp, axis, utils::int_<E::value>());
       return sum(t * t, axis) /= var_type<E>(expr_shape[axis] - ddof);
     }

--- a/pythran/pythonic/types/numpy_gexpr.hpp
+++ b/pythran/pythonic/types/numpy_gexpr.hpp
@@ -593,6 +593,34 @@ namespace types
   }
 
   template <class Arg, class... S>
+  template <class E>
+  numpy_gexpr<Arg, S...> &numpy_gexpr<Arg, S...>::operator|=(E const &expr)
+  {
+    return update_<pythonic::operator_::functor::ior>(expr);
+  }
+
+  template <class Arg, class... S>
+  numpy_gexpr<Arg, S...> &numpy_gexpr<Arg, S...>::
+  operator|=(numpy_gexpr<Arg, S...> const &expr)
+  {
+    return update_<pythonic::operator_::functor::ior>(expr);
+  }
+
+  template <class Arg, class... S>
+  template <class E>
+  numpy_gexpr<Arg, S...> &numpy_gexpr<Arg, S...>::operator&=(E const &expr)
+  {
+    return update_<pythonic::operator_::functor::iand>(expr);
+  }
+
+  template <class Arg, class... S>
+  numpy_gexpr<Arg, S...> &numpy_gexpr<Arg, S...>::
+  operator&=(numpy_gexpr<Arg, S...> const &expr)
+  {
+    return update_<pythonic::operator_::functor::iand>(expr);
+  }
+
+  template <class Arg, class... S>
   typename numpy_gexpr<Arg, S...>::const_iterator
   numpy_gexpr<Arg, S...>::begin() const
   {

--- a/pythran/tests/test_numpy_func0.py
+++ b/pythran/tests/test_numpy_func0.py
@@ -519,7 +519,7 @@ def np_rosen_der(x):
         self.run_test("def np_rot901(x): from numpy import rot90; return rot90(x)", numpy.arange(4).reshape(2,2), np_rot901=[NDArray[int,:,:]])
 
     def test_select2(self):
-        self.run_test("def np_select2(x): from numpy import select; condlist = [x<3, x>5]; choicelist = [x, x**2]; return select(condlist, choicelist)", numpy.arange(10).reshape(2,5), np_select2=[NDArray[int,:,:]])
+        self.run_test("def np_select2(x): from numpy import select; condlist = [x<3, x>5]; choicelist = [x**3, x**2]; return select(condlist, choicelist)", numpy.arange(10).reshape(2,5), np_select2=[NDArray[int,:,:]])
 
     def test_select1(self):
         self.run_test("def np_select1(x): from numpy import select; condlist = [x<3, x>5]; choicelist = [x+3, x**2]; return select(condlist, choicelist)", numpy.arange(10), np_select1=[NDArray[int,:]])


### PR DESCRIPTION
This avoids a few extra copies and should (partially) fix #805.