### PR TITLE
Fix OSX bug when dealing with numpy_gexpr

### DIFF
--- a/pythran/pythonic/include/types/ndarray.hpp
+++ b/pythran/pythonic/include/types/ndarray.hpp
@@ -654,15 +654,15 @@ namespace types
       template <size_t N>
       struct _build_gexpr {
         template <class E, class... S>
-        auto operator()(E const &a, S &&... slices)
+        auto operator()(E const &a, S const &... slices)
             -> decltype(_build_gexpr<N - 1>{}(a, contiguous_slice(),
-                                              std::forward<S>(slices)...));
+                                              slices...));
       };
 
       template <>
       struct _build_gexpr<1> {
         template <class E, class... S>
-        numpy_gexpr<E, S...> operator()(E const &a, S &&... slices);
+        numpy_gexpr<E, S...> operator()(E const &a, S const &... slices);
       };
     }
 

--- a/pythran/pythonic/types/ndarray.hpp
+++ b/pythran/pythonic/types/ndarray.hpp
@@ -986,20 +986,19 @@ namespace types
     {
       template <size_t N>
       template <class E, class... S>
-      auto _build_gexpr<N>::operator()(E const &a, S &&... slices)
-          -> decltype(_build_gexpr<N - 1>{}(a, contiguous_slice(),
-                                            std::forward<S>(slices)...))
+      auto _build_gexpr<N>::operator()(E const &a, S const &... slices)
+          -> decltype(_build_gexpr<N - 1>{}(a, contiguous_slice(), slices...))
       {
         return _build_gexpr<N - 1>{}(
             a, contiguous_slice(__builtin__::None, __builtin__::None),
-            std::forward<S>(slices)...);
+            slices...);
       }
 
       template <class E, class... S>
       numpy_gexpr<E, S...> _build_gexpr<1>::operator()(E const &a,
-                                                       S &&... slices)
+                                                       S const &... slices)
       {
-        return a(std::forward<S>(slices)...);
+        return a(slices...);
       }
     }
 

--- a/pythran/pythonic/types/numpy_gexpr.hpp
+++ b/pythran/pythonic/types/numpy_gexpr.hpp
@@ -212,21 +212,21 @@ namespace types
   namespace details
   {
 
-    std::tuple<> const &merge_gexpr<std::tuple<>, std::tuple<>>::
+    std::tuple<> merge_gexpr<std::tuple<>, std::tuple<>>::
     operator()(std::tuple<> const &t0, std::tuple<> const &)
     {
       return t0;
     }
 
     template <class... T0>
-    std::tuple<T0...> const &merge_gexpr<std::tuple<T0...>, std::tuple<>>::
+    std::tuple<T0...> merge_gexpr<std::tuple<T0...>, std::tuple<>>::
     operator()(std::tuple<T0...> const &t0, std::tuple<>)
     {
       return t0;
     }
 
     template <class... T1>
-    std::tuple<T1...> const &merge_gexpr<std::tuple<>, std::tuple<T1...>>::
+    std::tuple<T1...> merge_gexpr<std::tuple<>, std::tuple<T1...>>::
     operator()(std::tuple<>, std::tuple<T1...> const &t1)
     {
       return t1;
@@ -236,26 +236,27 @@ namespace types
     auto merge_gexpr<std::tuple<S0, T0...>, std::tuple<S1, T1...>>::
     operator()(std::tuple<S0, T0...> const &t0, std::tuple<S1, T1...> const &t1)
         -> decltype(
-            std::tuple_cat(std::make_tuple(std::get<0>(t0) * std::get<0>(t1)),
-                           merge_gexpr<std::tuple<T0...>, std::tuple<T1...>>{}(
-                               tuple_tail(t0), tuple_tail(t1))))
-    {
-      return std::tuple_cat(std::make_tuple(std::get<0>(t0) * std::get<0>(t1)),
+            tuple_push_head(std::get<0>(t0) * std::get<0>(t1),
                             merge_gexpr<std::tuple<T0...>, std::tuple<T1...>>{}(
-                                tuple_tail(t0), tuple_tail(t1)));
+                                tuple_tail(t0), tuple_tail(t1))))
+    {
+      return tuple_push_head(
+          std::get<0>(t0) * std::get<0>(t1),
+          merge_gexpr<std::tuple<T0...>, std::tuple<T1...>>{}(tuple_tail(t0),
+                                                              tuple_tail(t1)));
     }
 
     template <class... T0, class S1, class... T1>
     auto merge_gexpr<std::tuple<long, T0...>, std::tuple<S1, T1...>>::
     operator()(std::tuple<long, T0...> const &t0,
                std::tuple<S1, T1...> const &t1)
-        -> decltype(std::tuple_cat(
-            std::make_tuple(std::get<0>(t0)),
+        -> decltype(tuple_push_head(
+            std::get<0>(t0),
             merge_gexpr<std::tuple<T0...>, std::tuple<S1, T1...>>{}(
                 tuple_tail(t0), t1)))
     {
-      return std::tuple_cat(
-          std::make_tuple(std::get<0>(t0)),
+      return tuple_push_head(
+          std::get<0>(t0),
           merge_gexpr<std::tuple<T0...>, std::tuple<S1, T1...>>{}(
               tuple_tail(t0), t1));
     }
@@ -264,15 +265,13 @@ namespace types
     auto merge_gexpr<std::tuple<S0, T0...>, std::tuple<long, T1...>>::
     operator()(std::tuple<S0, T0...> const &t0,
                std::tuple<long, T1...> const &t1)
-        -> decltype(std::tuple_cat(
-            std::make_tuple(std::get<0>(t1) * std::get<0>(t0).step +
-                            std::get<0>(t0).lower),
+        -> decltype(tuple_push_head(
+            std::get<0>(t1) * std::get<0>(t0).step + std::get<0>(t0).lower,
             merge_gexpr<std::tuple<T0...>, std::tuple<T1...>>{}(
                 tuple_tail(t0), tuple_tail(t1))))
     {
-      return std::tuple_cat(
-          std::make_tuple(std::get<0>(t1) * std::get<0>(t0).step +
-                          std::get<0>(t0).lower),
+      return tuple_push_head(
+          std::get<0>(t1) * std::get<0>(t0).step + std::get<0>(t0).lower,
           merge_gexpr<std::tuple<T0...>, std::tuple<T1...>>{}(tuple_tail(t0),
                                                               tuple_tail(t1)));
     }
@@ -281,13 +280,13 @@ namespace types
     auto merge_gexpr<std::tuple<long, T0...>, std::tuple<long, T1...>>::
     operator()(std::tuple<long, T0...> const &t0,
                std::tuple<long, T1...> const &t1)
-        -> decltype(std::tuple_cat(
-            std::make_tuple(std::get<0>(t0)),
+        -> decltype(tuple_push_head(
+            std::get<0>(t0),
             merge_gexpr<std::tuple<T0...>, std::tuple<long, T1...>>{}(
                 tuple_tail(t0), t1)))
     {
-      return std::tuple_cat(
-          std::make_tuple(std::get<0>(t0)),
+      return tuple_push_head(
+          std::get<0>(t0),
           merge_gexpr<std::tuple<T0...>, std::tuple<long, T1...>>{}(
               tuple_tail(t0), t1));
     }


### PR DESCRIPTION
Probably due to std::tuple_cat misuse, but... who knows?