### PR TITLE
Fix a.reshape(-1)

### DIFF
--- a/pythran/pythonic/include/types/tuple.hpp
+++ b/pythran/pythonic/include/types/tuple.hpp
@@ -1115,23 +1115,28 @@ namespace sutils
   using push_front_t = concat_t<types::pshape<T>, P>;
 
   template <class S>
-  long find(S &s, long v, std::integral_constant<size_t, 0>)
+  long find(S &s, long v, std::integral_constant<size_t, 0>, long start,
+            bool comp(long, long))
   {
-    return v == std::get<0>(s) ? 0 : -1;
+    return comp(std::get<0>(s), v) && 0 < start ? 0 : -1;
   }
   template <class S, size_t I>
-  long find(S &s, long v, std::integral_constant<size_t, I>)
+  long find(S &s, long v, std::integral_constant<size_t, I>, long start,
+            bool comp(long, long))
   {
-    return v == std::get<I>(s)
+    return comp(std::get<I>(s), v) && I < start
                ? I
-               : find(s, v, std::integral_constant<size_t, I - 1>());
+               : find(s, v, std::integral_constant<size_t, I - 1>(), start,
+                      comp);
   }
 
   template <class S>
-  long find(S &s, long v)
+  long find(S &s, long v, long start = std::tuple_size<S>::value,
+            bool comp(long, long) = [](long a, long b) { return (a == b); })
   {
-    return find(
-        s, v, std::integral_constant<size_t, std::tuple_size<S>::value - 1>());
+    return find(s, v,
+                std::integral_constant<size_t, std::tuple_size<S>::value - 1>(),
+                start, comp);
   }
 
   template <class S, class B>

--- a/pythran/tests/test_numpy_func2.py
+++ b/pythran/tests/test_numpy_func2.py
@@ -849,6 +849,17 @@ def np_reshape1(a):
     def test_reshape4(self):
         self.run_test("def np_reshape4(a): return (1 + a.reshape(5, -1)), (1 + a[None])", numpy.arange(10), np_reshape4=[NDArray[int,:]])
         
+    def test_reshape5(self):
+        self.run_test("def np_reshape5(a): return a.reshape(-1)", numpy.random.random((10,2)), np_reshape5=[NDArray[float,:,:]])
+        
+    def test_reshape6(self):
+        code = "def test_reshape6(a): return a.reshape((-1,-1))"
+        with self.assertRaises(ValueError):
+            self.run_test(code, numpy.random.random((10,2)), test_reshape6=[NDArray[float,:,:]])
+
+    def test_reshape7(self):
+        self.run_test("def np_reshape7(a): return a.reshape(-10)", numpy.random.random((10,2)), np_reshape7=[NDArray[float,:,:]])
+
     def test_expand_dims1(self):
         code = """
 import numpy


### PR DESCRIPTION
There's a bug in the current implementation of a.reshape that causes a segmentation fault for calls like a.reshape(-1)
This PR fixes it, and adds a test.