### PR TITLE
Support PYTHRANRC environment variable

### DIFF
--- a/docs/MANUAL.rst
+++ b/docs/MANUAL.rst
@@ -429,6 +429,11 @@ Customizing Your ``.pythranrc``
 Pythran checks for a file named ``.pythranrc`` and use it to *replace* the site
 configuration. Here are a few tricks!
 
+You can change the default location of the pythran configuration file using the
+environment variable ``PYTHRANRC``::
+
+    PYTHRANRC=/opt/company/pythran/config.pythranrc pythran arc_distance.py
+
 
 ``[compiler]``
 **************

--- a/pythran/config.py
+++ b/pythran/config.py
@@ -17,14 +17,30 @@ def get_paths_cfg(
     platform_file='pythran-{}.cfg'.format(sys.platform),
     user_file='.pythranrc'
 ):
+    """
+    >>> os.environ['HOME'] = '/tmp/test'
+    >>> get_paths_cfg()['user']
+    '/tmp/test/.pythranrc'
+    >>> os.environ['HOME'] = '/tmp/test'
+    >>> os.environ['XDG_CONFIG_HOME'] = '/tmp/test2'
+    >>> get_paths_cfg()['user']
+    '/tmp/test2/.pythranrc'
+    >>> os.environ['HOME'] = '/tmp/test'
+    >>> os.environ['XDG_CONFIG_HOME'] = '/tmp/test2'
+    >>> os.environ['PYTHRANRC'] = '/tmp/test3/pythranrc'
+    >>> get_paths_cfg()['user']
+    '/tmp/test3/pythranrc'
+    """
     sys_config_dir = os.path.dirname(__file__)
     sys_config_path = os.path.join(sys_config_dir, sys_file)
 
     platform_config_path = os.path.join(sys_config_dir, platform_file)
 
-    user_config_dir = os.environ.get('XDG_CONFIG_HOME', '~')
-    user_config_path = os.path.expanduser(
-        os.path.join(user_config_dir, user_file))
+    user_config_path = os.environ.get('PYTHRANRC', None)
+    if not user_config_path:
+        user_config_dir = os.environ.get('XDG_CONFIG_HOME', '~')
+        user_config_path = os.path.expanduser(
+            os.path.join(user_config_dir, user_file))
     return {"sys": sys_config_path, "platform": platform_config_path, "user": user_config_path}
 
 


### PR DESCRIPTION
Allow to override the default .pythranrc path using environment variable PYTHRANRC