### PR TITLE
fix none-comparison

### DIFF
--- a/pythran/pythonic/types/NoneType.hpp
+++ b/pythran/pythonic/types/NoneType.hpp
@@ -109,7 +109,7 @@ namespace types
   template <class O>
   bool none<T, true>::operator==(O const &t) const
   {
-    return !is_none && data == t;
+    return !is_none && t == data;
   }
 
   template <class T>


### PR DESCRIPTION
`data` is a fundamental type, cannot equal with `t` which may be `none<>` type
on the contrary, `t` will be able to equal with `data`