### PR TITLE
Remove yaourt and unmaintained python2-pythran-git recommendation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,9 +70,9 @@ Depending on your setup, you may need to add the following to your \\~/.pythranr
 ArchLinux
 =========
 
-Using `yaourt`::
+Using any working `AUR helper <https://wiki.archlinux.org/index.php/AUR_helpers>`_, say aurman::
 
-    $> yaourt -S python2-pythran-git
+    $> aurman -S python-pythran
 
 Windows
 =======


### PR DESCRIPTION
`yaourt` is not recommended and frowned upon among Arch Linux people, as it fail to [satisfy many criterias](https://wiki.archlinux.org/index.php/AUR_helpers#Pacman_wrappers) :) . I will maintain the `python-pythran` and `python2-pythran` packages, for which the PKGBUILD is derived from the old PKGBUILD by @xantares. You can see the what the package does below:

https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=python-pythran