### PR TITLE
Fix broken compilation with g++-8

### DIFF
--- a/pythran/pythonic/include/types/combined.hpp
+++ b/pythran/pythonic/include/types/combined.hpp
@@ -4,16 +4,6 @@
 #include "pythonic/include/types/traits.hpp"
 #include "pythonic/include/types/variant_functor.hpp"
 
-/* specialize remove_cv */
-namespace std
-{
-  template <class K, class V>
-  struct remove_cv<std::pair<const K, V>> {
-    using type = std::pair<K, V>;
-  };
-}
-/* specialize remove_cv */
-
 /* type inference stuff
 */
 

--- a/pythran/pythonic/include/types/dict.hpp
+++ b/pythran/pythonic/include/types/dict.hpp
@@ -28,6 +28,18 @@ namespace types
   struct empty_dict;
 
   template <class I>
+  struct item_iterator_adaptator : public I {
+    using value_type = std::pair<
+        typename std::remove_cv<typename I::value_type::first_type>::type,
+        typename I::value_type::second_type>;
+    using pointer = value_type *;
+    using reference = value_type &;
+    item_iterator_adaptator() = default;
+    item_iterator_adaptator(I const &i);
+    value_type operator*();
+  };
+
+  template <class I>
   struct key_iterator_adaptator : public I {
     using value_type = typename I::value_type::first_type;
     using pointer = typename I::value_type::first_type *;
@@ -108,10 +120,10 @@ namespace types
         key_iterator_adaptator<typename container_type::iterator>>;
     using const_iterator = utils::comparable_iterator<
         key_iterator_adaptator<typename container_type::const_iterator>>;
-    using item_iterator =
-        utils::comparable_iterator<typename container_type::iterator>;
-    using item_const_iterator =
-        utils::comparable_iterator<typename container_type::const_iterator>;
+    using item_iterator = utils::comparable_iterator<
+        item_iterator_adaptator<typename container_type::iterator>>;
+    using item_const_iterator = utils::comparable_iterator<
+        item_iterator_adaptator<typename container_type::const_iterator>>;
     using key_iterator = utils::comparable_iterator<
         key_iterator_adaptator<typename container_type::iterator>>;
     using key_const_iterator = utils::comparable_iterator<

--- a/pythran/pythonic/types/dict.hpp
+++ b/pythran/pythonic/types/dict.hpp
@@ -20,6 +20,20 @@ PYTHONIC_NS_BEGIN
 
 namespace types
 {
+  /// item implementation
+
+  template <class I>
+  item_iterator_adaptator<I>::item_iterator_adaptator(I const &i)
+      : I(i)
+  {
+  }
+
+  template <class I>
+  typename item_iterator_adaptator<I>::value_type item_iterator_adaptator<I>::
+  operator*()
+  {
+    return I::operator*();
+  }
 
   /// key_iterator_adaptator implementation
   template <class I>
@@ -216,25 +230,29 @@ namespace types
   template <class K, class V>
   typename dict<K, V>::item_iterator dict<K, V>::item_begin()
   {
-    return typename dict<K, V>::item_iterator(data->begin());
+    return item_iterator_adaptator<
+        typename dict<K, V>::container_type::iterator>(data->begin());
   }
 
   template <class K, class V>
   typename dict<K, V>::item_const_iterator dict<K, V>::item_begin() const
   {
-    return typename dict<K, V>::item_const_iterator(data->begin());
+    return item_iterator_adaptator<
+        typename dict<K, V>::container_type::const_iterator>(data->begin());
   }
 
   template <class K, class V>
   typename dict<K, V>::item_iterator dict<K, V>::item_end()
   {
-    return typename dict<K, V>::item_iterator(data->end());
+    return item_iterator_adaptator<
+        typename dict<K, V>::container_type::iterator>(data->end());
   }
 
   template <class K, class V>
   typename dict<K, V>::item_const_iterator dict<K, V>::item_end() const
   {
-    return typename dict<K, V>::item_const_iterator(data->end());
+    return item_iterator_adaptator<
+        typename dict<K, V>::container_type::const_iterator>(data->end());
   }
 
   template <class K, class V>
@@ -327,7 +345,8 @@ namespace types
   template <class K, class V>
   typename dict<K, V>::item_const_iterator dict<K, V>::find(K const &key) const
   {
-    return typename dict<K, V>::item_const_iterator(data->find(key));
+    return item_iterator_adaptator<
+        typename dict<K, V>::container_type::const_iterator>(data->find(key));
   }
 
   template <class K, class V>


### PR DESCRIPTION
Specializing remove_cv was indeed a terrible idea.