### PR TITLE
Fix contextmanager compiler_cfg

### DIFF
--- a/pythran/dist.py
+++ b/pythran/dist.py
@@ -7,19 +7,28 @@ import pythran.config as cfg
 import pythran.toolchain as tc
 
 from distutils.command.build_ext import build_ext as _build_ext
+from distutils.sysconfig import customize_compiler
 from numpy.distutils.extension import Extension
 
 import os.path
 import os
 
 
+
 class build_ext(_build_ext):
+    '''
+    Build PythranExtension within a contextmanager for handling the environment
+    variables. Subclasses `distutils.command.build_ext.build_ext`.
+    '''
     def build_extension(self, ext):
         if isinstance(ext, PythranExtension):
-            # with cfg.compiler_cfg():
-            os.environ['CC'] = "clang"
-            os.environ['CXX'] = "clang++"
-            super(build_ext, self).build_extension(ext)
+            with cfg.compiler_cfg():
+                # Use configured environment variables CC and CXX
+                customize_compiler(self.compiler)
+                super(build_ext, self).build_extension(ext)
+
+            # Restore environment variables CC and CXX
+            customize_compiler(self.compiler)
         else:
             super(build_ext, self).build_extension(ext)
 

--- a/pythran/dist.py
+++ b/pythran/dist.py
@@ -6,10 +6,22 @@ This modules contains a distutils extension mechanism for Pythran
 import pythran.config as cfg
 import pythran.toolchain as tc
 
+from distutils.command.build_ext import build_ext as _build_ext
 from numpy.distutils.extension import Extension
 
 import os.path
 import os
+
+
+class build_ext(_build_ext):
+    def build_extension(self, ext):
+        if isinstance(ext, PythranExtension):
+            # with cfg.compiler_cfg():
+            os.environ['CC'] = "clang"
+            os.environ['CXX'] = "clang++"
+            super(build_ext, self).build_extension(ext)
+        else:
+            super(build_ext, self).build_extension(ext)
 
 
 class PythranExtension(Extension):

--- a/pythran/toolchain.py
+++ b/pythran/toolchain.py
@@ -4,7 +4,7 @@ a dynamic library, see __init__.py for exported interfaces.
 '''
 
 from pythran.backend import Cxx, Python
-from pythran.config import cfg, make_extension
+from pythran.config import cfg, make_extension, compiler_cfg
 from pythran.cxxgen import PythonModule, Define, Include, Line, Statement
 from pythran.cxxgen import FunctionBody, FunctionDeclaration, Value, Block
 from pythran.cxxgen import ReturnStatement
@@ -333,17 +333,18 @@ def compile_cxxfile(module_name, cxxfile, output_binary=None, **kwargs):
                           **extension_args)
 
     try:
-        setup(name=module_name,
-              ext_modules=[extension],
-              # fake CLI call
-              script_name='setup.py',
-              script_args=['--verbose'
-                           if logger.isEnabledFor(logging.INFO)
-                           else '--quiet',
-                           'build_ext',
-                           '--build-lib', builddir,
-                           '--build-temp', buildtmp]
-              )
+        with compiler_cfg():
+            setup(name=module_name,
+                  ext_modules=[extension],
+                  # fake CLI call
+                  script_name='setup.py',
+                  script_args=['--verbose'
+                               if logger.isEnabledFor(logging.INFO)
+                               else '--quiet',
+                               'build_ext',
+                               '--build-lib', builddir,
+                               '--build-temp', buildtmp]
+            )
     except SystemExit as e:
         raise CompileError(str(e))
 


### PR DESCRIPTION
Fixes #933. Tested it with [fluiddyn/fluidsim](https://bitbucket.org/fluiddyn/fluidsim) installation with one Cython extension `fluidsim.base.time_stepping.pseudo_spect_cy` and a couple of Pythran extensions.
It seems to work when sequentially building extensions as follows:

```
FLUIDDYN_NUM_PROCS_BUILD=1 CC=mpicc python setup.py develop
```

In `~/.pythranrc` CC=clang CXX=clang++ was also set. Also note that a custom `build_ext` was supplied to the `setup()` call
```python
from Cython.Distutils import build_ext
from pythran.dist import build_ext as pythran_build_ext

class fluidsim_build_ext(build_ext, pythran_build_ext):
    pass
```

Output:
```c++
running build_ext
skipping 'fluidsim/base/time_stepping/pseudo_spect_cy.c' Cython extension (up-to-date)
building 'fluidsim.base.time_stepping.pseudo_spect_cy' extension
creating build
creating build/temp.linux-x86_64-3.6
creating build/temp.linux-x86_64-3.6/fluidsim
creating build/temp.linux-x86_64-3.6/fluidsim/base
creating build/temp.linux-x86_64-3.6/fluidsim/base/time_stepping
mpicc: fluidsim/base/time_stepping/pseudo_spect_cy.c
In file included from /scratch/avmo/opt/fluidmeta/lib/python3.6/site-packages/numpy/core/include/numpy/ndarraytypes.h:1816,
                 from /scratch/avmo/opt/fluidmeta/lib/python3.6/site-packages/numpy/core/include/numpy/ndarrayobject.h:18,
                 from /scratch/avmo/opt/fluidmeta/lib/python3.6/site-packages/numpy/core/include/numpy/arrayobject.h:4,
                 from fluidsim/base/time_stepping/pseudo_spect_cy.c:525:
/scratch/avmo/opt/fluidmeta/lib/python3.6/site-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h:15:2: warning: #warning "Using deprecated NumPy API, disable it by " "#defining NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION" [-Wcpp]
 #warning "Using deprecated NumPy API, disable it by " \
  ^~~~~~~
gcc -pthread -shared -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now build/temp.linux-x86_64-3.6/fluidsim/base/time_stepping/pseudo_spect_cy.o -L/usr/lib -lm -lpython3.6m -o /home/avmo/src/fluidmeta/fluidsim/fluidsim/base/time_stepping/pseudo_spect_cy.cpython-36m-x86_64-linux-gnu.so
building 'fluidsim.base.output.util_pythran' extension
creating build/temp.linux-x86_64-3.6/fluidsim/base/output
clang: fluidsim/base/output/util_pythran.cpp
clang++ -pthread -shared -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now build/temp.linux-x86_64-3.6/fluidsim/base/output/util_pythran.o -L/usr/lib64 -L/usr/lib -lgmp -lgmpxx -lcblas -lblas -lpython3.6m -o /home/avmo/src/fluidmeta/fluidsim/fluidsim/base/output/util_pythran.cpython-36m-x86_64-linux-gnu.so -fvisibility=hidden -Wl,-strip-all
building 'fluidsim.operators.util2d_pythran' extension
creating build/temp.linux-x86_64-3.6/fluidsim/operators
clang: fluidsim/operators/util2d_pythran.cpp
clang++ -pthread -shared -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now build/temp.linux-x86_64-3.6/fluidsim/operators/util2d_pythran.o -L/usr/lib64 -L/usr/lib -lgmp -lgmpxx -lcblas -lblas -lpython3.6m -o /home/avmo/src/fluidmeta/fluidsim/fluidsim/operators/util2d_pythran.cpython-36m-x86_64-linux-gnu.so -fvisibility=hidden -Wl,-strip-all
building 'fluidsim.operators.util3d_pythran' extension
clang: fluidsim/operators/util3d_pythran.cpp
clang++ -pthread -shared -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now build/temp.linux-x86_64-3.6/fluidsim/operators/util3d_pythran.o -L/usr/lib64 -L/usr/lib -lgmp -lgmpxx -lcblas -lblas -lpython3.6m -o /home/avmo/src/fluidmeta/fluidsim/fluidsim/operators/util3d_pythran.cpython-36m-x86_64-linux-gnu.so -fvisibility=hidden -Wl,-strip-all
building 'fluidsim.solvers.ns2d.util_pythran' extension
creating build/temp.linux-x86_64-3.6/fluidsim/solvers
creating build/temp.linux-x86_64-3.6/fluidsim/solvers/ns2d
clang: fluidsim/solvers/ns2d/util_pythran.cpp
clang++ -pthread -shared -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now build/temp.linux-x86_64-3.6/fluidsim/solvers/ns2d/util_pythran.o -L/usr/lib64 -L/usr/lib -lgmp -lgmpxx -lcblas -lblas -lpython3.6m -o /home/avmo/src/fluidmeta/fluidsim/fluidsim/solvers/ns2d/util_pythran.cpython-36m-x86_64-linux-gnu.so -fvisibility=hidden -Wl,-strip-all
```

However when parallelly buiding extensions using concurrent threads, a race condition can cause environment variables to be inconsistent. But this is not a standard technique, but a monkey-patched feature within fluidsim setup. So it is upto the user to be careful.

Output with race condition:
```
running build_ext
skipping 'fluidsim/base/time_stepping/pseudo_spect_cy.c' Cython extension (up-to-date)
building 'fluidsim.base.time_stepping.pseudo_spect_cy' extension
building 'fluidsim.base.output.util_pythran' extension
creating build
building 'fluidsim.operators.util2d_pythran' extension
creating build
creating build/temp.linux-x86_64-3.6
creating build/temp.linux-x86_64-3.6
creating build/temp.linux-x86_64-3.6
creating build/temp.linux-x86_64-3.6/fluidsim
creating build/temp.linux-x86_64-3.6/fluidsim
creating build/temp.linux-x86_64-3.6/fluidsim
creating build/temp.linux-x86_64-3.6/fluidsim/base
creating build/temp.linux-x86_64-3.6/fluidsim/operators
creating build/temp.linux-x86_64-3.6/fluidsim/base/time_stepping
creating build/temp.linux-x86_64-3.6/fluidsim/base
clang: fluidsim/operators/util2d_pythran.cpp
creating build/temp.linux-x86_64-3.6/fluidsim/base/output
clang: fluidsim/base/time_stepping/pseudo_spect_cy.c
clang: fluidsim/base/output/util_pythran.cpp
In file included from fluidsim/base/time_stepping/pseudo_spect_cy.c:525:
In file included from /scratch/avmo/opt/fluidmeta/lib/python3.6/site-packages/numpy/core/include/numpy/arrayobject.h:4:
In file included from /scratch/avmo/opt/fluidmeta/lib/python3.6/site-packages/numpy/core/include/numpy/ndarrayobject.h:18:
In file included from /scratch/avmo/opt/fluidmeta/lib/python3.6/site-packages/numpy/core/include/numpy/ndarraytypes.h:1816:
/scratch/avmo/opt/fluidmeta/lib/python3.6/site-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h:15:2: warning: "Using deprecated NumPy API, disable it by "          "#defining NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION" [-W#warnings]
#warning "Using deprecated NumPy API, disable it by " \
 ^
1 warning generated.
gcc -pthread -shared -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now build/temp.linux-x86_64-3.6/fluidsim/base/time_stepping/pseudo_spect_cy.o -L/usr/lib -lm -lpython3.6m -o /home/avmo/src/fluidmeta/fluidsim/fluidsim/base/time_stepping/pseudo_spect_cy.cpython-36m-x86_64-linux-gnu.so
building 'fluidsim.operators.util3d_pythran' extension
clang: fluidsim/operators/util3d_pythran.cpp
clang++ -pthread -shared -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now build/temp.linux-x86_64-3.6/fluidsim/operators/util2d_pythran.o -L/usr/lib64 -L/usr/lib -lgmp -lgmpxx -lcblas -lblas -lpython3.6m -o /home/avmo/src/fluidmeta/fluidsim/fluidsim/operators/util2d_pythran.cpython-36m-x86_64-linux-gnu.so -fvisibility=hidden -Wl,-strip-all
building 'fluidsim.solvers.ns2d.util_pythran' extension
creating build/temp.linux-x86_64-3.6/fluidsim/solvers
creating build/temp.linux-x86_64-3.6/fluidsim/solvers/ns2d
clang: fluidsim/solvers/ns2d/util_pythran.cpp
clang++ -pthread -shared -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now build/temp.linux-x86_64-3.6/fluidsim/base/output/util_pythran.o -L/usr/lib64 -L/usr/lib -lgmp -lgmpxx -lcblas -lblas -lpython3.6m -o /home/avmo/src/fluidmeta/fluidsim/fluidsim/base/output/util_pythran.cpython-36m-x86_64-linux-gnu.so -fvisibility=hidden -Wl,-strip-all
g++ -pthread -shared -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now build/temp.linux-x86_64-3.6/fluidsim/operators/util3d_pythran.o -L/usr/lib64 -L/usr/lib -lgmp -lgmpxx -lcblas -lblas -lpython3.6m -o /home/avmo/src/fluidmeta/fluidsim/fluidsim/operators/util3d_pythran.cpython-36m-x86_64-linux-gnu.so -fvisibility=hidden -Wl,-strip-all
g++ -pthread -shared -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now build/temp.linux-x86_64-3.6/fluidsim/solvers/ns2d/util_pythran.o -L/usr/lib64 -L/usr/lib -lgmp -lgmpxx -lcblas -lblas -lpython3.6m -o /home/avmo/src/fluidmeta/fluidsim/fluidsim/solvers/ns2d/util_pythran.cpython-36m-x86_64-linux-gnu.so -fvisibility=hidden -Wl,-strip-all
```