### PR TITLE
Fix issue with angle

### DIFF
--- a/pythran/pythonic/include/numpy/angle_in_rad.hpp
+++ b/pythran/pythonic/include/numpy/angle_in_rad.hpp
@@ -18,7 +18,7 @@ namespace numpy
   {
     template <class T>
     auto angle_in_rad(T const &t)
-        -> decltype(std::atan(std::imag(t) / std::real(t)));
+        -> decltype(std::atan2(std::imag(t), std::real(t)));
   }
 #define NUMPY_NARY_FUNC_NAME angle_in_rad
 #define NUMPY_NARY_FUNC_SYM wrapper::angle_in_rad

--- a/pythran/pythonic/numpy/angle_in_rad.hpp
+++ b/pythran/pythonic/numpy/angle_in_rad.hpp
@@ -21,12 +21,9 @@ namespace numpy
   {
     template <class T>
     auto angle_in_rad(T const &t)
-        -> decltype(std::atan(std::imag(t) / std::real(t)))
+        -> decltype(std::atan2(std::imag(t), std::real(t)))
     {
-      if (std::real(t))
-        return std::atan(std::imag(t) / std::real(t));
-      else
-        return pythonic::numpy::pi / 2;
+      return std::atan2(std::imag(t), std::real(t));
     }
   }
 

--- a/pythran/tests/test_numpy_func2.py
+++ b/pythran/tests/test_numpy_func2.py
@@ -480,10 +480,10 @@ def test_copy0(x):
         self.run_test("def np_append8(a): from numpy import append,array ; b = array([[4, 5, 6], [7, 8, 9]]) ; return append(a[:], b)", numpy.array([[1], [2], [3]]), np_append8=[NDArray[int,:, :]])
 
     def test_angle0(self):
-        self.run_test("def np_angle0(a): from numpy import angle ; return angle(a)", [1.0+0j, 1.0j, 1+1j], np_angle0=[List[complex]])
+        self.run_test("def np_angle0(a): from numpy import angle ; return angle(a)", [1.0+0j, 1.0j, 1+1j, -1.0+0j, -1.0j, -1-1j], np_angle0=[List[complex]])
 
     def test_angle1(self):
-                      self.run_test("def np_angle1(a): from numpy import angle ; return angle(a)", numpy.array([1.0, 1.0j, 1+1j]), np_angle1=[NDArray[complex,:]])
+                      self.run_test("def np_angle1(a): from numpy import angle ; return angle(a)", numpy.array([1.0+0j, 1.0j, 1+1j, -1.0+0j, -1.0j, -1-1j]), np_angle1=[NDArray[complex,:]])
 
     def test_angle2(self):
         self.run_test("def np_angle2(a): from numpy import angle ; return angle(a,True)", 1 + 1j, np_angle2=[complex])


### PR DESCRIPTION
This fixes the discrepancy between numpy and pythran for the angle() function.
Numpy uses a 4 quadrant arc-tangent, but pythran was using a regular 2 quadrant arc-tangent.