### PR TITLE
PyPy3.6 support (no PySlice_Unpack)

### DIFF
--- a/docs/INTERNAL.rst
+++ b/docs/INTERNAL.rst
@@ -253,7 +253,6 @@ about aliased values::
     [('a', 1), ('a_', 1), ('array', 1), ('b', 1)]
 
 
-
 Doc Strings
 -----------
 
@@ -269,6 +268,7 @@ Pythran preserves docstrings::
     <BLANKLINE>
         - foo()
     $> rm -f docstrings.*
+
 
 Integration with Scipy LowLevelCallable
 ---------------------------------------
@@ -289,3 +289,9 @@ When using a pointer type as argument, one can rely on ``numpy.ctypeslib.as_arra
     33
     $> rm -f llc2.*
 
+
+PyPy3 support
+-------------
+
+Pythran has been said to work well with PyPy3.6 v7.2.0. However, this setup is
+not yet tested on Travis so compilation failure may happen. Report them!

--- a/pythran/pythonic/types/slice.hpp
+++ b/pythran/pythonic/types/slice.hpp
@@ -498,7 +498,8 @@ types::slice from_python<types::slice>::convert(PyObject *obj)
 {
   Py_ssize_t start, stop, step;
 #if PY_MAJOR_VERSION > 3 || (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION > 6) || \
-    (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION == 6 && PY_MICRO_VERSION >= 1)
+    (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION == 6 &&                         \
+     PY_MICRO_VERSION >= 1 && !defined(PYPY_VERSION))
   PySlice_Unpack(obj, &start, &stop, &step);
 #elif PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 1
   PySlice_GetIndices((PyObject *)obj, PY_SSIZE_T_MAX, &start, &stop, &step);


### PR DESCRIPTION
Fixes #1395 

I don't know where PYTHRAN_COMPILING_IN_PYPY should be defined...