### PR TITLE
Fix packaging of numpy/interp_core.cpp

### DIFF
--- a/pythran/pythonic/numpy/interp.hpp
+++ b/pythran/pythonic/numpy/interp.hpp
@@ -14,7 +14,7 @@
 #include "pythonic/utils/numpy_conversion.hpp"
 #include "pythonic/types/ndarray.hpp"
 #include "pythonic/__builtin__/None.hpp"
-#include "pythonic/numpy/interp_core.cpp"
+#include "pythonic/numpy/interp_core.hpp"
 
 PYTHONIC_NS_BEGIN
 

--- a/pythran/pythonic/numpy/interp_core.hpp
+++ b/pythran/pythonic/numpy/interp_core.hpp
@@ -1,8 +1,6 @@
 //
-//  interp_core.cpp
-//  From /Users/jlaroche/temp/NumpySrc/numpy/core/src/multiarray/compiled_base.c
+//  From NumpySrc/numpy/core/src/multiarray/compiled_base.c
 
-#include <stdio.h>
 /** @brief find index of a sorted array such that arr[i] <= key < arr[i + 1].
  *
  * If an starting index guess is in-range, the array values around this


### PR DESCRIPTION
Problem due to file extension, should be a .hpp t be correclty bundled.

Thanks to Jean Laroche for spotting the issue!