### PR TITLE
Fix slicing of a broadcasting numpy_expr

### DIFF
--- a/pythran/pythonic/include/types/slice.hpp
+++ b/pythran/pythonic/include/types/slice.hpp
@@ -173,6 +173,38 @@ namespace types
     return s.normalize(n);
   }
 
+  template <class I0, class I1>
+  none_type adapt_slice(none_type, I0 const &, I1 const &)
+  {
+    return {};
+  }
+  template <class I0, class I1>
+  long adapt_slice(long l, I0 const &index0, I1 const &index1)
+  {
+
+    if ((long)index0 != (long)index1)
+      return 0;
+    else
+      return l;
+  }
+  template <class I0, class I1>
+  slice adapt_slice(slice const &s, I0 const &index0, I1 const &index1)
+  {
+    if ((long)index0 != (long)index1)
+      return {0, 1, 1};
+    else
+      return s;
+  }
+  template <class I0, class I1>
+  contiguous_slice adapt_slice(contiguous_slice const &s, I0 const &index0,
+                               I1 const &index1)
+  {
+    if ((long)index0 != (long)index1)
+      return {0, 1};
+    else
+      return s;
+  }
+
   std::ostream &operator<<(std::ostream &os, slice const &s);
   std::ostream &operator<<(std::ostream &os, contiguous_slice const &s);
 }

--- a/pythran/tests/test_numpy_broadcasting.py
+++ b/pythran/tests/test_numpy_broadcasting.py
@@ -205,3 +205,14 @@ class TestBroadcasting(TestEnv):
                       np.arange(100.),
                       broadcast_nth29=[NDArray[float, :]])
 
+    def test_broadcasting_expr0(self):
+        code = '''
+        import numpy as np
+        def broadcasting_expr0(num_pairs):
+            t = np.zeros((num_pairs, 4), dtype=float)
+            t[0,1] = t[1, 0] = 1
+            first_row = t[:, 0].reshape((-1, 1))
+            normalized_triples = np.subtract(t, first_row)
+            return normalized_triples[:,1:4]'''
+        self.run_test(code, 4, broadcasting_expr0=[int])
+


### PR DESCRIPTION
((5, 1) * (1, 5)) [1:3] cannot be folded into
((5,1)[1:3]) * ((1, 5)[1:3]) without some extra magic.

Fix #1445