### PR TITLE
Fix OMP on Windows

### DIFF
--- a/pythran/pythonic/utils/broadcast_copy.hpp
+++ b/pythran/pythonic/utils/broadcast_copy.hpp
@@ -70,7 +70,7 @@ namespace utils
 #ifdef _OPENMP
       if (self_size >= PYTHRAN_OPENMP_MIN_ITERATION_COUNT * other_size)
 #pragma omp parallel for
-        for (unsigned long i = other_size; i < self_size; i += other_size)
+        for (long i = other_size; i < self_size; i += other_size)
           std::copy_n(self.begin(), other_size, self.begin() + i);
       else
 #endif
@@ -145,7 +145,7 @@ namespace utils
 #ifdef _OPENMP
     if (self_size >= PYTHRAN_OPENMP_MIN_ITERATION_COUNT * other_size)
 #pragma omp parallel for
-      for (unsigned long i = other_size; i < self_size; i += other_size)
+      for (long i = other_size; i < self_size; i += other_size)
         std::copy_n(self.begin(), other_size, self.begin() + i);
     else
 #endif

--- a/pythran/pythonic/utils/broadcast_copy.hpp
+++ b/pythran/pythonic/utils/broadcast_copy.hpp
@@ -200,7 +200,8 @@ namespace utils
   template <class E, class F, size_t N, size_t D, bool vector_form>
   E &broadcast_copy(E &self, F const &other)
   {
-    broadcast_copy_dispatcher<E, F, N, D, vector_form>{}(self, other);
+    if (self.size())
+      broadcast_copy_dispatcher<E, F, N, D, vector_form>{}(self, other);
     return self;
   }
 
@@ -368,7 +369,8 @@ namespace utils
   template <class Op, class E, class F, size_t N, size_t D, bool vector_form>
   E &broadcast_update(E &self, F const &other)
   {
-    broadcast_update_dispatcher<Op, vector_form, E, F, N, D>{}(self, other);
+    if (self.size())
+      broadcast_update_dispatcher<Op, vector_form, E, F, N, D>{}(self, other);
     return self;
   }
 }


### PR DESCRIPTION
Without this modification, the following issue apprears

`pythran\pythonic/utils/broadcast_copy.hpp(71): error C3016: 'i': index variable in OpenMP 'for' statement must have signed integral type`