### PR TITLE
Correctly protect c++ identifiers in local_names

### DIFF
--- a/pythran/backend.py
+++ b/pythran/backend.py
@@ -321,7 +321,7 @@ class CxxFunction(ast.NodeVisitor):
         ctx = CachedTypeVisitor(self.lctx)
         operator_local_declarations = (
             [Statement("{0} {1}".format(
-                self.types[self.local_names[k]].generate(ctx), k))
+                self.types[self.local_names[k]].generate(ctx), cxxid(k)))
              for k in self.ldecls]
         )
         dependent_typedefs = ctx.typedefs()

--- a/pythran/tests/test_advanced.py
+++ b/pythran/tests/test_advanced.py
@@ -402,3 +402,13 @@ def combiner_on_empty_list():
                 B[0][3]=n
                 return B, X'''
         self.run_test(code, 20, tuple_slicing1=[int])
+
+    def test_reserved_identifier0(self):
+        code = '''
+        def reserved_identifier0(x):
+            if x == 1:
+                case = 1
+            else:
+                case = 2
+            return case'''
+        self.run_test(code, 3, reserved_identifier0=[int])


### PR DESCRIPTION
Fix #1528