### PR TITLE
Add --generic flag for pythran-config

### DIFF
--- a/pythran/dist.py
+++ b/pythran/dist.py
@@ -98,6 +98,6 @@ class PythranExtension(Extension):
                                        module_name, cpponly=True)
             cxx_sources.append(output_file)
 
-        cfg_ext = cfg.make_extension(**kwargs)
+        cfg_ext = cfg.make_extension(False, **kwargs)
         self.cxx = cfg_ext.pop('cxx')
         Extension.__init__(self, name, cxx_sources, *args, **cfg_ext)

--- a/pythran/toolchain.py
+++ b/pythran/toolchain.py
@@ -325,7 +325,7 @@ def compile_cxxfile(module_name, cxxfile, output_binary=None, **kwargs):
     builddir = mkdtemp()
     buildtmp = mkdtemp()
 
-    extension_args = make_extension(**kwargs)
+    extension_args = make_extension(False, **kwargs)
 
     extension = PythranExtension(module_name,
                                  [cxxfile],


### PR DESCRIPTION
Allow to have pythran flags (like from .pythranrc file) without python specific flags
This is not so clever implementation, I know ...