### PR TITLE
Do not try to distinguish between filepath and content in spec_parser

### DIFF
--- a/pythran/tests/__init__.py
+++ b/pythran/tests/__init__.py
@@ -397,11 +397,13 @@ class TestFromDir(TestEnv):
         # Look for an extra spec file
         spec_file = os.path.splitext(file_)[0] + '.pythran'
         if os.path.isfile(spec_file):
-            return load_specfile(open(spec_file).read())
+            with open(spec_file) as fd:
+                return load_specfile(fd.read())
         elif file_ is None:
             return Spec({name: []})
         else:
-            return spec_parser(open(file_).read())
+            with open(file_) as fd:
+                return spec_parser(fd.read())
 
     @staticmethod
     def extract_runas(name, filepath):

--- a/pythran/tests/test_spec_parser.py
+++ b/pythran/tests/test_spec_parser.py
@@ -39,7 +39,8 @@ class TestSpecParser(unittest.TestCase):
 
     def test_parser(self):
         real_path = os.path.splitext(os.path.realpath(__file__))[0]+".py"
-        print(pythran.spec_parser(real_path))
+        with open(real_path) as fd:
+            print(pythran.spec_parser(fd.read()))
 
     def test_invalid_specs0(self):
         code = '#pythran export foo()\ndef foo(n): return n'

--- a/pythran/toolchain.py
+++ b/pythran/toolchain.py
@@ -464,8 +464,9 @@ def compile_pythranfile(file_path, output_file=None, module_name=None,
     # Look for an extra spec file
     spec_file = os.path.splitext(file_path)[0] + '.pythran'
     if os.path.isfile(spec_file):
-        specs = load_specfile(open(spec_file).read())
-        kwargs.setdefault('specs', specs)
+        with open(spec_file) as fd:
+            specs = load_specfile(fd.read())
+            kwargs.setdefault('specs', specs)
 
     output_file = compile_pythrancode(module_name, open(file_path).read(),
                                       output_file=output_file,


### PR DESCRIPTION
This is both invalid (One can forge a content that looks like a path) and
fragile (long content leads to exception on Windows)

Fix #1539