### PR TITLE
Implement keyword-only argument extraction for Python3

### DIFF
--- a/pythran/pythonic/__builtin__/sorted.hpp
+++ b/pythran/pythonic/__builtin__/sorted.hpp
@@ -24,6 +24,7 @@ namespace __builtin__
     std::sort(out.begin(), out.end());
     return out;
   }
+#if defined(PY_MAJOR_VERSION) && PY_MAJOR_VERSION < 3
   template <class Iterable, class C>
   types::list<typename std::remove_cv<typename std::iterator_traits<
       typename Iterable::iterator>::value_type>::type>
@@ -35,6 +36,47 @@ namespace __builtin__
     std::sort(out.begin(), out.end(), cmp);
     return out;
   }
+#else
+
+  template <class Iterable, class Key>
+  types::list<typename std::remove_cv<typename std::iterator_traits<
+      typename Iterable::iterator>::value_type>::type>
+  sorted(Iterable const &seq, Key const &key, bool reverse)
+  {
+    using value_type = typename std::remove_cv<typename std::iterator_traits<
+        typename Iterable::iterator>::value_type>::type;
+    types::list<value_type> out(seq.begin(), seq.end());
+    if (reverse)
+      std::sort(out.begin(), out.end(),
+                [&key](value_type const &self, value_type const &other) {
+                  return key(self) > key(other);
+                });
+    else
+      std::sort(out.begin(), out.end(),
+                [&key](value_type const &self, value_type const &other) {
+                  return key(self) < key(other);
+                });
+    return out;
+  }
+
+  template <class Iterable>
+  types::list<typename std::remove_cv<typename std::iterator_traits<
+      typename Iterable::iterator>::value_type>::type>
+  sorted(Iterable const &seq, types::none_type const &key, bool reverse)
+  {
+    using value_type = typename std::remove_cv<typename std::iterator_traits<
+        typename Iterable::iterator>::value_type>::type;
+    types::list<value_type> out(seq.begin(), seq.end());
+    if (reverse)
+      std::sort(out.begin(), out.end(),
+                [](value_type const &self, value_type const &other) {
+                  return self > other;
+                });
+    else
+      std::sort(out.begin(), out.end());
+    return out;
+  }
+#endif
 }
 PYTHONIC_NS_END
 

--- a/pythran/pythonic/include/__builtin__/sorted.hpp
+++ b/pythran/pythonic/include/__builtin__/sorted.hpp
@@ -14,10 +14,24 @@ namespace __builtin__
       typename Iterable::iterator>::value_type>::type>
   sorted(Iterable const &seq);
 
+#if defined(PY_MAJOR_VERSION) && PY_MAJOR_VERSION < 3
   template <class Iterable, class C>
   types::list<typename std::remove_cv<typename std::iterator_traits<
       typename Iterable::iterator>::value_type>::type>
   sorted(Iterable const &seq, C const &cmp);
+#else
+
+  template <class Iterable, class Key>
+  types::list<typename std::remove_cv<typename std::iterator_traits<
+      typename Iterable::iterator>::value_type>::type>
+  sorted(Iterable const &seq, Key const &key, bool reverse = false);
+
+  template <class Iterable>
+  types::list<typename std::remove_cv<typename std::iterator_traits<
+      typename Iterable::iterator>::value_type>::type>
+  sorted(Iterable const &seq, types::none_type const &key,
+         bool reverse = false);
+#endif
 
   DEFINE_FUNCTOR(pythonic::__builtin__, sorted);
 }

--- a/pythran/tables.py
+++ b/pythran/tables.py
@@ -24,9 +24,9 @@ if sys.version_info.major == 3:
 
     import functools
     sys.modules['__builtin__'].reduce = functools.reduce
-    getargspec = inspect.getfullargspec
+    getfullargspec = inspect.getfullargspec
 else:
-    getargspec = inspect.getargspec
+    getfullargspec = inspect.getargspec
 
 logger = logging.getLogger("pythran")
 
@@ -4554,13 +4554,14 @@ def save_arguments(module_name, elements):
             try:
                 themodule = __import__(".".join(module_name))
                 obj = getattr(themodule, elem)
-                spec = getargspec(obj)
+                spec = getfullargspec(obj)
                 assert not signature.args.args
 
-                signature.args.args
-
                 args = [ast.Name(arg, ast.Param(), None) for arg in spec.args]
-                defaults = spec.defaults
+                defaults = list(spec.defaults or [])
+                if sys.version_info.major == 3:
+                    args += [ast.Name(arg, ast.Param(), None) for arg in spec.kwonlyargs]
+                    defaults += [spec.kwonlydefaults[kw] for kw in spec.kwonlyargs]
 
                 # Avoid use of comprehension to fill "as much args/defauls" as
                 # possible

--- a/pythran/tests/test_base.py
+++ b/pythran/tests/test_base.py
@@ -468,8 +468,18 @@ def nested_def(a):
     def test_round(self):
         self.run_test("def round_(v): return round(v) + round(v,2)", 0.1234, round_=[float])
 
-    def test_sorted(self):
-        self.run_test("def sorted_(l): return [x for x in sorted(l)]", [1,2,3], sorted_=[List[int]])
+    def test_sorted0(self):
+        self.run_test("def sorted0(l): return [x for x in sorted(l)]", [4, 1,2,3], sorted0=[List[int]])
+
+    if sys.version_info.major == 3:
+        def test_sorted1(self):
+            self.run_test("def sorted1(l): return [x for x in sorted(l, reverse=True)]", [4, 1,2,3], sorted1=[List[int]])
+
+        def test_sorted2(self):
+            self.run_test("def sorted2(l): return [x for x in sorted(l, key=lambda x:-x)]", [4, 1,2,3], sorted2=[List[int]])
+
+        def test_sorted3(self):
+            self.run_test("def sorted3(l): return [x for x in sorted(l,reverse=True,key=lambda x:-x)]", [4, 1,2,3], sorted3=[List[int]])
 
     def test_str(self):
         self.run_test("def str_(l): return str(l)", [1,2,3], str_=[List[int]])


### PR DESCRIPTION
Showcased by the sorted builtin, and fixes #1234