### PR TITLE
Improve Windows compilation

### DIFF
--- a/pythran/pythonic/__builtin__/str/isdigit.hpp
+++ b/pythran/pythonic/__builtin__/str/isdigit.hpp
@@ -6,6 +6,8 @@
 #include "pythonic/types/str.hpp"
 #include "pythonic/utils/functor.hpp"
 
+#include <cctype>
+
 PYTHONIC_NS_BEGIN
 
 namespace __builtin__

--- a/pythran/pythonic/include/types/tuple.hpp
+++ b/pythran/pythonic/include/types/tuple.hpp
@@ -494,7 +494,7 @@ namespace types
 
   template <class... Types>
   auto make_tuple(Types &&... types)
-#ifndef _MSC_VER
+#if !_MSC_VER || __clang__
       -> decltype(_make_tuple<alike<Types...>::value, Types...>()(
           std::forward<Types>(types)...))
 #endif

--- a/pythran/pythonic/include/utils/nested_container.hpp
+++ b/pythran/pythonic/include/utils/nested_container.hpp
@@ -13,7 +13,7 @@ namespace types
   template <class T, size_t N>
   struct array;
   template <class T>
-  class dynamic_tuple;
+  struct dynamic_tuple;
 }
 
 namespace utils

--- a/pythran/pythonic/include/utils/numpy_conversion.hpp
+++ b/pythran/pythonic/include/utils/numpy_conversion.hpp
@@ -5,7 +5,7 @@
 
 #include <utility>
 
-#if _MSC_VER
+#if _MSC_VER && !__clang__
 #define NUMPY_EXPR_TO_NDARRAY0_DECL(fname)                                     \
   template <class E, class... Types,                                           \
             typename std::enable_if<!types::is_ndarray<E>::value &&            \

--- a/pythran/pythonic/utils/numpy_conversion.hpp
+++ b/pythran/pythonic/utils/numpy_conversion.hpp
@@ -4,7 +4,7 @@
 #include "pythonic/include/utils/numpy_conversion.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
 
-#if _MSC_VER
+#if _MSC_VER && !__clang__
 #define NUMPY_EXPR_TO_NDARRAY0_IMPL(fname)                                     \
   template <class E, class... Types,                                           \
             typename std::enable_if<!types::is_ndarray<E>::value &&            \


### PR DESCRIPTION
Few windows improvements:
cctype missing for std::digit (maybe other headers have this issue)
struct/class warning
Support clang-cl (_MSC_VER + __clang__)