### PR TITLE
Add id defination to types::str

### DIFF
--- a/pythran/pythonic/types/str.hpp
+++ b/pythran/pythonic/types/str.hpp
@@ -286,6 +286,11 @@ namespace types
     *data = oss.str();
   }
 
+  intptr_t str::id() const
+  {
+    return reinterpret_cast<intptr_t>(&(*data));
+  }
+  
   str::operator char() const
   {
     assert(size() == 1);


### PR DESCRIPTION
So we could tell if types::str is None or not. Currently it will fail if we do the None check.