### PR TITLE
fix compile without ENABLE_PYTHON_MODULE

### DIFF
--- a/pythran/pythonic/include/__builtin__/pythran/is_none.hpp
+++ b/pythran/pythonic/include/__builtin__/pythran/is_none.hpp
@@ -115,12 +115,18 @@ namespace __builtin__
     DEFINE_FUNCTOR(pythonic::__builtin__::pythran, is_none);
   }
 }
+
+#ifdef ENABLE_PYTHON_MODULE
+
 template <>
 struct to_python<types::true_type> : to_python<bool> {
 };
 template <>
 struct to_python<types::false_type> : to_python<bool> {
 };
+
+#endif
+
 PYTHONIC_NS_END
 
 #endif


### PR DESCRIPTION
add #ifdef ENABLE_PYTHON_MODULE for
pythran -e and g++ compile without ENABLE_PYTHON_MODULE