### PR TITLE
dynamic tuple internal type

### DIFF
--- a/pythran/pythonic/__builtin__/tuple.hpp
+++ b/pythran/pythonic/__builtin__/tuple.hpp
@@ -3,7 +3,7 @@
 
 #include "pythonic/include/__builtin__/tuple.hpp"
 
-#include "pythonic/types/list.hpp"
+#include "pythonic/types/dynamic_tuple.hpp"
 #include "pythonic/types/tuple.hpp"
 #include "pythonic/utils/functor.hpp"
 
@@ -24,7 +24,7 @@ namespace __builtin__
       typename std::enable_if <
       types::len_of<typename std::remove_cv<
           typename std::remove_reference<Iterable>::type>::type>::
-          value<0, types::list<typename std::iterator_traits<
+          value<0, types::dynamic_tuple<typename std::iterator_traits<
                        typename std::remove_cv<typename std::remove_reference<
                            Iterable>::type>::type::iterator>::value_type>>::type
           tuple(Iterable &&i)

--- a/pythran/pythonic/include/__builtin__/tuple.hpp
+++ b/pythran/pythonic/include/__builtin__/tuple.hpp
@@ -1,8 +1,8 @@
 #ifndef PYTHONIC_INCLUDE_BUILTIN_TUPLE_HPP
 #define PYTHONIC_INCLUDE_BUILTIN_TUPLE_HPP
 
-#include "pythonic/include/types/list.hpp"
 #include "pythonic/include/types/tuple.hpp"
+#include "pythonic/include/types/dynamic_tuple.hpp"
 #include "pythonic/include/utils/functor.hpp"
 
 PYTHONIC_NS_BEGIN
@@ -19,7 +19,7 @@ namespace __builtin__
       typename std::enable_if <
       types::len_of<typename std::remove_cv<
           typename std::remove_reference<Iterable>::type>::type>::
-          value<0, types::list<typename std::iterator_traits<
+          value<0, types::dynamic_tuple<typename std::iterator_traits<
                        typename std::remove_cv<typename std::remove_reference<
                            Iterable>::type>::type::iterator>::value_type>>::type
           tuple(Iterable &&i);

--- a/pythran/pythonic/include/itertools/combinations.hpp
+++ b/pythran/pythonic/include/itertools/combinations.hpp
@@ -1,7 +1,7 @@
 #ifndef PYTHONIC_INCLUDE_ITERTOOLS_COMBINATIONS_HPP
 #define PYTHONIC_INCLUDE_ITERTOOLS_COMBINATIONS_HPP
 
-#include "pythonic/include/types/list.hpp"
+#include "pythonic/include/types/dynamic_tuple.hpp"
 #include "pythonic/include/utils/functor.hpp"
 
 #include <vector>
@@ -16,15 +16,15 @@ namespace itertools
     template <class T>
     struct combination_iterator
         : std::iterator<std::forward_iterator_tag,
-                        types::list<typename T::value_type>, ptrdiff_t,
-                        types::list<typename T::value_type> *,
-                        types::list<typename T::value_type> /*no ref*/
+                        types::dynamic_tuple<typename T::value_type>, ptrdiff_t,
+                        types::dynamic_tuple<typename T::value_type> *,
+                        types::dynamic_tuple<typename T::value_type> /*no ref*/
                         > {
       std::vector<typename T::value_type> pool;
       std::vector<long> indices;
       long r;
       bool stopped;
-      types::list<typename T::value_type> result;
+      std::vector<typename T::value_type> result;
 
       combination_iterator() = default;
       combination_iterator(bool);
@@ -32,7 +32,7 @@ namespace itertools
       template <class Iter>
       combination_iterator(Iter &&pool, long r);
 
-      types::list<typename T::value_type> operator*() const;
+      types::dynamic_tuple<typename T::value_type> operator*() const;
       combination_iterator &operator++();
       bool operator!=(combination_iterator const &other) const;
       bool operator==(combination_iterator const &other) const;

--- a/pythran/pythonic/include/itertools/permutations.hpp
+++ b/pythran/pythonic/include/itertools/permutations.hpp
@@ -2,7 +2,7 @@
 #define PYTHONIC_INCLUDE_ITERTOOLS_PERMUTATIONS_HPP
 
 #include "pythonic/include/utils/functor.hpp"
-#include "pythonic/include/types/list.hpp"
+#include "pythonic/include/types/dynamic_tuple.hpp"
 
 #include <iterator>
 #include <vector>
@@ -14,7 +14,8 @@ namespace itertools
   /** Permutation iterator
    *
    *  It wraps a vector && provide an iteration over every possible
-   *  permutation of the vector. The permutations are represented as lists
+   *  permutation of the vector. The permutations are represented as
+   *dynamic_tuple
    *  of elements.
    *
    *  The following iterator:
@@ -29,17 +30,17 @@ namespace itertools
   template <class T>
   struct permutations_iterator
       : std::iterator<std::forward_iterator_tag,
-                      types::list<typename T::value_type>, ptrdiff_t,
-                      types::list<typename T::value_type> *,
-                      types::list<typename T::value_type> /* no ref*/
+                      types::dynamic_tuple<typename T::value_type>, ptrdiff_t,
+                      types::dynamic_tuple<typename T::value_type> *,
+                      types::dynamic_tuple<typename T::value_type> /* no ref*/
                       > {
     // Vector of inputs, contains elements to permute
     std::vector<typename T::value_type> pool;
 
-    // The current permutation as a list of index in the pool
+    // The current permutation as a dynamic_tuple of index in the pool
     // Internally it always has the same size as the pool, even if the
     // external view is limited
-    types::list<int> curr_permut;
+    std::vector<long> curr_permut;
 
     // Size of the "visible" permutation
     size_t _size;
@@ -50,7 +51,7 @@ namespace itertools
                           size_t num_elts, bool end);
 
     /** Build the permutation visible from the "outside" */
-    types::list<typename T::value_type> operator*() const;
+    types::dynamic_tuple<typename T::value_type> operator*() const;
 
     /*  Generate next permutation
      *
@@ -66,11 +67,11 @@ namespace itertools
   template <class T>
   // FIXME document why this inheritance???
   struct _permutations : permutations_iterator<T> {
-    using value_type = T;
     using iterator = permutations_iterator<T>;
+    using value_type = typename iterator::value_type;
 
     _permutations();
-    _permutations(T iter, int elts);
+    _permutations(T iter, long elts);
 
     iterator const &begin() const;
     iterator begin();
@@ -78,7 +79,7 @@ namespace itertools
   };
 
   template <typename T0>
-  _permutations<T0> permutations(T0 iter, int num_elts);
+  _permutations<T0> permutations(T0 iter, long num_elts);
 
   template <typename T0>
   _permutations<T0> permutations(T0 iter);

--- a/pythran/pythonic/include/types/ndarray.hpp
+++ b/pythran/pythonic/include/types/ndarray.hpp
@@ -30,6 +30,7 @@
 #include "pythonic/include/numpy/complex64.hpp"
 #include "pythonic/include/numpy/complex128.hpp"
 
+#include "pythonic/include/types/dynamic_tuple.hpp"
 #include "pythonic/include/types/vectorizable_type.hpp"
 #include "pythonic/include/types/numpy_op_helper.hpp"
 #include "pythonic/include/types/numpy_expr.hpp"
@@ -549,11 +550,9 @@ namespace types
       return _fwdindex(indices, utils::make_index_sequence<M>());
     }
     template <class S>
-    auto operator[](list<S> const &indices) const -> typename std::enable_if<
-        std::is_same<S, slice>::value ||
-            std::is_same<S, contiguous_slice>::value,
-        decltype(this->_fwdindex(indices,
-                                 utils::make_index_sequence<value>()))>::type
+    auto operator[](dynamic_tuple<S> const &indices) const
+        -> decltype(this->_fwdindex(indices,
+                                    utils::make_index_sequence<value>()))
     {
       return _fwdindex(indices, utils::make_index_sequence<value>());
     }

--- a/pythran/pythonic/include/types/tuple.hpp
+++ b/pythran/pythonic/include/types/tuple.hpp
@@ -69,9 +69,6 @@ namespace types
     }
   }
 
-  template <class T>
-  class list; // forward declared for array slicing
-
   template <class T, size_t N>
   struct array;
 

--- a/pythran/pythonic/itertools/combinations.hpp
+++ b/pythran/pythonic/itertools/combinations.hpp
@@ -3,7 +3,7 @@
 
 #include "pythonic/include/itertools/combinations.hpp"
 
-#include "pythonic/types/list.hpp"
+#include "pythonic/types/dynamic_tuple.hpp"
 #include "pythonic/utils/functor.hpp"
 
 #include <numeric>
@@ -23,7 +23,7 @@ namespace itertools
       assert(r >= 0 && "r must be non-negative");
       if (!stopped) {
         std::iota(indices.begin(), indices.end(), 0);
-        result = types::list<typename T::value_type>(this->pool.begin(),
+        result = std::vector<typename T::value_type>(this->pool.begin(),
                                                      this->pool.begin() + r);
       }
     }
@@ -35,7 +35,7 @@ namespace itertools
     }
 
     template <class T>
-    types::list<typename T::value_type> combination_iterator<T>::
+    types::dynamic_tuple<typename T::value_type> combination_iterator<T>::
     operator*() const
     {
       assert(!stopped && "! stopped");

--- a/pythran/pythonic/types/dynamic_tuple.hpp
+++ b/pythran/pythonic/types/dynamic_tuple.hpp
@@ -1,0 +1,109 @@
+#ifndef PYTHONIC_TYPES_DYNAMIC_TUPLE_HPP
+#define PYTHONIC_TYPES_DYNAMIC_TUPLE_HPP
+
+#include "pythonic/include/types/dynamic_tuple.hpp"
+
+#include "pythonic/types/assignable.hpp"
+#include "pythonic/types/traits.hpp"
+#include "pythonic/types/nditerator.hpp"
+#include "pythonic/utils/int_.hpp"
+#include "pythonic/utils/seq.hpp"
+#include "pythonic/utils/shared_ref.hpp"
+#include "pythonic/utils/nested_container.hpp"
+
+#include <algorithm>
+
+PYTHONIC_NS_BEGIN
+namespace types
+{
+  template <typename T>
+  template <class E>
+  long dynamic_tuple<T>::_flat_size(E const &e, utils::int_<1>) const
+  {
+    return e.size();
+  }
+  template <class T>
+  intptr_t dynamic_tuple<T>::id() const
+  {
+    return reinterpret_cast<intptr_t>(&(*buffer));
+  }
+
+  template <typename T>
+  template <class E, size_t L>
+  long dynamic_tuple<T>::_flat_size(E const &e, utils::int_<L>) const
+  {
+    return e.size() * _flat_size(e.fast(0), utils::int_<L - 1>{});
+  }
+
+  template <typename T>
+  long dynamic_tuple<T>::flat_size() const
+  {
+    return _flat_size(*this, utils::int_<value>{});
+  }
+  template <typename T>
+  bool dynamic_tuple<T>::operator==(dynamic_tuple<T> const &other) const
+  {
+    return size() == other.size() && std::equal(begin(), end(), other.begin());
+  }
+
+  template <typename T>
+  bool dynamic_tuple<T>::operator!=(dynamic_tuple<T> const &other) const
+  {
+    return !(*this == other);
+  }
+
+  template <typename T>
+  bool dynamic_tuple<T>::operator<(dynamic_tuple<T> const &other) const
+  {
+    return std::lexicographical_compare(begin(), end(), other.begin(),
+                                        other.end());
+  }
+
+  template <typename T>
+  dynamic_tuple<T> dynamic_tuple<T>::
+  operator+(dynamic_tuple<T> const &other) const
+  {
+    dynamic_tuple<T> result(begin(), end());
+    std::copy(other.begin(), other.end(), end());
+    return result;
+  }
+}
+PYTHONIC_NS_END
+
+namespace std
+{
+  template <class T>
+  size_t hash<pythonic::types::dynamic_tuple<T>>::
+  operator()(pythonic::types::dynamic_tuple<T> const &l) const
+  {
+    std::hash<T> hasher;
+    size_t seed = 0x9e3779b9;
+    for (auto &&v : l)
+      seed ^= hasher(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+    return seed;
+  }
+}
+
+#ifdef ENABLE_PYTHON_MODULE
+
+#include "pythonic/include/utils/seq.hpp"
+#include "pythonic/include/utils/fwd.hpp"
+#include "pythonic/python/core.hpp"
+
+PYTHONIC_NS_BEGIN
+
+template <typename T>
+PyObject *
+to_python<types::dynamic_tuple<T>>::convert(types::dynamic_tuple<T> const &t)
+{
+  size_t N = t.size();
+  PyObject *out = PyTuple_New(N);
+  for (size_t i = 0; i < N; ++i)
+    PyTuple_SET_ITEM(out, i, ::to_python(t.fast(i)));
+  return out;
+}
+
+PYTHONIC_NS_END
+#endif
+
+#endif


### PR DESCRIPTION
This type can be used as a tuple of elements of the same type, with a
size only known at runtime. It is an alternative to types::array,
introduced for situation when the tuple is created from an iterable with
unknown size.

This not a general solution of the list-to-tuple problem, but it helps.

This fixes #1152 and improves #1113.