### PR TITLE
Fix Windows compilation

### DIFF
--- a/pythran/pythonic/include/types/numpy_expr.hpp
+++ b/pythran/pythonic/include/types/numpy_expr.hpp
@@ -98,7 +98,7 @@ namespace types
                      utils::index_sequence<I...>) const
     {
       std::initializer_list<long> distances{
-          (std::get<I>(iters_) - std::get<I>(other.iters_))...};
+          (static_cast<long>(std::get<I>(iters_) - std::get<I>(other.iters_)))...};
       return *std::max_element(distances.begin(), distances.end());
     }
 

--- a/pythran/pythonic/types/numpy_fexpr.hpp
+++ b/pythran/pythonic/types/numpy_fexpr.hpp
@@ -19,9 +19,7 @@ namespace types
     _copy_mask(filter.begin(), filter.end(), iter, index,
                utils::int_<std::remove_reference<
                    typename std::remove_cv<Arg>::type>::type::value>());
-    // FIXME {iter - buffer} is a long long int? (Windows say that...
-    // && warn us)
-    _shape[0] = {iter - buffer};
+    _shape[0] = {static_cast<long>(iter - buffer)};
   }
 
   template <class Arg, class F>


### PR DESCRIPTION
Without these casts, VS2017 fails with a C2397 and C2398.
Indeed pointer difference is not natively a long on Windows X64.
We need to do a static_cast in order to avoid these issues.