### PR TITLE
Fix optional argument handling in spec

### DIFF
--- a/pythran/spec.py
+++ b/pythran/spec.py
@@ -286,8 +286,7 @@ class SpecParser(object):
         elif len(p) == 4:
             p[0] = tuple((t,) + ts for t in p[1] for ts in p[3])
         else:
-            non_defaults = [t for t in p[4] if len(t) == len(p[4][0])]
-            p[0] = tuple((t,) + ts for t in p[1] for ts in non_defaults) + p[4]
+            p[0] = tuple((t,) + ts for t in p[1] for ts in p[4]) + ((),)
 
     def p_default_types(self, p):
         '''default_types : type OPT
@@ -295,8 +294,7 @@ class SpecParser(object):
         if len(p) == 3:
             p[0] = tuple((t,) for t in p[1]) + ((),)
         else:
-            non_defaults = [t for t in p[4] if len(t) == len(p[4][0])]
-            p[0] = tuple((t,) + ts for t in p[1] for ts in non_defaults) + p[4]
+            p[0] = tuple((t,) + ts for t in p[1] for ts in p[4]) + ((),)
 
     def p_types(self, p):
         '''types : type

--- a/pythran/tests/rosetta/proba_choice.py
+++ b/pythran/tests/rosetta/proba_choice.py
@@ -1,5 +1,5 @@
 #from http://rosettacode.org/wiki/Probabilistic_choice#Python
-#pythran export test()
+#pythran export test(str?, int?)
 #runas test()
 
 import random, bisect
@@ -62,9 +62,9 @@ def tester(func=probchoice, items='good bad ugly'.split(),
     print("Attained probability:", problist2string(
         counter[x]/float(trials) for x in items))
 
-def test():
-    items = 'aleph beth gimel daleth he waw zayin heth'.split()
+def test(init_seq='aleph beth gimel daleth he waw zayin heth', bincount=1000000):
+    items = init_seq.split()
     probs = [1/(float(n)+5) for n in range(len(items))]
     probs[-1] = 1-sum(probs[:-1])
-    tester(probchoice, items, probs, 1000000)
+    tester(probchoice, items, probs, bincount)
     tester(probchoice2, items, probs, 1000000)


### PR DESCRIPTION
Default argument list was split in the reverse order...
Modify a rosetta test case to use that spec syntax.

Fix #1508