### PR TITLE
Stricter type checking between Python and Pythran result

### DIFF
--- a/pythran/pythonic/include/math/ceil.hpp
+++ b/pythran/pythonic/include/math/ceil.hpp
@@ -2,13 +2,15 @@
 #define PYTHONIC_INCLUDE_MATH_CEIL_HPP
 
 #include "pythonic/include/utils/functor.hpp"
-#include <cmath>
 
 PYTHONIC_NS_BEGIN
 
 namespace math
 {
-  DEFINE_FUNCTOR_2(ceil, std::ceil);
+  template <class T>
+  long ceil(T x);
+
+  DEFINE_FUNCTOR(pythonic::math, ceil);
 }
 PYTHONIC_NS_END
 

--- a/pythran/pythonic/include/math/floor.hpp
+++ b/pythran/pythonic/include/math/floor.hpp
@@ -2,13 +2,15 @@
 #define PYTHONIC_INCLUDE_MATH_FLOOR_HPP
 
 #include "pythonic/include/utils/functor.hpp"
-#include <cmath>
 
 PYTHONIC_NS_BEGIN
 
 namespace math
 {
-  DEFINE_FUNCTOR_2(floor, std::floor);
+  template <class T>
+  long floor(T x);
+
+  DEFINE_FUNCTOR(pythonic::math, floor);
 }
 PYTHONIC_NS_END
 

--- a/pythran/pythonic/include/math/trunc.hpp
+++ b/pythran/pythonic/include/math/trunc.hpp
@@ -2,13 +2,15 @@
 #define PYTHONIC_INCLUDE_MATH_TRUNC_HPP
 
 #include "pythonic/include/utils/functor.hpp"
-#include <cmath>
 
 PYTHONIC_NS_BEGIN
 
 namespace math
 {
-  DEFINE_FUNCTOR_2(trunc, std::trunc);
+  template <class T>
+  long trunc(T x);
+
+  DEFINE_FUNCTOR(pythonic::math, trunc);
 }
 PYTHONIC_NS_END
 

--- a/pythran/pythonic/include/numpy/count_nonzero.hpp
+++ b/pythran/pythonic/include/numpy/count_nonzero.hpp
@@ -10,18 +10,18 @@ namespace numpy
 {
 
   template <class dtype, class E>
-  auto _count_nonzero(E begin, E end, size_t &count, utils::int_<1>) ->
+  auto _count_nonzero(E begin, E end, long &count, utils::int_<1>) ->
       typename std::enable_if<std::is_same<dtype, bool>::value>::type;
 
   template <class dtype, class E>
-  auto _count_nonzero(E begin, E end, size_t &count, utils::int_<1>) ->
+  auto _count_nonzero(E begin, E end, long &count, utils::int_<1>) ->
       typename std::enable_if<!std::is_same<dtype, bool>::value>::type;
 
   template <class dtype, class E, size_t N>
-  void _count_nonzero(E begin, E end, size_t &count, utils::int_<N>);
+  void _count_nonzero(E begin, E end, long &count, utils::int_<N>);
 
   template <class E>
-  size_t count_nonzero(E const &array);
+  long count_nonzero(E const &array);
 
   DEFINE_FUNCTOR(pythonic::numpy, count_nonzero);
 }

--- a/pythran/pythonic/include/numpy/rank.hpp
+++ b/pythran/pythonic/include/numpy/rank.hpp
@@ -9,7 +9,7 @@ PYTHONIC_NS_BEGIN
 namespace numpy
 {
   template <class E>
-  size_t rank(E const &expr);
+  long rank(E const &expr);
 
   DEFINE_FUNCTOR(pythonic::numpy, rank);
 }

--- a/pythran/pythonic/include/numpy/reduce.hpp
+++ b/pythran/pythonic/include/numpy/reduce.hpp
@@ -7,24 +7,36 @@
 #include <algorithm>
 
 PYTHONIC_NS_BEGIN
+namespace operator_
+{
+  namespace functor
+  {
+    struct imax;
+    struct imin;
+  }
+}
 
 namespace numpy
 {
 
   namespace
   {
-    template <class E>
+    template <class Op, class E>
     using reduce_result_type = typename std::conditional<
         std::is_integral<typename E::dtype>::value &&
-            (sizeof(typename E::dtype) < sizeof(long)),
-        typename std::conditional<std::is_signed<typename E::dtype>::value,
-                                  long, unsigned long>::type,
+            (sizeof(typename E::dtype) < sizeof(long)) &&
+            !std::is_same<Op, operator_::functor::imin>::value &&
+            !std::is_same<Op, operator_::functor::imax>::value,
+        typename std::conditional<
+            std::is_same<typename E::dtype, bool>::value, long,
+            typename std::conditional<std::is_signed<typename E::dtype>::value,
+                                      long, unsigned long>::type>::type,
         typename E::dtype>::type;
   }
 
   template <class Op, class E>
   typename std::enable_if<types::is_numexpr_arg<E>::value,
-                          reduce_result_type<E>>::type
+                          reduce_result_type<Op, E>>::type
   reduce(E const &expr, types::none_type _ = types::none_type());
 
   template <class Op, class E>
@@ -38,28 +50,28 @@ namespace numpy
   reduce(E const &array, long axis);
 
   template <class Op, class E>
-  typename std::enable_if<E::value == 1, reduce_result_type<E>>::type
+  typename std::enable_if<E::value == 1, reduce_result_type<Op, E>>::type
   reduce(E const &array, long axis, types::none_type dtype = types::none_type(),
          types::none_type out = types::none_type());
 
   template <class Op, class E, class Out>
-  typename std::enable_if<E::value == 1, reduce_result_type<E>>::type
+  typename std::enable_if<E::value == 1, reduce_result_type<Op, E>>::type
   reduce(E const &array, long axis, types::none_type dtype, Out &&out);
 
   namespace
   {
-    template <class E>
-    using reduced_type =
-        types::ndarray<reduce_result_type<E>, types::array<long, E::value - 1>>;
+    template <class E, class Op>
+    using reduced_type = types::ndarray<reduce_result_type<Op, E>,
+                                        types::array<long, E::value - 1>>;
   }
 
   template <class Op, class E>
-  typename std::enable_if<E::value != 1, reduced_type<E>>::type
+  typename std::enable_if<E::value != 1, reduced_type<E, Op>>::type
   reduce(E const &array, long axis, types::none_type dtype = types::none_type(),
          types::none_type out = types::none_type());
 
   template <class Op, class E, class Out>
-  typename std::enable_if<E::value != 1, reduced_type<E>>::type
+  typename std::enable_if<E::value != 1, reduced_type<E, Op>>::type
   reduce(E const &array, long axis, types::none_type dtype, Out &&out);
 }
 PYTHONIC_NS_END

--- a/pythran/pythonic/include/types/dynamic_tuple.hpp
+++ b/pythran/pythonic/include/types/dynamic_tuple.hpp
@@ -60,6 +60,10 @@ namespace types
     {
     }
 
+    dynamic_tuple(std::initializer_list<T> values) : data(values)
+    {
+    }
+
     // Iterators.
     const_iterator begin() const noexcept
     {

--- a/pythran/pythonic/include/types/exceptions.hpp
+++ b/pythran/pythonic/include/types/exceptions.hpp
@@ -2,7 +2,7 @@
 #define PYTHONIC_INCLUDE_TYPES_EXCEPTIONS_HPP
 
 #include "pythonic/include/types/str.hpp"
-#include "pythonic/include/types/list.hpp"
+#include "pythonic/include/types/dynamic_tuple.hpp"
 #include "pythonic/include/types/attr.hpp"
 #include "pythonic/include/__builtin__/str.hpp"
 
@@ -20,7 +20,7 @@ namespace types
     template <typename... Types>
     BaseException(Types const &... types);
     virtual ~BaseException() noexcept = default;
-    list<str> args;
+    dynamic_tuple<str> args;
   };
 
 // Use this to create a python exception class
@@ -99,8 +99,8 @@ PYTHONIC_NS_END
   PYTHONIC_NS_BEGIN                                                            \
   namespace __builtin__                                                        \
   {                                                                            \
-    types::none<types::list<types::str>> getattr(types::attr::ARGS,            \
-                                                 types::name const &f);        \
+    types::none<types::dynamic_tuple<types::str>>                              \
+    getattr(types::attr::ARGS, types::name const &f);                          \
   }                                                                            \
   PYTHONIC_NS_END
 
@@ -108,8 +108,8 @@ PYTHONIC_NS_END
   PYTHONIC_NS_BEGIN                                                            \
   namespace __builtin__                                                        \
   {                                                                            \
-    types::none<types::list<types::str>> getattr(types::attr::ARGS,            \
-                                                 types::name const &e);        \
+    types::none<types::dynamic_tuple<types::str>>                              \
+    getattr(types::attr::ARGS, types::name const &e);                          \
     types::none<types::str> getattr(types::attr::ERRNO, types::name const &e); \
     types::none<types::str> getattr(types::attr::STRERROR,                     \
                                     types::name const &e);                     \

--- a/pythran/pythonic/include/types/ndarray.hpp
+++ b/pythran/pythonic/include/types/ndarray.hpp
@@ -697,7 +697,9 @@ namespace types
     };
 #if defined(_WIN32) || defined(__APPLE__)
     template <>
-    struct dtype_helper<long> : dtype_helper<int64_t> {
+    struct dtype_helper<long>
+        : dtype_helper<typename std::conditional<
+              sizeof(long) == sizeof(int64_t), int64_t, int32_t>::type> {
     };
 #endif
     template <>

--- a/pythran/pythonic/math/ceil.hpp
+++ b/pythran/pythonic/math/ceil.hpp
@@ -10,6 +10,11 @@ PYTHONIC_NS_BEGIN
 
 namespace math
 {
+  template <class T>
+  long ceil(T x)
+  {
+    return std::ceil(x);
+  }
 }
 PYTHONIC_NS_END
 

--- a/pythran/pythonic/math/floor.hpp
+++ b/pythran/pythonic/math/floor.hpp
@@ -10,6 +10,11 @@ PYTHONIC_NS_BEGIN
 
 namespace math
 {
+  template <class T>
+  long floor(T x)
+  {
+    return std::floor(x);
+  }
 }
 PYTHONIC_NS_END
 

--- a/pythran/pythonic/math/trunc.hpp
+++ b/pythran/pythonic/math/trunc.hpp
@@ -10,6 +10,11 @@ PYTHONIC_NS_BEGIN
 
 namespace math
 {
+  template <class T>
+  long trunc(T x)
+  {
+    return x;
+  }
 }
 PYTHONIC_NS_END
 

--- a/pythran/pythonic/numpy/count_nonzero.hpp
+++ b/pythran/pythonic/numpy/count_nonzero.hpp
@@ -12,7 +12,7 @@ namespace numpy
 {
 
   template <class dtype, class E>
-  auto _count_nonzero(E begin, E end, size_t &count, utils::int_<1>) ->
+  auto _count_nonzero(E begin, E end, long &count, utils::int_<1>) ->
       typename std::enable_if<std::is_same<dtype, bool>::value>::type
   {
     for (; begin != end; ++begin)
@@ -21,7 +21,7 @@ namespace numpy
   }
 
   template <class dtype, class E>
-  auto _count_nonzero(E begin, E end, size_t &count, utils::int_<1>) ->
+  auto _count_nonzero(E begin, E end, long &count, utils::int_<1>) ->
       typename std::enable_if<!std::is_same<dtype, bool>::value>::type
   {
     for (; begin != end; ++begin)
@@ -30,7 +30,7 @@ namespace numpy
   }
 
   template <class dtype, class E, size_t N>
-  void _count_nonzero(E begin, E end, size_t &count, utils::int_<N>)
+  void _count_nonzero(E begin, E end, long &count, utils::int_<N>)
   {
     for (; begin != end; ++begin)
       _count_nonzero<dtype>((*begin).begin(), (*begin).end(), count,
@@ -38,9 +38,9 @@ namespace numpy
   }
 
   template <class E>
-  size_t count_nonzero(E const &array)
+  long count_nonzero(E const &array)
   {
-    size_t count(0);
+    long count(0);
     _count_nonzero<typename E::dtype>(array.begin(), array.end(), count,
                                       utils::int_<E::value>());
     return count;

--- a/pythran/pythonic/numpy/rank.hpp
+++ b/pythran/pythonic/numpy/rank.hpp
@@ -11,7 +11,7 @@ PYTHONIC_NS_BEGIN
 namespace numpy
 {
   template <class E>
-  size_t rank(E const &expr)
+  long rank(E const &expr)
   {
     return E::value;
   }

--- a/pythran/pythonic/types/exceptions.hpp
+++ b/pythran/pythonic/types/exceptions.hpp
@@ -4,7 +4,7 @@
 #include "pythonic/include/types/exceptions.hpp"
 
 #include "pythonic/types/str.hpp"
-#include "pythonic/types/list.hpp"
+#include "pythonic/types/dynamic_tuple.hpp"
 #include "pythonic/types/attr.hpp"
 #include "pythonic/__builtin__/None.hpp"
 #include "pythonic/__builtin__/str.hpp"
@@ -87,8 +87,8 @@ PYTHONIC_NS_END
   PYTHONIC_NS_BEGIN                                                            \
   namespace __builtin__                                                        \
   {                                                                            \
-    types::none<types::list<types::str>> getattr(types::attr::ARGS,            \
-                                                 types::name const &f)         \
+    types::none<types::dynamic_tuple<types::str>>                              \
+    getattr(types::attr::ARGS, types::name const &f)                           \
     {                                                                          \
       return f.args;                                                           \
     }                                                                          \
@@ -99,13 +99,14 @@ PYTHONIC_NS_END
   PYTHONIC_NS_BEGIN                                                            \
   namespace __builtin__                                                        \
   {                                                                            \
-    types::none<types::list<types::str>> getattr(types::attr::ARGS,            \
-                                                 types::name const &e)         \
+    types::none<types::dynamic_tuple<types::str>>                              \
+    getattr(types::attr::ARGS, types::name const &e)                           \
     {                                                                          \
       if (e.args.size() > 3 || e.args.size() < 2)                              \
         return e.args;                                                         \
       else                                                                     \
-        return types::list<types::str>(e.args.begin(), e.args.begin() + 2);    \
+        return types::dynamic_tuple<types::str>(e.args.begin(),                \
+                                                e.args.begin() + 2);           \
     }                                                                          \
     types::none<types::str> getattr(types::attr::ERRNO, types::name const &e)  \
     {                                                                          \

--- a/pythran/tests/cases/compute_subpix_2d_gaussian2.py
+++ b/pythran/tests/cases/compute_subpix_2d_gaussian2.py
@@ -1,5 +1,5 @@
 import numpy as np
-#runas import numpy as np; x = np.arange(16., dtype=np.float32).reshape(4,4); compute_subpix_2d_gaussian2(x, 1, 1)
+#runas import numpy as np; x = (np.arange(16., dtype=np.float32) - 8.).reshape(4,4); compute_subpix_2d_gaussian2(x, 1, 1)
 
 # pythran export compute_subpix_2d_gaussian2(float32[][], int, int)
 def compute_subpix_2d_gaussian2(correl, ix, iy):
@@ -28,6 +28,6 @@ def compute_subpix_2d_gaussian2(correl, ix, iy):
 
     c00, c10, c01, c11, c20, c02 = \
         c00/9, c10/6, c01/6, c11/4, c20/6, c02/6
-    deplx = (c11*c01-2*c10*c02)/(4*c20*c02-c11**2)
-    deply = (c11*c10-2*c01*c20)/(4*c20*c02-c11**2)
+    deplx = np.float32((c11*c01-2*c10*c02)/(4*c20*c02-c11**2))
+    deply = np.float32((c11*c10-2*c01*c20)/(4*c20*c02-c11**2))
     return deplx, deply, correl_crop

--- a/pythran/tests/cases/pselect.py
+++ b/pythran/tests/cases/pselect.py
@@ -2,12 +2,13 @@
 #runas pselect(0)
 #runas pselect(1)
 def pselect(n):
-    if n:
-        a=sel0
-    else:
-        a=sel1
     l=list()
-    a(l)
+    for k in (n, not n):
+        if k:
+            a=sel0
+        else:
+            a=sel1
+        a(l)
     return l
 
 def sel0(n):

--- a/pythran/tests/cases/train_eq.py
+++ b/pythran/tests/cases/train_eq.py
@@ -23,7 +23,7 @@ def train_eq(E, TrSyms, os, mu, wx,  errfctprs, adapt):
             if err[i].real*err[i-1].real > 0 and err[i].imag*err[i-1].imag > 0:
                 mu = mu
             else:
-                mu = mu/(1+mu*(err[i].real*err[i].real + err[i].imag*err[i].imag))
+                mu = np.float32(mu/(1+mu*(err[i].real*err[i].real + err[i].imag*err[i].imag)))
     return err, wx, mu
 
 def train_eq2(E, TrSyms, os, mu, wx,  errfctprs, adapt):
@@ -40,7 +40,7 @@ def train_eq2(E, TrSyms, os, mu, wx,  errfctprs, adapt):
             if err[i].real*err[i-1].real > 0 and err[i].imag*err[i-1].imag > 0:
                 mu = mu
             else:
-                mu = mu/(1+mu*(err[i].real*err[i].real + err[i].imag*err[i].imag))
+                mu = np.float32(mu/(1+mu*(err[i].real*err[i].real + err[i].imag*err[i].imag)))
     return err, wx, mu
 
 def cma_error(Xest, R, symbs):

--- a/pythran/tests/rosetta/pythagor_triples.py
+++ b/pythran/tests/rosetta/pythagor_triples.py
@@ -10,7 +10,7 @@ def triples(lim, a = 3, b = 4, c = 5):
     l = a + b + c
     if l > lim: return (0, 0)
     return reduce(lambda x, y: (x[0] + y[0], x[1] + y[1]), [
-            (1, lim / l),
+            (1, int(lim / l)),
             triples(lim,  a - 2*b + 2*c,  2*a - b + 2*c,  2*a - 2*b + 3*c),
             triples(lim,  a + 2*b + 2*c,  2*a + b + 2*c,  2*a + 2*b + 3*c),
             triples(lim, -a + 2*b + 2*c, -2*a + b + 2*c, -2*a + 2*b + 3*c) ])

--- a/pythran/tests/test_base.py
+++ b/pythran/tests/test_base.py
@@ -97,7 +97,7 @@ def fibo2(n): return fibo2(n-1) + fibo2(n-2) if n > 1 else n
         self.run_test("def max_(l):return max(l)", [ 1.1, 2.2 ], max_=[List[float]])
 
     def test_multimax(self):
-        self.run_test("def multimax(l,v):return max(v,max(l))", [ 1.1, 2.2 ], 3, multimax=[List[float],int])
+        self.run_test("def multimax(l,v):return max(v,max(l))", [ 1.1, 2.2 ], 1, multimax=[List[float],int])
 
     def test_min(self):
         self.run_test("def min_(l):return min(l)", [ 1.1, 2.2 ], min_=[List[float]])
@@ -197,8 +197,12 @@ def fibo2(n): return fibo2(n-1) + fibo2(n-2) if n > 1 else n
     def test_multiassign(self):
         self.run_test("def multiassign(a):\n c=b=a\n return c", [1], multiassign=[List[int]])
 
-    def test_list(self):
-        self.run_test("def list_(a): b=2*a;c=b/2;return max(c,b)", 1, list_=[int])
+    def test_divmax(self):
+        self.run_test("def divmax_(a): b=4.*a;c=b/2;return max(c,b)", 1, divmax_=[int])
+
+    @unittest.skip("impossible to handle max(int, float) without conversion")
+    def test_divmax_float(self):
+        self.run_test("def divmax_float_(a): b=2*a;c=b/2;return max(c,b)", 1, divmax_float_=[int])
 
     def test_if(self):
         self.run_test("def if_(a,b):\n if a>b: return a\n else: return b", 1, 1.1, if_=[int, float])

--- a/pythran/tests/user_defined_import/mix_builtin.py
+++ b/pythran/tests/user_defined_import/mix_builtin.py
@@ -3,4 +3,4 @@ import mix_builtin_main, numpy, math as m
 from numpy import sin
 
 def foo(a):
-    return bar(a+42) + mix_builtin_main.foo(a) + m.floor(numpy.cos(a) + sin(a))
+    return float(bar(a+42) + mix_builtin_main.foo(a) + m.floor(numpy.cos(a) + sin(a)))

--- a/pythran/transformations/normalize_compare.py
+++ b/pythran/transformations/normalize_compare.py
@@ -2,6 +2,7 @@
 
 from pythran.analyses import ImportedIds
 from pythran.passmanager import Transformation
+from pythran.utils import path_to_attr
 
 import gast as ast
 
@@ -33,12 +34,12 @@ class NormalizeCompare(Transformation):
         if (0 < $1):
             pass
         else:
-            return 0
+            return __builtin__.False
         if ($1 < 3):
             pass
         else:
-            return 0
-        return 1
+            return __builtin__.False
+        return __builtin__.True
     '''
 
     def visit_Module(self, node):
@@ -99,10 +100,10 @@ class NormalizeCompare(Transformation):
                                    [holder])
                 body.append(ast.If(cond,
                                    [ast.Pass()],
-                                   [ast.Return(ast.Num(0))]))
+                                   [ast.Return(path_to_attr(('__builtin__', 'False')))]))
                 prev_holder = holder
 
-            body.append(ast.Return(ast.Num(1)))
+            body.append(ast.Return(path_to_attr(('__builtin__', 'True'))))
 
             forged_fdef = ast.FunctionDef(forged_name, args, body, [], None)
             self.compare_functions.append(forged_fdef)


### PR DESCRIPTION
- ceil/floor/trunc return an int
- max/min don't do type promotion
- exception's args can be stored as dynamic_tuple instead of list
- rank returns an int and not a size_t
- normalize_compare generates bool and not int

This fixes #339 that actually got fixed a while ago, but now we are sure
it won't regress.

Still allow int64 <> long, bool_ <> bool float32 <> float conversion.