### PR TITLE
Fix combiner between ndarray and expression

### DIFF
--- a/pythran/pythonic/include/types/numpy_gexpr.hpp
+++ b/pythran/pythonic/include/types/numpy_gexpr.hpp
@@ -1050,7 +1050,7 @@ struct __combined<pythonic::types::none_type,
 template <class Arg, class... S, class T, class pS>
 struct __combined<pythonic::types::numpy_gexpr<Arg, S...>,
                   pythonic::types::ndarray<T, pS>> {
-  using type = pythonic::types::numpy_gexpr<Arg, S...>;
+  using type = pythonic::types::ndarray<T, pS>;
 };
 
 template <class Arg, class... S, class T, class pS>

--- a/pythran/pythonic/include/types/numpy_iexpr.hpp
+++ b/pythran/pythonic/include/types/numpy_iexpr.hpp
@@ -361,5 +361,10 @@ struct __combined<pythonic::types::numpy_iexpr<E0>,
                   pythonic::types::numpy_iexpr<E1>> {
   using type = pythonic::types::numpy_iexpr<typename __combined<E0, E1>::type>;
 };
+template <class E, class T, class pS>
+struct __combined<pythonic::types::numpy_iexpr<E>,
+                  pythonic::types::ndarray<T, pS>> {
+  using type = pythonic::types::ndarray<T, pS>;
+};
 /*}*/
 #endif

--- a/pythran/pythonic/include/types/numpy_vexpr.hpp
+++ b/pythran/pythonic/include/types/numpy_vexpr.hpp
@@ -167,4 +167,17 @@ struct lazy<types::numpy_vexpr<T, F>> {
 
 PYTHONIC_NS_END
 
+/* combined are sorted such that the assigned type comes first */
+template <class E, class F, class T, class pS>
+struct __combined<pythonic::types::numpy_vexpr<E, F>,
+                  pythonic::types::ndarray<T, pS>> {
+  using type = pythonic::types::ndarray<T, pS>;
+};
+
+template <class E, class F, class T, class pS>
+struct __combined<pythonic::types::ndarray<T, pS>,
+                  pythonic::types::numpy_vexpr<E, F>> {
+  using type = pythonic::types::ndarray<T, pS>;
+};
+
 #endif

--- a/pythran/tests/test_ndarray.py
+++ b/pythran/tests/test_ndarray.py
@@ -1188,3 +1188,49 @@ def hanning(M):
         self.run_test(code,
                       numpy.arange(200.).reshape(10, 20),
                       subscripting_slice_array_transpose=[NDArray[float, :, :]])
+
+    def test_combiner_0(self):
+        code = '''
+import numpy as np
+def test_combiner_0(X):
+    O=test1(X[:,0], False)
+    P=test1(X[:,0], True)   # <- Ask to concatenate
+    return O,P
+
+def test1(X,A):
+    N = 20
+    if A:
+        X = np.concatenate((np.zeros(N),X))
+    return X'''
+        self.run_test(code, numpy.ones((10,10)), test_combiner_0=[NDArray[float,:,:]])
+
+    def test_combiner_1(self):
+        code = '''
+import numpy as np
+def test_combiner_1(X):
+    O=test1(X[0], False)
+    P=test1(X[1], True)   # <- Ask to concatenate
+    return O,P
+
+def test1(X,A):
+    N = 20
+    if A:
+        X = np.concatenate((np.zeros((N)),X))
+    return X'''
+        self.run_test(code, numpy.ones((10,10)), test_combiner_1=[NDArray[float,:,:]])
+
+    def test_combiner_2(self):
+        code = '''
+import numpy as np
+def test_combiner_2(X):
+    O=test1(X[X==1], False)
+    P=test1(X[X==1], True)   # <- Ask to concatenate
+    return O,P
+
+def test1(X,A):
+    N = 20
+    if A:
+        X = np.concatenate((np.zeros((N)),X))
+    return X'''
+        self.run_test(code, numpy.ones((10)), test_combiner_2=[NDArray[float,:]])
+


### PR DESCRIPTION
By default use ndarray to hold the expression in case of mixed type. It's ok
(but sometimes costly) if the expression is in read mode, and not okay if it's a
mixed view to write too...

Fix #1040