### PR TITLE
No inlining of global variable if their initializer has a side effect

### DIFF
--- a/pythran/analyses/inlinable.py
+++ b/pythran/analyses/inlinable.py
@@ -2,6 +2,8 @@
 
 from pythran.passmanager import ModuleAnalysis
 from pythran.analyses import Identifiers
+from pythran.analyses.pure_expressions import PureExpressions
+import pythran.metadata as metadata
 
 import gast as ast
 import copy
@@ -17,13 +19,23 @@ class Inlinable(ModuleAnalysis):
 
     def __init__(self):
         self.result = dict()
-        super(Inlinable, self).__init__()
+        super(Inlinable, self).__init__(PureExpressions)
 
     def visit_FunctionDef(self, node):
         """ Determine this function definition can be inlined. """
-        if (len(node.body) == 1 and
-                isinstance(node.body[0], (ast.Call, ast.Return))):
-            ids = self.gather(Identifiers, node.body[0])
-            # FIXME : It mark "not inlinable" def foo(foo): return foo
-            if node.name not in ids:
-                self.result[node.name] = copy.deepcopy(node)
+        if len(node.body) != 1:
+            return
+
+        sbody = node.body[0]
+        if not isinstance(sbody, (ast.Call, ast.Return)):
+            return
+
+        # only consider static return if they are pure
+        if metadata.get(sbody, metadata.StaticReturn):
+            if sbody not in self.pure_expressions:
+                return
+
+        ids = self.gather(Identifiers, sbody)
+        # FIXME : It mark "not inlinable" def foo(foo): return foo
+        if node.name not in ids:
+            self.result[node.name] = copy.deepcopy(node)

--- a/pythran/tests/test_optimizations.py
+++ b/pythran/tests/test_optimizations.py
@@ -564,6 +564,17 @@ class TestAnalyses(TestEnv):
                       1,
                       argument_effects_unknown=[int])
 
+    def test_inlining_globals_side_effect(self):
+        code = '''
+            import random
+            r = random.random()
+            def inlining_globals_side_effect():
+                return r == r == r
+            '''
+
+        self.run_test(code,
+                      inlining_globals_side_effect=[])
+
     def test_subscript_function_aliasing(self):
         code = '''
             SP = 0x20


### PR DESCRIPTION
That would duplicate the side effect at each use site.