### PR TITLE
Make pythran.Python generator compatible with collapse clause

### DIFF
--- a/pythran/tests/openmp.legacy/pythran_collapse.py
+++ b/pythran/tests/openmp.legacy/pythran_collapse.py
@@ -1,0 +1,16 @@
+import numpy as np
+def collapse_bug(x, m, btx):
+    n = int(np.log2(m))
+    lv = np.zeros((x.shape[0], n))
+    N = x.shape[0]
+    #omp parallel for collapse(2)
+    for i in range(N):
+        for k in range(n):
+            lv[i,k] = abs(x[i]- btx[k])
+    return lv
+
+def pythran_collapse():
+    from random import randint
+    n = randint(50, 50)
+    x = np.ones(n)
+    return collapse_bug(x, 5, 3. * x)


### PR DESCRIPTION
Basically generate loop bound in a nested fashion as long as the upperbound is a
pure expression.

Fix #1337