### PR TITLE
Windows

### DIFF
--- a/pythran/backend.py
+++ b/pythran/backend.py
@@ -914,7 +914,7 @@ class CxxFunction(Backend):
 
     def visit_Str(self, node):
         quoted = node.s.replace('"', '\\"').replace('\n', '\\n"\n"')
-        return '"' + quoted + '"'
+        return 'pythonic::types::str("' + quoted + '")'
 
     def visit_Attribute(self, node):
         obj, path = attr_to_path(node)
@@ -1230,7 +1230,7 @@ result_type;
       }  ;
       typename foo::type::result_type foo::operator()() const
       {
-        return "hello world";
+        return pythonic::types::str("hello world");
       }
     }
     """

--- a/pythran/pythonic/include/types/tuple.hpp
+++ b/pythran/pythonic/include/types/tuple.hpp
@@ -11,6 +11,13 @@
 #include <tuple>
 #include <algorithm>
 
+#if !defined(HAVE_SSIZE_T) || !HAVE_SSIZE_T
+#if defined(_MSC_VER)
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+#endif
+
 // Equality comparison between pair && tuple
 namespace std
 {

--- a/pythran/pythonic/include/types/tuple.hpp
+++ b/pythran/pythonic/include/types/tuple.hpp
@@ -203,7 +203,7 @@ namespace types
     }
 
     template <class S>
-    pshape(array<S, sizeof...(Tys)> data)
+    pshape(pythonic::types::array<S, sizeof...(Tys)> data)
         : pshape(data.data())
     {
     }
@@ -770,14 +770,20 @@ namespace sutils
   };
 
   template <size_t I, class Ss>
+  struct shape_selecter
+      : std::conditional<
+            (I < std::tuple_size<Ss>::value),
+            typename std::tuple_element<
+                (I < std::tuple_size<Ss>::value ? I : 0L), Ss>::type,
+            std::integral_constant<long, 1>> {
+  };
+
+  template <size_t I, class Ss>
   struct merge_shape;
   template <size_t I, class... Ss>
   struct merge_shape<I, std::tuple<Ss...>> {
-    using type = typename shape_merger<typename std::conditional<
-        (I < std::tuple_size<Ss>::value),
-        typename std::tuple_element<(I < std::tuple_size<Ss>::value ? I : 0L),
-                                    Ss>::type,
-        std::integral_constant<long, 1>>::type...>::type;
+    using type =
+        typename shape_merger<typename shape_selecter<I, Ss>::type...>::type;
   };
   template <class Ss, class T>
   struct merged_shapes;

--- a/pythran/pythonic/include/utils/numpy_conversion.hpp
+++ b/pythran/pythonic/include/utils/numpy_conversion.hpp
@@ -5,6 +5,14 @@
 
 #include <utility>
 
+#if _MSC_VER
+#define NUMPY_EXPR_TO_NDARRAY0_DECL(fname)                                     \
+  template <class E, class... Types,                                           \
+            typename std::enable_if<!types::is_ndarray<E>::value &&            \
+                                        types::is_array<E>::value,             \
+                                    E>::type * = nullptr>                      \
+  auto fname(E const &expr, Types &&... others);
+#else
 #define NUMPY_EXPR_TO_NDARRAY0_DECL(fname)                                     \
   template <class E, class... Types>                                           \
   auto fname(E const &expr, Types &&... others)                                \
@@ -13,5 +21,5 @@
           decltype(fname(                                                      \
               types::ndarray<typename E::dtype, typename E::shape_t>{expr},    \
               std::forward<Types>(others)...))>::type;
-
+#endif
 #endif

--- a/pythran/pythonic/types/ndarray.hpp
+++ b/pythran/pythonic/types/ndarray.hpp
@@ -59,6 +59,13 @@
 #include <initializer_list>
 #include <numeric>
 
+#if !defined(HAVE_SSIZE_T) || !HAVE_SSIZE_T
+#if defined(_MSC_VER)
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+#endif
+
 PYTHONIC_NS_BEGIN
 
 namespace types

--- a/pythran/pythonic/types/ndarray.hpp
+++ b/pythran/pythonic/types/ndarray.hpp
@@ -913,7 +913,7 @@ namespace types
   template <class T, class pS>
   ndarray<T, pshape<long>> ndarray<T, pS>::flat() const
   {
-    return {mem, array<long, 1>{{flat_size()}}};
+    return {mem, pshape<long>{{flat_size()}}};
   }
 
   template <class T, class pS>

--- a/pythran/pythonic/utils/broadcast_copy.hpp
+++ b/pythran/pythonic/utils/broadcast_copy.hpp
@@ -70,11 +70,11 @@ namespace utils
 #ifdef _OPENMP
       if (self_size >= PYTHRAN_OPENMP_MIN_ITERATION_COUNT * other_size)
 #pragma omp parallel for
-        for (size_t i = other_size; i < self_size; i += other_size)
+        for (unsigned long i = other_size; i < self_size; i += other_size)
           std::copy_n(self.begin(), other_size, self.begin() + i);
       else
 #endif
-        for (size_t i = other_size; i < self_size; i += other_size)
+        for (long i = other_size; i < self_size; i += other_size)
           std::copy_n(self.begin(), other_size, self.begin() + i);
     }
   };
@@ -143,11 +143,11 @@ namespace utils
 #ifdef _OPENMP
     if (self_size >= PYTHRAN_OPENMP_MIN_ITERATION_COUNT * other_size)
 #pragma omp parallel for
-      for (size_t i = other_size; i < self_size; i += other_size)
+      for (unsigned long i = other_size; i < self_size; i += other_size)
         std::copy_n(self.begin(), other_size, self.begin() + i);
     else
 #endif
-      for (size_t i = other_size; i < self_size; i += other_size)
+      for (long i = other_size; i < self_size; i += other_size)
         std::copy_n(self.begin(), other_size, self.begin() + i);
   }
 

--- a/pythran/pythonic/utils/numpy_conversion.hpp
+++ b/pythran/pythonic/utils/numpy_conversion.hpp
@@ -4,6 +4,18 @@
 #include "pythonic/include/utils/numpy_conversion.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
 
+#if _MSC_VER
+#define NUMPY_EXPR_TO_NDARRAY0_IMPL(fname)                                     \
+  template <class E, class... Types,                                           \
+            typename std::enable_if<!types::is_ndarray<E>::value &&            \
+                                        types::is_array<E>::value,             \
+                                    E>::type * = nullptr>                      \
+  auto fname(E const &expr, Types &&... others)                                \
+  {                                                                            \
+    return fname(types::ndarray<typename E::dtype, typename E::shape_t>{expr}, \
+                 std::forward<Types>(others)...);                              \
+  }
+#else
 #define NUMPY_EXPR_TO_NDARRAY0_IMPL(fname)                                     \
   template <class E, class... Types>                                           \
   auto fname(E const &expr, Types &&... others)                                \
@@ -16,5 +28,5 @@
     return fname(types::ndarray<typename E::dtype, typename E::shape_t>{expr}, \
                  std::forward<Types>(others)...);                              \
   }
-
+#endif
 #endif

--- a/pythran/tables.py
+++ b/pythran/tables.py
@@ -4246,16 +4246,6 @@ MODULES = {
         "test_nest_lock": FunctionIntr(global_effects=True),
         "get_wtime": FunctionIntr(global_effects=True),
         "get_wtick": FunctionIntr(global_effects=True),
-        "set_schedule": FunctionIntr(global_effects=True),
-        "get_schedule": FunctionIntr(global_effects=True),
-        "get_thread_limit": FunctionIntr(global_effects=True),
-        "set_max_active_levels": FunctionIntr(global_effects=True),
-        "get_max_active_levels": FunctionIntr(global_effects=True),
-        "get_level": FunctionIntr(global_effects=True),
-        "get_ancestor_thread_num": FunctionIntr(global_effects=True),
-        "get_team_size": FunctionIntr(global_effects=True),
-        "get_active_level": FunctionIntr(global_effects=True),
-        "in_final": FunctionIntr(global_effects=True),
     },
     "operator_": {
         "lt": ConstFunctionIntr(signature=_operator_eq_signature),
@@ -4445,6 +4435,27 @@ if sys.version_info.major == 3:
 else:
     del MODULES['operator_']['matmul']
     del MODULES['operator_']['__matmul__']
+
+# OMP version
+try:
+    import omp
+    omp_version = omp.VERSION
+except ImportError:
+    omp_version = 45 # Fallback on last version
+
+if omp_version >= 30:
+    MODULES['omp'].update({
+        "set_schedule": FunctionIntr(global_effects=True),
+        "get_schedule": FunctionIntr(global_effects=True),
+        "get_thread_limit": FunctionIntr(global_effects=True),
+        "set_max_active_levels": FunctionIntr(global_effects=True),
+        "get_max_active_levels": FunctionIntr(global_effects=True),
+        "get_level": FunctionIntr(global_effects=True),
+        "get_ancestor_thread_num": FunctionIntr(global_effects=True),
+        "get_team_size": FunctionIntr(global_effects=True),
+        "get_active_level": FunctionIntr(global_effects=True),
+        "in_final": FunctionIntr(global_effects=True),
+    })
 
 # VMSError is only available on VMS
 if 'VMSError' in sys.modules['__builtin__'].__dict__:


### PR DESCRIPTION
This is the fixes for better support of Windows
- Use the compiler used by numpy
- Support only OMP 2.0 (MSVC ...)
- Not so nice way to get the OMP library with MSVC (but working) 