### PR TITLE
numpy fft: Copy twiddle factors into local array to make algo thread safe

### DIFF
--- a/pythran/pythonic/numpy/fft/rfft.hpp
+++ b/pythran/pythonic/numpy/fft/rfft.hpp
@@ -43,17 +43,33 @@ namespace numpy
 
       // Create the twiddle factors. These must be kept from call to call as
       // it's very wasteful to recompute them.
+      // The call to npy_rfftf makes changes to the twiddle factor buffer (then
+      // restores it) so it's
+      // not thread safe. To avoid this:
+      // I keep one copy of the twiddle factors that no thread is allowed to
+      // modify. Then each thread
+      // has its own copy of it that it can modify at will.
       // This is from fftpack_litemodule.c
+      static std::map<long, std::vector<double>> all_twiddles_rfft_global;
+      static thread_local std::map<long, std::vector<double>>
+          all_twiddles_rfft_local;
       mtx_rfft.lock();
-      static std::map<long, types::ndarray<double, types::pshape<long>>>
-          all_twiddles_rfft;
-      if (all_twiddles_rfft.find(NFFT) == all_twiddles_rfft.end()) {
+      if (all_twiddles_rfft_global.find(NFFT) ==
+          all_twiddles_rfft_global.end()) {
+        // This happens only once across all threads for a give NFFT
         // Insert a new twiddle array into our map and initialize it
-        all_twiddles_rfft.insert(std::make_pair(
-            NFFT, types::ndarray<double, types::pshape<long>>(
-                      {(long)(2 * NFFT + 15)}, __builtin__::None)));
-        npy_rffti(NFFT, (double *)all_twiddles_rfft[NFFT].buffer);
+        all_twiddles_rfft_global.emplace(NFFT,
+                                         std::vector<double>(2 * NFFT + 15));
+        // This is the (costly) initialization of the array.
+        npy_rffti(NFFT, all_twiddles_rfft_global[NFFT].data());
       }
+
+      if (all_twiddles_rfft_local.find(NFFT) == all_twiddles_rfft_local.end()) {
+        // This happens once per thread.
+        all_twiddles_rfft_local.emplace(NFFT, all_twiddles_rfft_global[NFFT]);
+      }
+
+      double *twiddle_buffer = all_twiddles_rfft_local[NFFT].data();
       mtx_rfft.unlock();
 
       // Call fft (fftpack.py) r = work_function(in_array, wsave)
@@ -61,7 +77,6 @@ namespace numpy
       // https://raw.githubusercontent.com/numpy/numpy/master/numpy/fft/fftpack_litemodule.c
 
       double *rptr = (double *)out_array.buffer;
-      double *twiddle_buffer = (double *)all_twiddles_rfft[NFFT].buffer;
       long nrepeats = in_array.flat_size() / npts;
       long to_copy = (NFFT <= npts) ? NFFT : npts;
       for (i = 0; i < nrepeats; i++) {
@@ -86,7 +101,6 @@ namespace numpy
           rptr[i] *= scale;
         }
       }
-
       return out_array;
     }
 

--- a/pythran/tests/test_numpy_fft.py
+++ b/pythran/tests/test_numpy_fft.py
@@ -40,6 +40,18 @@ class TestNumpyFFT(TestEnv):
     def test_rfft_11(self):
         self.run_test("def test_rfft_11(x,n): from numpy.fft import rfft ; return rfft(x,n)", numpy.arange(0,8.).astype(numpy.float32),16,test_rfft_11=[NDArray[numpy.float32,:],int])
 
+    # Test parallel:
+    def test_rfft_12(self):
+        self.run_test('''
+import numpy as np
+def test_rfft_12(x):
+    out = out = [np.empty_like(x, dtype=complex) for i in range(20)] 
+    #omp parallel for
+    for ii in range(20):
+        out[ii] = np.fft.rfft(x)
+    return np.concatenate(out)
+''',numpy.random.random((4,128)), test_rfft_12=[NDArray[float,:,:]])
+
     ############# IRFFT
     # Basic test
     def test_irfft_0(self):
@@ -73,3 +85,15 @@ class TestNumpyFFT(TestEnv):
         self.run_test("def test_irfft_10(x): from numpy.fft import irfft ; return irfft(x)", numpy.exp(1j*numpy.random.random(8)).astype(numpy.complex64), test_irfft_10=[NDArray[numpy.complex64,:]])
     def test_irfft_11(self):
         self.run_test("def test_irfft_11(x,n): from numpy.fft import irfft ; return irfft(x,n)", numpy.exp(1j*numpy.random.random(8)).astype(numpy.complex64),16,test_irfft_11=[NDArray[numpy.complex64,:],int])
+
+    # Test parallel:
+    def test_irfft_12(self):
+        self.run_test('''
+import numpy as np
+def test_irfft_12(x):
+    out = [np.empty_like(x, dtype=float) for i in range(20)] 
+    #omp parallel for
+    for ii in range(20):
+        out[ii] = np.fft.irfft(x)
+    return np.concatenate(out)
+''',numpy.exp(1j*numpy.random.random((4,128))).astype(numpy.complex64), test_irfft_12=[NDArray[numpy.complex64,:,:]])


### PR DESCRIPTION
The core C++ routines in numpy.fft are not thread safe because they modify the twiddle factors during the function call (the get restored at the end).
This is to avoid the threading issue: I create a temp copy of the twiddle factors before calling the fft routine. It's not great but it does fix the issue.