### PR TITLE
Fix compilation with Python < 3.6.1

### DIFF
--- a/pythran/pythonic/types/slice.hpp
+++ b/pythran/pythonic/types/slice.hpp
@@ -497,8 +497,11 @@ bool from_python<types::slice>::is_convertible(PyObject *obj)
 types::slice from_python<types::slice>::convert(PyObject *obj)
 {
   Py_ssize_t start, stop, step;
-#if PY_MAJOR_VERSION >= 3
+#if PY_MAJOR_VERSION > 3 || (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION > 6) || \
+    (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION == 6 && PY_MICRO_VERSION >= 1)
   PySlice_Unpack(obj, &start, &stop, &step);
+#elif PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 1
+  PySlice_GetIndices((PyObject *)obj, PY_SSIZE_T_MAX, &start, &stop, &step);
 #else
   PySlice_GetIndices((PySliceObject *)obj, PY_SSIZE_T_MAX, &start, &stop,
                      &step);


### PR DESCRIPTION
PySlice_Unpack is only supported since 3.6.1