### PR TITLE
pythranrc check

### DIFF
--- a/pythran/config.py
+++ b/pythran/config.py
@@ -1,8 +1,8 @@
 try:
     # python3 vs. python2
-    import configparser
+    from configparser import ConfigParser
 except ImportError:
-    import ConfigParser as configparser
+    from ConfigParser import SafeConfigParser as ConfigParser
 import logging
 import numpy.distutils.system_info as numpy_sys
 import numpy
@@ -12,7 +12,11 @@ import sys
 logger = logging.getLogger('pythran')
 
 
-def init_cfg(sys_file, platform_file, user_file):
+def get_paths_cfg(
+    sys_file='pythran.cfg',
+    platform_file='pythran-{}.cfg'.format(sys.platform),
+    user_file='.pythranrc'
+):
     sys_config_dir = os.path.dirname(__file__)
     sys_config_path = os.path.join(sys_config_dir, sys_file)
 
@@ -21,18 +25,65 @@ def init_cfg(sys_file, platform_file, user_file):
     user_config_dir = os.environ.get('XDG_CONFIG_HOME', '~')
     user_config_path = os.path.expanduser(
         os.path.join(user_config_dir, user_file))
+    return {"sys": sys_config_path, "platform": platform_config_path, "user": user_config_path}
 
-    cfgp = configparser.SafeConfigParser()
+
+def init_cfg(sys_file, platform_file, user_file):
+    paths = get_paths_cfg(sys_file, platform_file, user_file)
+    sys_config_path, platform_config_path, user_config_path = paths.values()
+
+    cfgp = ConfigParser()
     for required in (sys_config_path, platform_config_path):
         cfgp.readfp(open(required))
     cfgp.read([user_config_path])
 
-    for obsolete_section in ('user', 'sys'):
-        if cfgp.has_section(obsolete_section):
-            logger.warn("Your pythranrc has an obsolete `%s' section",
-                        obsolete_section)
-
     return cfgp
+
+
+def lint_cfg(cfgp, **paths):
+    if not paths:
+        paths = get_paths_cfg()
+
+    # Use configuration from sys and platform as "reference"
+    cfgp_ref = ConfigParser()
+    cfgp_ref.read([paths["sys"], paths["platform"]])
+
+    # Check if pythran configuration files exists
+    for loc, path in paths.items():
+        exists = os.path.exists(path)
+
+        msg = " ".join([
+            "{} file".format(loc).rjust(13),
+            "exists:" if exists else "does not exist:",
+            path
+        ])
+        logger.info(msg) if exists else logger.warn(msg)
+
+    for section in cfgp.sections():
+        # Check if section in the current configuration exists in the
+        # reference configuration
+        if cfgp_ref.has_section(section):
+            options = set(cfgp.options(section))
+            options_ref = set(cfgp_ref.options(section))
+
+            # Check if the options in the section are supported by the
+            # reference configuration
+            if options.issubset(options_ref):
+                logger.info(
+                    (
+                        "pythranrc section [{}] is valid and options are "
+                        "correct"
+                    ).format(section)
+                )
+            else:
+                logger.warn(
+                    (
+                        "pythranrc section [{}] is valid but options {} "
+                        "are incorrect!"
+                    ).format(section, options.difference(options_ref))
+                )
+        else:
+            logger.warn("pythranrc section [{}] is invalid!".format(section))
 
 
 def make_extension(python, **extra):
@@ -148,7 +199,7 @@ def run():
         prog='pythran-config',
         description='output build options for pythran-generated code',
         epilog="It's a megablast!"
-        )
+    )
 
     parser.add_argument('--compiler', action='store_true',
                         help='print default compiler')
@@ -162,6 +213,13 @@ def run():
     parser.add_argument('--no-python', action='store_true',
                         help='do not include Python-related flags')
 
+    parser.add_argument('--verbose', '-v', action='count', default=0,
+                        help=(
+                            'verbose mode: [-v] prints compiler and flags, '
+                            'and checks for invalid configuration; use '
+                            '[-vv] for more information')
+                        )
+
     args = parser.parse_args(sys.argv[1:])
 
     args.python = not args.no_python
@@ -170,8 +228,21 @@ def run():
 
     extension = pythran.config.make_extension(python=args.python)
 
+    if args.verbose >= 1:
+        logger.setLevel(max(logging.DEBUG, logging.ERROR - args.verbose * 10))
+        lint_cfg(cfg)
+        args.compiler = True
+        args.cflags = True
+        args.libs = True
+
+    if args.verbose >= 2:
+        output.append("CXX =".rjust(10))
+
     if args.compiler:
         output.append(compiler() or 'c++')
+
+    if args.verbose >= 2:
+        output.append("\n" + "CFLAGS =".rjust(10))
 
     if args.cflags:
         def fmt_define(define):
@@ -187,6 +258,9 @@ def run():
         if args.python:
             output.append('-I' + numpy.get_include())
             output.append('-I' + distutils.sysconfig.get_python_inc())
+
+    if args.verbose >= 2:
+        output.append("\n" + "LDFLAGS =".rjust(10))
 
     if args.libs:
         output.extend(('-L' + include)

--- a/pythran/config.py
+++ b/pythran/config.py
@@ -34,7 +34,7 @@ def init_cfg(sys_file, platform_file, user_file):
 
     cfgp = ConfigParser()
     for required in (sys_config_path, platform_config_path):
-        cfgp.readfp(open(required))
+        cfgp.read([required])
     cfgp.read([user_config_path])
 
     return cfgp

--- a/pythran/run.py
+++ b/pythran/run.py
@@ -129,6 +129,10 @@ def run():
     if args.warn_off:
         logger.setLevel(logging.ERROR)
 
+
+    if args.verbose and not args.warn_off:
+        pythran.config.lint_cfg(pythran.config.cfg)
+
     try:
         if not os.path.exists(args.input_file):
             raise ValueError("input file `{0}' not found".format(


### PR DESCRIPTION
Relates to issue #1117.

With this implementation we get output like:

```bash
❯❯❯ pythran-config -v                                                                                                                            (pythran) enh/pythranrc-sanity-check
WARNING  pythranrc section [pythran] is invalid!
WARNING  pythranrc section [pythran] options: {'cc', 'blas', 'ignoreflags', 'cxx'} are invalid!
WARNING  pythranrc section [dummy] is invalid!
c++ -DENABLE_PYTHON_MODULE -D__PYTHRAN__=3 -DPYTHRAN_BLAS_BLAS -I/home/avmo/src/pythran/pythran -I/scratch/avmo/opt/pythran/lib/python3.7/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I/scratch/avmo/opt/pythran/include -I/scratch/avmo/opt/pythran/lib/python3.7/site-packages/numpy/core/include -I/usr/include/python3.7m -L/usr/lib64 -lcblas -lblas -L/usr/lib/python3.7/config-3.7m-x86_64-linux-gnu -lpthread -ldl -lutil -lpython3.7

❯❯❯ pythran-config -vv                                                                                                                           (pythran) enh/pythranrc-sanity-check
INFO     sys file exists: True 
	/home/avmo/src/pythran/pythran/pythran.cfg
INFO     platform file exists: True 
	/home/avmo/src/pythran/pythran/pythran-linux.cfg
INFO     user file exists: True 
	/home/avmo/.pythranrc
WARNING  pythranrc section [pythran] is invalid!
WARNING  pythranrc section [pythran] options: {'cc', 'blas', 'cxx', 'ignoreflags'} are invalid!
INFO     pythranrc section [typing] is valid
INFO     pythranrc section [compiler] is valid
WARNING  pythranrc section [dummy] is invalid!
     CXX = c++ 
  CFLAGS = -DENABLE_PYTHON_MODULE -D__PYTHRAN__=3 -DPYTHRAN_BLAS_BLAS -I/home/avmo/src/pythran/pythran -I/scratch/avmo/opt/pythran/lib/python3.7/site-packages/numpy/core/include -I/usr/local/include -I/usr/include -I/scratch/avmo/opt/pythran/include -I/scratch/avmo/opt/pythran/lib/python3.7/site-packages/numpy/core/include -I/usr/include/python3.7m 
 LDFLAGS = -L/usr/lib64 -lcblas -lblas -L/usr/lib/python3.7/config-3.7m-x86_64-linux-gnu -lpthread -ldl -lutil -lpython3.7
```

Also for pythran command:

```sh
 ❯❯❯ pythran -v euler01.py                                                                                                                        (pythran) enh/pythranrc-sanity-check
INFO     sys file exists: True 
	/home/avmo/src/pythran/pythran/pythran.cfg
INFO     platform file exists: True 
	/home/avmo/src/pythran/pythran/pythran-linux.cfg
INFO     user file exists: True 
	/home/avmo/.pythranrc
WARNING  pythranrc section [pythran] is invalid!
WARNING  pythranrc section [pythran] options: {'cc', 'ignoreflags', 'blas', 'cxx'} are invalid!
INFO     pythranrc section [typing] is valid
INFO     pythranrc section [compiler] is valid
WARNING  pythranrc section [dummy] is invalid!
CRITICAL I am in trouble. Your input file does not seem to match Pythran's constraints...
E: identifier xrange unknown, either because it is an unsupported intrinsic, the input code is faulty, or... pythran is buggy. (line 11)
```