### PR TITLE
Bugfix/cxxtypes recursion generate

### DIFF
--- a/pythran/cxxtypes.py
+++ b/pythran/cxxtypes.py
@@ -225,21 +225,18 @@ std::declval<bool>()))
                 return Type.__add__(self, other)
 
             def generate(self, ctx):
+                import sys
+                current_recursion_limit = sys.getrecursionlimit()
                 try:
                     return 'typename __combined<{}>::type'.format(
                         ','.join(ctx(t) for t in self.types))
                 except RuntimeError:
                     # this is a situation where we accept to somehow extend
                     # the recursion limit, because of degenerated trees
-                    import sys
-                    current_recursion_limit = sys.getrecursionlimit()
-                    try:
-                        return self.generate(ctx)
-                    except RuntimeError:
-                        sys.setrecursionlimit(current_recursion_limit * 2)
-                        return self.generate(ctx)
-                    finally:
-                        sys.setrecursionlimit(current_recursion_limit)
+                    sys.setrecursionlimit(current_recursion_limit * 2)
+                    res = self.generate(ctx)
+                    sys.setrecursionlimit(current_recursion_limit)
+                    return res
 
         class ArgumentType(Type):
             """


### PR DESCRIPTION
A infinite recursion was being generated due to the recursion logic using the exception handler. A fix was proposed.