### PR TITLE
T cannot convert to bool implicitly

### DIFF
--- a/pythran/pythonic/types/NoneType.hpp
+++ b/pythran/pythonic/types/NoneType.hpp
@@ -55,7 +55,7 @@ namespace types
   template <class T>
   none<T, false>::operator bool() const
   {
-    return !is_none && static_cast<const T &>(*this);
+    return !is_none;
   }
 
   template <class T>


### PR DESCRIPTION
If `T` is `std::tuple<long, long>` or other class, `T` is not able to convert to `bool`.