### PR TITLE
Harden gexpr conversion from pythran export

### DIFF
--- a/pythran/pythonic/types/ndarray.hpp
+++ b/pythran/pythonic/types/ndarray.hpp
@@ -1703,7 +1703,7 @@ from_python<types::numpy_gexpr<types::ndarray<T, pS>, S...>>::convert(
                       utils::int_<sizeof...(S)>());
   types::numpy_gexpr<types::ndarray<T, pS>, S...> r(base_array, slices);
 
-  Py_INCREF(obj);
+  Py_INCREF(base_arr);
   return r;
 }
 

--- a/pythran/tests/test_conversion.py
+++ b/pythran/tests/test_conversion.py
@@ -96,6 +96,11 @@ def dict_of_complex64_and_complex_128(l):
                           ndarray_with_negative_stride=[NDArray[np.uint8, ::-1]])
 
 
+    def iexpr_with_strides_and_offsets(self):
+        code = 'def iexpr_with_strides_and_offsets(a): return a'
+        self.run_test(code, np.array(np.arange((160), dtype=np.uint8).reshape((4, 5, 8)))[1][1::][:-1],
+                      ndarray_with_strides_and_offsets=[NDArray[np.uint8, :, ::-1]])
+
     def test_ndarray_with_strides_and_offsets(self):
         code = 'def ndarray_with_strides_and_offsets(a): return a'
         self.run_test(code, np.array(np.arange((128), dtype=np.uint8).reshape((16,8)))[1::3,2::2],


### PR DESCRIPTION
Avoid a segfault due to bad incref.