### PR TITLE
Remove annoying colorlog warning

### DIFF
--- a/pythran/log.py
+++ b/pythran/log.py
@@ -21,4 +21,4 @@ try:
 except ImportError:
     # No color available, use default config
     logging.basicConfig(format='%(levelname)s: %(message)s')
-    logger.warn("Disabling color, you really want to install colorlog.")
+    logger.info("Disabling color, you really want to install colorlog.")


### PR DESCRIPTION
This is especially important for packages that depend on pythran like cython.