### PR TITLE
Remove xrange in python3

### DIFF
--- a/pythran/tables.py
+++ b/pythran/tables.py
@@ -21,7 +21,6 @@ from functools import reduce
 
 if sys.version_info.major == 3:
     sys.modules['__builtin__'] = sys.modules['builtins']
-    sys.modules['__builtin__'].xrange = sys.modules['builtins'].range
 
     import functools
     sys.modules['__builtin__'].reduce = functools.reduce
@@ -4432,6 +4431,7 @@ if sys.version_info.major == 3:
     del MODULES['operator_']['__div__']
     del MODULES['__builtin__']['cmp']
     del MODULES['__builtin__']['file']
+    del MODULES['__builtin__']['xrange']
     del MODULES['__builtin__']['StandardError']
     MODULES['io'] = {
         '_io': {


### PR DESCRIPTION
- Remove xrange support in Python 3 (not existing)
- Fix loop optimizatin with xrange/range support on python 2 and range on python 3
- Support of past module xrange/range. Allow to have a python 2 & 3 compatible code
