### PR TITLE
Add optimization for replacing identities of binary operators.

### DIFF
--- a/pythran/optimizations/__init__.py
+++ b/pythran/optimizations/__init__.py
@@ -22,6 +22,7 @@ from .pattern_transform import PatternTransform
 from .range_loop_unfolding import RangeLoopUnfolding
 from .range_based_simplify import RangeBasedSimplify
 from .square import Square
+from .binop_identities import BinOpIdentities
 from .inlining import Inlining
 from .inline_builtins import InlineBuiltins
 from .list_to_tuple import ListToTuple

--- a/pythran/optimizations/binop_identities.py
+++ b/pythran/optimizations/binop_identities.py
@@ -1,0 +1,79 @@
+""" Replaces identities of binary operators """
+
+from pythran.passmanager import Transformation
+from pythran.analyses.ast_matcher import ASTMatcher, AST_any
+
+import gast as ast
+
+
+class BinOpIdentities(Transformation):
+
+    """
+    Replaces identities of binary operators
+
+    >>> import gast as ast
+    >>> from pythran import passmanager, backend
+    >>> from pythran.optimizations import BinOpIdentities
+    >>> node = ast.parse('b = a * 0')
+    >>> pm = passmanager.PassManager("test")
+    >>> _, node = pm.apply(BinOpIdentities, node)
+    >>> print(pm.dump(backend.Python, node))
+    b = 0
+    >>> node = ast.parse('b = a * 1')
+    >>> pm = passmanager.PassManager("test")
+    >>> _, node = pm.apply(BinOpIdentities, node)
+    >>> print(pm.dump(backend.Python, node))
+    b = a
+    """
+
+    """ 
+    Identites for binary operators are implemented as:
+      IDs[ast.OPERATION.__name__] = ( ( A, B, C) )
+    i.e
+      ast.BinOp(left=A, op=OPERATION(), right=B) is replaced with C
+
+    A or B can be AST_any(). 
+    If C is AST_any(), then the node will be replaced with node.left
+    or node.right depending if A or B was AST_any(), respectively.
+
+    The implemented identities are
+       x * 0 = 0
+       0 * x = 0
+       x * 1 = x
+       1 * x = x
+       x + 0 = x
+       0 + x = x
+       x - 0 = x
+    """
+    IDs = {}
+    IDs[ast.Mult.__name__] = ( (ast.Num(0), AST_any(), ast.Num(0)),
+                               (AST_any(), ast.Num(0), ast.Num(0)),
+                               (AST_any(), ast.Num(1), AST_any()),
+                               (ast.Num(1), AST_any(), AST_any()), )
+
+    IDs[ast.Add.__name__] = ( (ast.Num(0), AST_any(), AST_any()),
+                              (AST_any(), ast.Num(0), AST_any()), )
+
+    IDs[ast.Sub.__name__] = ( (AST_any(), ast.Num(0), AST_any()), )
+
+    def __init__(self):
+        Transformation.__init__(self)
+        
+    def visit_BinOp(self, node):
+        self.generic_visit(node)
+        if node.op.__class__.__name__ in self.IDs:
+            for identity in self.IDs[node.op.__class__.__name__]:
+                if ASTMatcher(ast.BinOp(identity[0], node.op, identity[1])).search(node):
+                    replace = identity[2]
+                    if isinstance(replace, AST_any):
+                        if isinstance(identity[0], AST_any) and isinstance(identity[1], AST_any):
+                            print("Error: identity (AST_any(), AST_any(), AST_any()) not allowed.")
+                            replace = node
+                        elif isinstance(identity[0], AST_any):
+                            replace = node.left
+                        elif isinstance(identity[1], AST_any):
+                            replace = node.right
+                    #print("Replacing ", ast.dump(node), " with ", ast.dump(replace))
+                    ast.copy_location(replace, node)
+                    return replace
+        return node

--- a/pythran/pythran.cfg
+++ b/pythran/pythran.cfg
@@ -13,6 +13,7 @@ optimizations = pythran.optimizations.InlineBuiltins
                 pythran.transformations.FalsePolymorphism
                 pythran.optimizations.DeadCodeElimination
                 pythran.optimizations.PatternTransform
+                pythran.optimizations.BinOpIdentities
                 pythran.optimizations.Square
                 pythran.optimizations.RangeLoopUnfolding
                 pythran.optimizations.RangeBasedSimplify


### PR DESCRIPTION
Hi,

I've casually find out pythran and it's a very interesting project. Thank you for all the effort you have put in it. I was experimenting a bit and trying to understand if it can be useful for the project I have in mind.
The structure is nice and easy to develop with it.

I've tried to implement an optimization which replace identities of the operators (BinOp at the moment). I tried to give a generic structure such that many identities can be implemented easily. Similarly in the optimization Square you have the function expand_pow which replace x**0 and x**1. This can be moved here for instance.

The pull request is not complete yet, but I wanted first to ask if it's something needed and the implementation is up-to-standard.

Cheers,
Simone