### PR TITLE
Fix shape computation of nexpr when one of the expr is empty

### DIFF
--- a/pythran/pythonic/include/types/numpy_broadcast.hpp
+++ b/pythran/pythonic/include/types/numpy_broadcast.hpp
@@ -297,7 +297,7 @@ namespace types
     auto load(I i) const -> decltype(this->_base.load(i));
     template <class... Args>
     dtype operator()(Args &&...) const;
-    using shape_t = types::pshape<std::integral_constant<long, 0>>;
+    using shape_t = types::pshape<std::integral_constant<long, 1>>;
     shape_t shape() const;
     long flat_size() const;
     const_iterator begin() const

--- a/pythran/pythonic/types/numpy_expr.hpp
+++ b/pythran/pythonic/types/numpy_expr.hpp
@@ -37,21 +37,21 @@ namespace types
         typename all_valid_indices<value, Args,
                                    std::tuple_size<Args>::value>::type;
 
-    template <class V>
-    long max_of(V v)
+    long best_of()
     {
-      return v;
+      return 1;
     }
-    template <class V0, class V1, class... Vs>
-    long max_of(V0 v0, V1 v1, Vs... vs)
+    template <class V0, class... Vs>
+    long best_of(V0 v0, Vs... vs)
     {
-      return std::max((long)v0, max_of(v1, vs...));
+      long vtail = best_of(vs...);
+      return (v0 == vtail) ? v0 : (v0 * vtail);
     }
 
     template <size_t I, class Args, size_t... Is>
     long init_shape_element(Args const &args, utils::index_sequence<Is...>)
     {
-      return max_of(std::get<I>(std::get<Is>(args).shape())...);
+      return best_of(std::get<I>(std::get<Is>(args).shape())...);
     }
 
     template <class pS, class Args, size_t... Is>

--- a/pythran/tests/cases/matrix_class_distance.py
+++ b/pythran/tests/cases/matrix_class_distance.py
@@ -1,0 +1,9 @@
+#pythran export matrix_class_distance(float64[:,:], int[], float64[:,:], int)
+#from https://stackoverflow.com/questions/59601987
+#runas import numpy as np; n = 200;d = 10;iterations = 20;np.random.seed(42);dat = np.random.random((n, d));dat_filter = np.random.randint(0, n, size=n); dat_points = np.random.random((n, d)); matrix_class_distance(dat, dat_filter, dat_points, iterations)
+import numpy as np
+def matrix_class_distance(dat, dat_filter, dat_points, iterations):
+    aggregation = 0
+    for i in range(iterations):
+        aggregation += np.sum(np.linalg.norm(dat[dat_filter==i] - dat_points[i], axis=1))
+    return aggregation


### PR DESCRIPTION
Fixes #1434