### PR TITLE
\o/ was not intended as a backslash-escape.  Tell python.

### DIFF
--- a/pythran/analyses/aliases.py
+++ b/pythran/analyses/aliases.py
@@ -602,7 +602,7 @@ class Aliases(ModuleAnalysis):
             node.return_alias = merge_return_aliases
 
     def visit_Assign(self, node):
-        '''
+        r'''
         Assignment creates aliasing between lhs and rhs
 
         >>> from pythran import passmanager


### PR DESCRIPTION
Avoid SyntaxWarnings due to invalid backslash-escapes.