### PR TITLE
Iterable imported from collections.abc to avoid a warning

### DIFF
--- a/pythran/dist.py
+++ b/pythran/dist.py
@@ -5,7 +5,11 @@ This modules contains a distutils extension mechanism for Pythran
 
 import pythran.config as cfg
 
-from collections import defaultdict, Iterable
+from collections import defaultdict
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 import os.path
 import os
 


### PR DESCRIPTION
Avoid the warning
```
pythran/dist.py:8: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    from collections import defaultdict, Iterable
```

It should be supported by Python >= 3.3. Python 3.3 was released on Sept. 29, 2012.

Does Pythran need to support Python < 3.3 ? See https://numpy.org/neps/nep-0029-deprecation_policy.html
