### PR TITLE
Correctly set buffer when assigning default constructed gexpr

### DIFF
--- a/pythran/pythonic/types/numpy_gexpr.hpp
+++ b/pythran/pythonic/types/numpy_gexpr.hpp
@@ -424,7 +424,7 @@ namespace types
       // arg = expr.arg;
       const_cast<typename std::decay<Arg>::type &>(arg) = expr.arg;
       slices = expr.slices;
-      buffer = arg.buffer;
+      buffer = arg.buffer + (expr.buffer - expr.arg.buffer);
       _shape = expr.shape();
       return *this;
     } else {

--- a/pythran/tests/test_ndarray.py
+++ b/pythran/tests/test_ndarray.py
@@ -900,6 +900,20 @@ def assign_ndarray(t):
                       10, "b", 10, 10,
                       numpy_lazy_gexpr=[int, str, int, int])
 
+    def test_numpy_lazy_gexpr2(self):
+        code = '''
+            import numpy as np
+            def numpy_lazy_gexpr2(c, y):
+                z = [0] * 2
+                if c:
+                    x = y[1:3]
+                z[0] = x[0]
+                z[1] = x[1]
+                return z'''
+        self.run_test(code,
+                      1, numpy.array([1,2,3,4]),
+                      numpy_lazy_gexpr2=[int, NDArray[int, :]])
+
     def test_fexpr0(self):
         code = '''
             import numpy as np


### PR DESCRIPTION
Fix #1538