### PR TITLE
import pythran.intrinsic as -> from ... import ...

### DIFF
--- a/pythran/analyses/argument_effects.py
+++ b/pythran/analyses/argument_effects.py
@@ -4,7 +4,8 @@ from pythran.analyses.aliases import Aliases
 from pythran.analyses.global_declarations import GlobalDeclarations
 from pythran.passmanager import ModuleAnalysis
 from pythran.tables import MODULES
-import pythran.intrinsic as intrinsic
+# FIXME: investigate why we need to import it that way
+from pythran import intrinsic
 
 import gast as ast
 import networkx as nx


### PR DESCRIPTION
i don't really understand this strange problem arising with pip when using pyproject.toml but this tiny modification solves this bug we encounter with fluidfft CI.

https://bitbucket.org/fluiddyn/fluidfft/addon/pipelines/home#!/results/272/steps/%7Bce153d2e-f01a-4cbf-9313-fe9ec13aaed5%7D

It could be similar to this issue https://bugs.python.org/issue18145