### PR TITLE
Disable @ operator for < 3.5

### DIFF
--- a/pythran/tables.py
+++ b/pythran/tables.py
@@ -4426,6 +4426,9 @@ if sys.version_info.major == 3:
                 CLASSES['file'], global_effects=True)
         }
     }
+    if sys.version_info.minor < 5:
+        del MODULES['operator_']['matmul']
+        del MODULES['operator_']['__matmul__']
 else:
     del MODULES['operator_']['matmul']
     del MODULES['operator_']['__matmul__']


### PR DESCRIPTION
matmul was added in python 3.5 (https://docs.python.org/3/whatsnew/3.5.html)