### PR TITLE
Make arange a lazy expression

### DIFF
--- a/pythran/pythonic/include/numpy/arange.hpp
+++ b/pythran/pythonic/include/numpy/arange.hpp
@@ -2,19 +2,100 @@
 #define PYTHONIC_INCLUDE_NUMPY_ARANGE_HPP
 
 #include "pythonic/include/utils/functor.hpp"
+#include "pythonic/include/operator_/pos.hpp"
 #include "pythonic/include/types/ndarray.hpp"
 
 PYTHONIC_NS_BEGIN
 
 namespace numpy
 {
+  namespace details
+  {
+    template <class T>
+    struct arange_index {
+      T start, step;
+      long size;
+      using iterator = types::nditerator<arange_index>;
+      using const_iterator = types::const_nditerator<arange_index>;
+      using dtype = T;
+      using value_type = dtype;
+      using shape_t = types::pshape<long>;
+#ifdef USE_XSIMD
+      using simd_iterator = types::const_simd_nditerator<arange_index>;
+      using simd_iterator_nobroadcast = simd_iterator;
+      template <class vectorizer>
+      simd_iterator vbegin(vectorizer) const;
+      template <class vectorizer>
+      simd_iterator vend(vectorizer) const;
+#endif
+      static constexpr size_t value = 1;
+      static constexpr bool is_strided = false;
+      static constexpr bool is_vectorizable =
+          false; // FIXME: this is feasible, but I'm lazy
+
+      T fast(long i) const
+      {
+        return start + i * step;
+      }
+
+      shape_t shape() const
+      {
+        return {size};
+      }
+      types::ndarray<dtype, shape_t> operator[](types::slice s) const
+      {
+        auto ns = s.normalize(size);
+        arange_index r{start + s.lower * step, step * ns.step, ns.size()};
+        return {
+            types::numpy_expr<pythonic::operator_::functor::pos, arange_index>{
+                r}};
+      }
+      types::ndarray<dtype, shape_t> operator()(types::slice s) const
+      {
+        return operator[](s);
+      }
+      types::ndarray<dtype, shape_t> operator[](types::contiguous_slice s) const
+      {
+        auto ns = s.normalize(size);
+        arange_index r{start + s.lower * step, step, ns.size()};
+        return {
+            types::numpy_expr<pythonic::operator_::functor::pos, arange_index>{
+                r}};
+      }
+      types::ndarray<dtype, shape_t> operator()(types::contiguous_slice s) const
+      {
+        return operator[](s);
+      }
+      const_iterator begin() const
+      {
+        return {*this, 0};
+      }
+      const_iterator end() const
+      {
+        return {*this, size};
+      }
+
+      iterator begin()
+      {
+        return {*this, 0};
+      }
+      iterator end()
+      {
+        return {*this, size};
+      }
+    };
+  }
+
   template <class T, class U, class S = long,
             class dtype = types::dtype_t<typename __combined<T, U, S>::type>>
-  types::ndarray<typename dtype::type, types::pshape<long>>
+  types::numpy_expr<pythonic::operator_::functor::pos,
+                    details::arange_index<typename dtype::type>>
   arange(T begin, U end, S step = S(1), dtype d = dtype());
 
   template <class T>
-  types::ndarray<T, types::pshape<long>> arange(T end);
+  types::numpy_expr<pythonic::operator_::functor::pos,
+                    details::arange_index<typename types::dtype_t<T>::type>>
+  arange(T end);
 
   DEFINE_FUNCTOR(pythonic::numpy, arange);
 }

--- a/pythran/pythonic/numpy/arange.hpp
+++ b/pythran/pythonic/numpy/arange.hpp
@@ -3,6 +3,7 @@
 
 #include "pythonic/include/numpy/arange.hpp"
 
+#include "pythonic/operator_/pos.hpp"
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/types/ndarray.hpp"
 
@@ -11,26 +12,19 @@ PYTHONIC_NS_BEGIN
 namespace numpy
 {
   template <class T, class U, class S, class dtype>
-  types::ndarray<typename dtype::type, types::pshape<long>>
+  types::numpy_expr<pythonic::operator_::functor::pos,
+                    details::arange_index<typename dtype::type>>
   arange(T begin, U end, S step, dtype d)
   {
     using R = typename dtype::type;
-    size_t size = std::max(R(0), R(std::ceil((end - begin) / step)));
-    types::ndarray<R, types::pshape<long>> a(types::pshape<long>((long)size),
-                                             __builtin__::None);
-    if (size) {
-      auto prev = a.fbegin(), end = a.fend();
-      *prev = begin;
-      for (auto iter = prev + 1; iter != end; ++iter) {
-        *iter = *prev + step;
-        prev = iter;
-      }
-    }
-    return a;
+    long size = std::max(R(0), R(std::ceil((end - begin) / step)));
+    return {details::arange_index<R>{(R)begin, (R)step, size}};
   }
 
   template <class T>
-  types::ndarray<T, types::pshape<long>> arange(T end)
+  types::numpy_expr<pythonic::operator_::functor::pos,
+                    details::arange_index<typename types::dtype_t<T>::type>>
+  arange(T end)
   {
     return arange<T, T, T, types::dtype_t<T>>(T(0), end);
   }

--- a/pythran/tests/test_env.py
+++ b/pythran/tests/test_env.py
@@ -69,7 +69,7 @@ class TestEnv(unittest.TestCase):
                                              float64, float128)),
                          (float32, (int, float, float32, float128)),
                          (float128, (int, float, float32, float128)),
-                         ((uint64, int64), (int, uint64, int64)),
+                         ((uint64, int64), (int, uint32, int32, uint64, int64)),
                          (bool, (bool, bool_)),
                          # FIXME combiner for boolean doesn't work
                          (int, (int, bool, bool_, int8, int16, int32, int64,

--- a/pythran/tests/test_numpy_func2.py
+++ b/pythran/tests/test_numpy_func2.py
@@ -564,6 +564,9 @@ def test_copy0(x):
     def test_arange13(self):
         self.run_test("def np_arange12_(a):\n from numpy import arange, float32\n return arange(a, 25, dtype=float32)", 0, np_arange12_=[int])
 
+    def test_arange14(self):
+        self.run_test("def np_arange14_(a):\n from numpy import arange, float32\n return 50000 * arange(a, 25, dtype=float32)", 0, np_arange14_=[int])
+
     def test_linspace(self):
         self.run_test("def np_linspace_(a):\n from numpy import linspace\n return linspace(a,4,32)", 1, np_linspace_=[int])
 

--- a/third_party/xsimd/types/xsimd_base.hpp
+++ b/third_party/xsimd/types/xsimd_base.hpp
@@ -1176,7 +1176,21 @@ namespace xsimd
         using kernel = detail::batch_kernel<value_type, simd_batch_traits<X>::size>;
         return kernel::neg(rhs());
     }
-    
+
+    /**
+     * @ingroup simd_batch_arithmetic
+     *
+     * No-op on \c rhs.
+     * @tparam X the actual type of batch.
+     * @param rhs batch involved in the operation.
+     * @return \c rhs.
+     */
+    template <class X>
+    inline X operator+(const simd_batch<X>& rhs)
+    {
+        return rhs();
+    }
+
     /**
      * @ingroup simd_batch_arithmetic
      *


### PR DESCRIPTION
This speedsup expression like ``np.arange(x) * y``.