### PR TITLE
Fix/gitignore pythran xsimd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ website/*.html
 website/license.txt
 pythran/nt2
 pythran/boost
+pythran/xsimd
 parsetab.py
 
 .eggs/*

--- a/pythran/pythonic/include/types/vectorizable_type.hpp
+++ b/pythran/pythonic/include/types/vectorizable_type.hpp
@@ -46,9 +46,7 @@ namespace types
   template <class T>
   struct is_vectorizable_dtype {
     static const bool value = is_dtype<T>::value &&
-                              !std::is_same<T, bool>::value &&
-                              !std::is_same<T, std::complex<float>>::value &&
-                              !std::is_same<T, std::complex<double>>::value;
+                              !std::is_same<T, bool>::value;
   };
 
   /* trait to check if is T is an array-like type that supports vectorization


### PR DESCRIPTION
I just added pythran/xsimd to gitignore.

I don't understand why there is this change to pythran/pythonic/include/types/vectorizable_type.hpp ...