### PR TITLE
Properly handle variables referenced in private/shared omp clause

### DIFF
--- a/pythran/analyses/lazyness_analysis.py
+++ b/pythran/analyses/lazyness_analysis.py
@@ -150,6 +150,10 @@ class LazynessAnalysis(FunctionAnalysis):
         super(LazynessAnalysis, self).visit(node)
         if omp_nodes:
             new_nodes = set(self.name_count).difference(self.in_omp)
+            for omp_node in omp_nodes:
+                for n in omp_node.deps:
+                    if isinstance(n, ast.Name):
+                        self.result[n.id] = LazynessAnalysis.INF
             self.dead.update(new_nodes)
         self.in_omp = old_omp
 

--- a/pythran/tests/openmp.legacy/pythran_forward_substitution.py
+++ b/pythran/tests/openmp.legacy/pythran_forward_substitution.py
@@ -1,0 +1,12 @@
+import numpy as np
+def aaa(a):
+    grid = np.empty((a, ))
+    # omp parallel for private(i, j)
+    for i in range(a):
+        j = i * i
+        grid[i] = j
+    return grid
+
+def pythran_forward_substitution():
+    from random import randint
+    return aaa(randint(5,5))


### PR DESCRIPTION
Even the one that no longer exist! Fix #1259