### PR TITLE
Support from .X import Y

### DIFF
--- a/pythran/dist.py
+++ b/pythran/dist.py
@@ -52,10 +52,13 @@ class PythranExtension(Extension):
                 # get the last name in the path
                 if '.' in name:
                     module_name = os.path.splitext(name)[-1][1:]
+                    package = os.path.splitext(name)[0]
                 else:
                     module_name = name
+                    package = None
                 tc.compile_pythranfile(source, output_file,
-                                       module_name, cpponly=True)
+                                       module_name, cpponly=True,
+                                       package=package)
             cxx_sources.append(output_file)
 
         kwargs.update(cfg.make_extension())

--- a/pythran/passmanager.py
+++ b/pythran/passmanager.py
@@ -183,8 +183,9 @@ class PassManager(object):
     '''
     Front end to the pythran pass system.
     '''
-    def __init__(self, module_name):
+    def __init__(self, module_name, package=None):
         self.module_name = module_name
+        self.package = package
         self._cache = {}
 
     def gather(self, analysis, node, ctx=None):

--- a/pythran/run.py
+++ b/pythran/run.py
@@ -38,6 +38,8 @@ def compile_flags(args):
         'library_dirs': args.libraries_dir,
         'extra_link_args': args.extra_flags,
     }
+    if args.package:
+        compiler_options['package'] = args.package
     if args.opts:
         compiler_options['opts'] = args.opts
 
@@ -81,6 +83,9 @@ def run():
                         help='any pythran optimization to apply before code '
                         'generation',
                         default=list())
+
+    parser.add_argument('-C', dest='package', type=str,
+                        help='package')
 
     parser.add_argument('-I', dest='include_dirs', metavar='include_dir',
                         action='append',

--- a/pythran/toolchain.py
+++ b/pythran/toolchain.py
@@ -114,9 +114,9 @@ class HasArgument(ast.NodeVisitor):
         return []
 
 
-def front_middle_end(module_name, code, optimizations=None):
+def front_middle_end(module_name, code, optimizations=None, package=None):
     """Front-end and middle-end compilation steps"""
-    pm = PassManager(module_name)
+    pm = PassManager(module_name, package=package)
 
     # front end
     ir, renamings, docstrings = frontend.parse(pm, code)
@@ -145,7 +145,8 @@ def generate_py(module_name, code, optimizations=None):
     return pm.dump(Python, ir)
 
 
-def generate_cxx(module_name, code, specs=None, optimizations=None):
+def generate_cxx(module_name, code, specs=None, optimizations=None,
+                 package=None):
     '''python + pythran spec -> c++ code
     returns a PythonModule object and an error checker
 
@@ -155,7 +156,8 @@ def generate_cxx(module_name, code, specs=None, optimizations=None):
     '''
 
     pm, ir, renamings, docstrings = front_middle_end(module_name, code,
-                                                     optimizations)
+                                                     optimizations,
+                                                     package=package)
 
     # back-end
     content = pm.dump(Cxx, ir)
@@ -369,7 +371,7 @@ def compile_cxxcode(module_name, cxxcode, output_binary=None, keep_temp=False,
 
 def compile_pythrancode(module_name, pythrancode, specs=None,
                         opts=None, cpponly=False, pyonly=False,
-                        output_file=None, **kwargs):
+                        output_file=None, package=None, **kwargs):
     '''Pythran code (string) -> c++ code -> native module
 
     if `cpponly` is set to true, return the generated C++ filename
@@ -393,7 +395,8 @@ def compile_pythrancode(module_name, pythrancode, specs=None,
         specs = spec_parser(pythrancode)
 
     # Generate C++, get a PythonModule object
-    module, error_checker = generate_cxx(module_name, pythrancode, specs, opts)
+    module, error_checker = generate_cxx(module_name, pythrancode, specs, opts,
+                                         package=package)
 
     if 'ENABLE_PYTHON_MODULE' in kwargs.get('undef_macros', []):
         module.preamble.insert(0, Line('#undef ENABLE_PYTHON_MODULE'))
@@ -422,7 +425,7 @@ def compile_pythrancode(module_name, pythrancode, specs=None,
 
 
 def compile_pythranfile(file_path, output_file=None, module_name=None,
-                        cpponly=False, pyonly=False, **kwargs):
+                        cpponly=False, pyonly=False, package=None, **kwargs):
     """
     Pythran file -> c++ file -> native module.
 
@@ -451,6 +454,8 @@ def compile_pythranfile(file_path, output_file=None, module_name=None,
 
     # Add compiled module path to search for imported modules
     sys.path.append(os.path.dirname(file_path))
+    if package is not None:
+        sys.path.append(os.getcwd())
 
     # Look for an extra spec file
     spec_file = os.path.splitext(file_path)[0] + '.pythran'
@@ -461,6 +466,7 @@ def compile_pythranfile(file_path, output_file=None, module_name=None,
     output_file = compile_pythrancode(module_name, open(file_path).read(),
                                       output_file=output_file,
                                       cpponly=cpponly, pyonly=pyonly,
+                                      package=package,
                                       **kwargs)
 
     return output_file


### PR DESCRIPTION
Work as-is with setup.py mechanism, for command line invocation a package argument can be provided in order to specify the current package of the "compiled" python file