### PR TITLE
No such module pythran.test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -181,6 +181,6 @@ setup(name='pythran',
       setup_requires=["pytest-runner"],
       tests_require=['pytest', 'flake8'],
       extras_require={'deps': ['numpy']},
-      test_suite="pythran/test",
+      test_suite="pythran/tests",
       cmdclass={'build_py': BuildWithThirdParty,
                 'develop': DevelopWithThirdParty})


### PR DESCRIPTION
Not sure if this is even used, but `python setup.py test` failed with ModuleNotFoundError.