### PR TITLE
Support reduce function for various numpy operators

### DIFF
--- a/pythran/pythonic/include/numpy/add/reduce.hpp
+++ b/pythran/pythonic/include/numpy/add/reduce.hpp
@@ -1,0 +1,10 @@
+#ifndef PYTHONIC_INCLUDE_NUMPY_ADD_REDUCE_HPP
+#define PYTHONIC_INCLUDE_NUMPY_ADD_REDUCE_HPP
+
+#define UFUNC_NAME add
+#define UFUNC_INAME iadd
+#include "pythonic/include/numpy/ufunc_reduce.hpp"
+#undef UFUNC_NAME
+#undef UFUNC_INAME
+
+#endif

--- a/pythran/pythonic/include/numpy/bitwise_and/reduce.hpp
+++ b/pythran/pythonic/include/numpy/bitwise_and/reduce.hpp
@@ -1,0 +1,10 @@
+#ifndef PYTHONIC_INCLUDE_NUMPY_BITWISE_AND_REDUCE_HPP
+#define PYTHONIC_INCLUDE_NUMPY_BITWISE_AND_REDUCE_HPP
+
+#define UFUNC_NAME bitwise_and
+#define UFUNC_INAME iand
+#include "pythonic/include/numpy/ufunc_reduce.hpp"
+#undef UFUNC_NAME
+#undef UFUNC_INAME
+
+#endif

--- a/pythran/pythonic/include/numpy/bitwise_or/reduce.hpp
+++ b/pythran/pythonic/include/numpy/bitwise_or/reduce.hpp
@@ -1,0 +1,10 @@
+#ifndef PYTHONIC_INCLUDE_NUMPY_BITWISE_OR_REDUCE_HPP
+#define PYTHONIC_INCLUDE_NUMPY_BITWISE_OR_REDUCE_HPP
+
+#define UFUNC_NAME bitwise_or
+#define UFUNC_INAME ior
+#include "pythonic/include/numpy/ufunc_reduce.hpp"
+#undef UFUNC_NAME
+#undef UFUNC_INAME
+
+#endif

--- a/pythran/pythonic/include/numpy/bitwise_xor/reduce.hpp
+++ b/pythran/pythonic/include/numpy/bitwise_xor/reduce.hpp
@@ -1,0 +1,10 @@
+#ifndef PYTHONIC_INCLUDE_NUMPY_BITWISE_XOR_REDUCE_HPP
+#define PYTHONIC_INCLUDE_NUMPY_BITWISE_XOR_REDUCE_HPP
+
+#define UFUNC_NAME bitwise_xor
+#define UFUNC_INAME ixor
+#include "pythonic/include/numpy/ufunc_reduce.hpp"
+#undef UFUNC_NAME
+#undef UFUNC_INAME
+
+#endif

--- a/pythran/pythonic/include/numpy/fmax/reduce.hpp
+++ b/pythran/pythonic/include/numpy/fmax/reduce.hpp
@@ -1,0 +1,10 @@
+#ifndef PYTHONIC_INCLUDE_NUMPY_FMAX_REDUCE_HPP
+#define PYTHONIC_INCLUDE_NUMPY_FMAX_REDUCE_HPP
+
+#define UFUNC_NAME fmax
+#define UFUNC_INAME imax
+#include "pythonic/include/numpy/ufunc_reduce.hpp"
+#undef UFUNC_NAME
+#undef UFUNC_INAME
+
+#endif

--- a/pythran/pythonic/include/numpy/fmin/reduce.hpp
+++ b/pythran/pythonic/include/numpy/fmin/reduce.hpp
@@ -1,0 +1,10 @@
+#ifndef PYTHONIC_INCLUDE_NUMPY_FMIN_REDUCE_HPP
+#define PYTHONIC_INCLUDE_NUMPY_FMIN_REDUCE_HPP
+
+#define UFUNC_NAME fmin
+#define UFUNC_INAME imin
+#include "pythonic/include/numpy/ufunc_reduce.hpp"
+#undef UFUNC_NAME
+#undef UFUNC_INAME
+
+#endif

--- a/pythran/pythonic/include/numpy/maximum/reduce.hpp
+++ b/pythran/pythonic/include/numpy/maximum/reduce.hpp
@@ -1,0 +1,10 @@
+#ifndef PYTHONIC_INCLUDE_NUMPY_MAXIMUM_REDUCE_HPP
+#define PYTHONIC_INCLUDE_NUMPY_MAXIMUM_REDUCE_HPP
+
+#define UFUNC_NAME maximum
+#define UFUNC_INAME imax
+#include "pythonic/include/numpy/ufunc_reduce.hpp"
+#undef UFUNC_NAME
+#undef UFUNC_INAME
+
+#endif

--- a/pythran/pythonic/include/numpy/minimum/reduce.hpp
+++ b/pythran/pythonic/include/numpy/minimum/reduce.hpp
@@ -1,0 +1,10 @@
+#ifndef PYTHONIC_INCLUDE_NUMPY_MINIMUM_REDUCE_HPP
+#define PYTHONIC_INCLUDE_NUMPY_MINIMUM_REDUCE_HPP
+
+#define UFUNC_NAME minimum
+#define UFUNC_INAME imin
+#include "pythonic/include/numpy/ufunc_reduce.hpp"
+#undef UFUNC_NAME
+#undef UFUNC_INAME
+
+#endif

--- a/pythran/pythonic/include/numpy/multiply/reduce.hpp
+++ b/pythran/pythonic/include/numpy/multiply/reduce.hpp
@@ -1,0 +1,10 @@
+#ifndef PYTHONIC_INCLUDE_NUMPY_MULTIPLY_REDUCE_HPP
+#define PYTHONIC_INCLUDE_NUMPY_MULTIPLY_REDUCE_HPP
+
+#define UFUNC_NAME multiply
+#define UFUNC_INAME imul
+#include "pythonic/include/numpy/ufunc_reduce.hpp"
+#undef UFUNC_NAME
+#undef UFUNC_INAME
+
+#endif

--- a/pythran/pythonic/include/numpy/ufunc_reduce.hpp
+++ b/pythran/pythonic/include/numpy/ufunc_reduce.hpp
@@ -1,0 +1,42 @@
+#ifndef UFUNC_NAME
+#error missing UFUNC_NAME
+#endif
+#ifndef UFUNC_INAME
+#error missing UFUNC_INAME
+#endif
+
+// clang-format off
+#include INCLUDE_FILE(pythonic/include/operator_,UFUNC_INAME)
+// clang-format on
+#include "pythonic/include/numpy/reduce.hpp"
+#include "pythonic/include/utils/functor.hpp"
+
+PYTHONIC_NS_BEGIN
+
+namespace numpy
+{
+  namespace UFUNC_NAME
+  {
+
+    template <class Arg>
+    auto reduce(Arg &&arg)
+        -> decltype(numpy::reduce<operator_::functor::UFUNC_INAME>(
+            std::forward<Arg>(arg), 0L))
+    {
+      return numpy::reduce<operator_::functor::UFUNC_INAME>(
+          std::forward<Arg>(arg), 0L);
+    }
+    template <class... Args>
+    auto reduce(Args &&... args) -> typename std::enable_if<
+        sizeof...(Args) != 1,
+        decltype(numpy::reduce<operator_::functor::UFUNC_INAME>(
+            std::forward<Args>(args)...))>::type
+    {
+      return numpy::reduce<operator_::functor::UFUNC_INAME>(
+          std::forward<Args>(args)...);
+    }
+
+    DEFINE_FUNCTOR(pythonic::numpy::UFUNC_NAME, reduce);
+  }
+}
+PYTHONIC_NS_END

--- a/pythran/pythonic/include/utils/neutral.hpp
+++ b/pythran/pythonic/include/utils/neutral.hpp
@@ -2,9 +2,12 @@
 #define PYTHONIC_INCLUDE_UTILS_NEUTRAL_HPP
 
 #include "pythonic/include/operator_/iadd.hpp"
+#include "pythonic/include/operator_/iand.hpp"
+#include "pythonic/include/operator_/ior.hpp"
 #include "pythonic/include/operator_/imul.hpp"
 #include "pythonic/include/operator_/imax.hpp"
 #include "pythonic/include/operator_/imin.hpp"
+#include "pythonic/include/operator_/ixor.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -19,6 +22,20 @@ namespace utils
   };
   template <class T>
   T const neutral<operator_::functor::iadd, T>::value = 0;
+
+  template <class T>
+  struct neutral<operator_::functor::iand, T> {
+    static T const value;
+  };
+  template <class T>
+  T const neutral<operator_::functor::iand, T>::value = (T)-1;
+
+  template <class T>
+  struct neutral<operator_::functor::ior, T> {
+    static T const value;
+  };
+  template <class T>
+  T const neutral<operator_::functor::ior, T>::value = 0;
 
   template <class T>
   struct neutral<operator_::functor::imul, T> {
@@ -44,6 +61,14 @@ namespace utils
   template <class T>
   T const neutral<operator_::functor::imin, T>::value =
       std::numeric_limits<T>::max();
+
+  template <class T>
+  struct neutral<operator_::functor::ixor, T> {
+    static T const value;
+  };
+
+  template <class T>
+  T const neutral<operator_::functor::ixor, T>::value = 0;
 }
 PYTHONIC_NS_END
 

--- a/pythran/pythonic/numpy/add/reduce.hpp
+++ b/pythran/pythonic/numpy/add/reduce.hpp
@@ -1,0 +1,11 @@
+#ifndef PYTHONIC_NUMPY_ADD_REDUCE_HPP
+#define PYTHONIC_NUMPY_ADD_REDUCE_HPP
+
+#define UFUNC_NAME add
+#define UFUNC_INAME iadd
+#include "pythonic/include/numpy/add/reduce.hpp"
+#include "pythonic/numpy/ufunc_reduce.hpp"
+#undef UFUNC_NAME
+#undef UFUNC_INAME
+
+#endif

--- a/pythran/pythonic/numpy/bitwise_and/reduce.hpp
+++ b/pythran/pythonic/numpy/bitwise_and/reduce.hpp
@@ -1,0 +1,11 @@
+#ifndef PYTHONIC_NUMPY_BITWISE_AND_REDUCE_HPP
+#define PYTHONIC_NUMPY_BITWISE_AND_REDUCE_HPP
+
+#define UFUNC_NAME bitwise_and
+#define UFUNC_INAME iand
+#include "pythonic/include/numpy/bitwise_and/reduce.hpp"
+#include "pythonic/numpy/ufunc_reduce.hpp"
+#undef UFUNC_NAME
+#undef UFUNC_INAME
+
+#endif

--- a/pythran/pythonic/numpy/bitwise_or/reduce.hpp
+++ b/pythran/pythonic/numpy/bitwise_or/reduce.hpp
@@ -1,0 +1,11 @@
+#ifndef PYTHONIC_NUMPY_BITWISE_OR_REDUCE_HPP
+#define PYTHONIC_NUMPY_BITWISE_OR_REDUCE_HPP
+
+#define UFUNC_NAME bitwise_or
+#define UFUNC_INAME ior
+#include "pythonic/include/numpy/bitwise_or/reduce.hpp"
+#include "pythonic/numpy/ufunc_reduce.hpp"
+#undef UFUNC_NAME
+#undef UFUNC_INAME
+
+#endif

--- a/pythran/pythonic/numpy/bitwise_xor/reduce.hpp
+++ b/pythran/pythonic/numpy/bitwise_xor/reduce.hpp
@@ -1,0 +1,11 @@
+#ifndef PYTHONIC_NUMPY_BITWISE_XOR_REDUCE_HPP
+#define PYTHONIC_NUMPY_BITWISE_XOR_REDUCE_HPP
+
+#define UFUNC_NAME bitwise_xor
+#define UFUNC_INAME ixor
+#include "pythonic/include/numpy/bitwise_xor/reduce.hpp"
+#include "pythonic/numpy/ufunc_reduce.hpp"
+#undef UFUNC_NAME
+#undef UFUNC_INAME
+
+#endif

--- a/pythran/pythonic/numpy/fmax/reduce.hpp
+++ b/pythran/pythonic/numpy/fmax/reduce.hpp
@@ -1,0 +1,11 @@
+#ifndef PYTHONIC_NUMPY_FMAX_REDUCE_HPP
+#define PYTHONIC_NUMPY_FMAX_REDUCE_HPP
+
+#define UFUNC_NAME fmax
+#define UFUNC_INAME imax
+#include "pythonic/include/numpy/fmax/reduce.hpp"
+#include "pythonic/numpy/ufunc_reduce.hpp"
+#undef UFUNC_NAME
+#undef UFUNC_INAME
+
+#endif

--- a/pythran/pythonic/numpy/fmin/reduce.hpp
+++ b/pythran/pythonic/numpy/fmin/reduce.hpp
@@ -1,0 +1,11 @@
+#ifndef PYTHONIC_NUMPY_FMIN_REDUCE_HPP
+#define PYTHONIC_NUMPY_FMIN_REDUCE_HPP
+
+#define UFUNC_NAME fmin
+#define UFUNC_INAME imin
+#include "pythonic/include/numpy/fmin/reduce.hpp"
+#include "pythonic/numpy/ufunc_reduce.hpp"
+#undef UFUNC_NAME
+#undef UFUNC_INAME
+
+#endif

--- a/pythran/pythonic/numpy/maximum/reduce.hpp
+++ b/pythran/pythonic/numpy/maximum/reduce.hpp
@@ -1,0 +1,11 @@
+#ifndef PYTHONIC_NUMPY_MAXIMUM_REDUCE_HPP
+#define PYTHONIC_NUMPY_MAXIMUM_REDUCE_HPP
+
+#define UFUNC_NAME maximum
+#define UFUNC_INAME imax
+#include "pythonic/include/numpy/maximum/reduce.hpp"
+#include "pythonic/numpy/ufunc_reduce.hpp"
+#undef UFUNC_NAME
+#undef UFUNC_INAME
+
+#endif

--- a/pythran/pythonic/numpy/minimum/reduce.hpp
+++ b/pythran/pythonic/numpy/minimum/reduce.hpp
@@ -1,0 +1,11 @@
+#ifndef PYTHONIC_NUMPY_MINIMUM_REDUCE_HPP
+#define PYTHONIC_NUMPY_MINIMUM_REDUCE_HPP
+
+#define UFUNC_NAME minimum
+#define UFUNC_INAME imin
+#include "pythonic/include/numpy/minimum/reduce.hpp"
+#include "pythonic/numpy/ufunc_reduce.hpp"
+#undef UFUNC_NAME
+#undef UFUNC_INAME
+
+#endif

--- a/pythran/pythonic/numpy/multiply/reduce.hpp
+++ b/pythran/pythonic/numpy/multiply/reduce.hpp
@@ -1,0 +1,11 @@
+#ifndef PYTHONIC_NUMPY_MULTIPLY_REDUCE_HPP
+#define PYTHONIC_NUMPY_MULTIPLY_REDUCE_HPP
+
+#define UFUNC_NAME multiply
+#define UFUNC_INAME imul
+#include "pythonic/include/numpy/multiply/reduce.hpp"
+#include "pythonic/numpy/ufunc_reduce.hpp"
+#undef UFUNC_NAME
+#undef UFUNC_INAME
+
+#endif

--- a/pythran/pythonic/numpy/ufunc_reduce.hpp
+++ b/pythran/pythonic/numpy/ufunc_reduce.hpp
@@ -1,0 +1,9 @@
+#ifndef UFUNC_INAME
+#error missing UFUNC_INAME
+#endif
+
+// clang-format off
+#include INCLUDE_FILE(pythonic/operator_,UFUNC_INAME)
+// clang-format on
+#include "pythonic/numpy/reduce.hpp"
+#include "pythonic/utils/functor.hpp"

--- a/pythran/pythonic/utils/neutral.hpp
+++ b/pythran/pythonic/utils/neutral.hpp
@@ -3,8 +3,11 @@
 
 #include "pythonic/include/utils/neutral.hpp"
 #include "pythonic/operator_/iadd.hpp"
+#include "pythonic/operator_/iand.hpp"
+#include "pythonic/operator_/ior.hpp"
 #include "pythonic/operator_/imul.hpp"
 #include "pythonic/operator_/imax.hpp"
 #include "pythonic/operator_/imin.hpp"
+#include "pythonic/operator_/ixor.hpp"
 
 #endif

--- a/pythran/tables.py
+++ b/pythran/tables.py
@@ -162,6 +162,8 @@ def update_effects(self, node):
 
 
 BINARY_UFUNC = {"accumulate": FunctionIntr()}
+REDUCED_BINARY_UFUNC = {"accumulate": FunctionIntr(),
+                        "reduce": ConstFunctionIntr()}
 
 CLASSES = {
     "dtype": {
@@ -2876,7 +2878,7 @@ MODULES = {
         "abs": ConstFunctionIntr(signature=_numpy_unary_op_signature),
         "absolute": ConstFunctionIntr(signature=_numpy_ones_signature),
         "add": UFunc(
-            BINARY_UFUNC,
+            REDUCED_BINARY_UFUNC,
             signature=_numpy_binary_op_signature,
         ),
         "alen": ConstFunctionIntr(
@@ -3346,18 +3348,18 @@ MODULES = {
             ],
         ),
         "bitwise_and": UFunc(
-            BINARY_UFUNC,
+            REDUCED_BINARY_UFUNC,
             signature=_numpy_int_binary_op_signature
         ),
         "bitwise_not": ConstFunctionIntr(
             signature=_numpy_int_unary_op_signature
         ),
         "bitwise_or": UFunc(
-            BINARY_UFUNC,
+            REDUCED_BINARY_UFUNC,
             signature=_numpy_int_binary_op_signature
         ),
         "bitwise_xor": UFunc(
-            BINARY_UFUNC,
+            REDUCED_BINARY_UFUNC,
             signature=_numpy_int_binary_op_signature
         ),
         "bool": ConstFunctionIntr(signature=_bool_signature),
@@ -3705,8 +3707,8 @@ MODULES = {
         "float": ConstFunctionIntr(signature=_float_signature),
         "floor": ConstFunctionIntr(signature=_numpy_float_unary_op_signature),
         "floor_divide": UFunc(BINARY_UFUNC),
-        "fmax": UFunc(BINARY_UFUNC),
-        "fmin": UFunc(BINARY_UFUNC),
+        "fmax": UFunc(REDUCED_BINARY_UFUNC),
+        "fmin": UFunc(REDUCED_BINARY_UFUNC),
         "fmod": UFunc(BINARY_UFUNC),
         "frexp": ConstFunctionIntr(),
         "fromfunction": ConstFunctionIntr(),
@@ -3797,7 +3799,7 @@ MODULES = {
         "longlong": ConstFunctionIntr(signature=_int_signature),
         "max": ConstMethodIntr(signature=_numpy_unary_op_axis_signature),
         "maximum": UFunc(
-            BINARY_UFUNC,
+            REDUCED_BINARY_UFUNC,
             signature=_numpy_binary_op_signature
         ),
         "mean": ConstMethodIntr(),
@@ -3806,12 +3808,12 @@ MODULES = {
         ),
         "min": ConstMethodIntr(signature=_numpy_unary_op_axis_signature),
         "minimum": UFunc(
-            BINARY_UFUNC,
+            REDUCED_BINARY_UFUNC,
             signature=_numpy_binary_op_signature
         ),
         "mod": UFunc(BINARY_UFUNC),
         "multiply": UFunc(
-            BINARY_UFUNC,
+            REDUCED_BINARY_UFUNC,
             signature=_numpy_binary_op_signature,
         ),
         "nan": ConstantIntr(),

--- a/pythran/tests/test_numpy_ufunc_binary.py
+++ b/pythran/tests/test_numpy_ufunc_binary.py
@@ -17,6 +17,9 @@ class TestNumpyUFuncBinary(TestEnv):
 binary_ufunc = ([("numpy", k) for k, v in MODULES["numpy"].items() if isinstance(v, UFunc)] +
                 [("scipy.special", k) for k, v in MODULES["scipy"]["special"].items() if isinstance(v, UFunc)])
 
+reduced_ufunc = {'add', 'minimum', 'maximum', 'multiply', 'bitwise_or',
+                 'bitwise_and', 'bitwise_xor'}
+
 for ns, f in binary_ufunc:
     if 'bitwise_' in f or 'ldexp' in f or '_shift' in f :
         setattr(TestNumpyUFuncBinary, 'test_' + f, eval("lambda self: self.run_test('def np_{0}(a): from {1} import {0} ; return {0}(a,a)', numpy.ones(10, numpy.int32), np_{0}=[NDArray[numpy.int32,:]])".format(f, ns)))
@@ -28,6 +31,10 @@ for ns, f in binary_ufunc:
             # accumulation.
             setattr(TestNumpyUFuncBinary, 'test_accumulate_' + f, eval("lambda self: self.run_test('def np_{0}_accumulate(a): from {1} import {0} ; return {0}.accumulate(a)', numpy.ones(10, numpy.int32), np_{0}_accumulate=[NDArray[numpy.int32, :]])".format(f, ns)))
             setattr(TestNumpyUFuncBinary, 'test_accumulate_' + f + '_matrix', eval("lambda self: self.run_test('def np_{0}_matrix_accumulate(a): from {1} import {0} ; return {0}.accumulate(a)', numpy.ones((2,5), numpy.int32), np_{0}_matrix_accumulate=[NDArray[numpy.int32,:,:]])".format(f, ns)))
+        # Tests for reduction
+        if f in reduced_ufunc:
+            setattr(TestNumpyUFuncBinary, 'test_reduce_' + f, eval("lambda self: self.run_test('def np_{0}_reduce(a): from {1} import {0} ; return {0}.reduce(a)', numpy.ones(10, numpy.int32), np_{0}_reduce=[NDArray[numpy.int32, :]])".format(f, ns)))
+            setattr(TestNumpyUFuncBinary, 'test_reduce_' + f + '_matrix', eval("lambda self: self.run_test('def np_{0}_matrix_reduce(a): from {1} import {0} ; return {0}.reduce(a)', numpy.ones((2,5), numpy.int32), np_{0}_matrix_reduce=[NDArray[numpy.int32,:,:]])".format(f, ns)))
     else:
         if 'spherical' in f and 'scipy' in ns:
             setattr(TestNumpyUFuncBinary, 'test_' + f, eval("lambda self: self.run_test('def np_{0}(a): from {1} import {0}; import numpy; return {0}(numpy.array(a, dtype=int) +2 ,a)', numpy.ones(10), np_{0}=[NDArray[float, :]])".format(f, ns)))
@@ -60,3 +67,7 @@ for ns, f in binary_ufunc:
         if 'scipy' not in ns:
             setattr(TestNumpyUFuncBinary, 'test_accumulate_' + f, eval("lambda self: self.run_test('def np_{0}_accumulate(a): from {1} import {0} ; return {0}.accumulate(a)', numpy.ones(10), np_{0}_accumulate=[NDArray[float,:]])".format(f, ns)))
             setattr(TestNumpyUFuncBinary, 'test_accumulate_' + f + '_matrix', eval("lambda self: self.run_test('def np_{0}_matrix_accumulate(a): from {1} import {0} ; return {0}.accumulate(a)', numpy.ones((2,5)) - 0.2 , np_{0}_matrix_accumulate=[NDArray[float, :, :]])".format(f, ns)))
+        ## Tests for reduction
+        if f in reduced_ufunc:
+            setattr(TestNumpyUFuncBinary, 'test_reduce_' + f, eval("lambda self: self.run_test('def np_{0}_reduce(a): from {1} import {0} ; return {0}.reduce(a)', numpy.ones(10), np_{0}_reduce=[NDArray[float,:]])".format(f, ns)))
+            setattr(TestNumpyUFuncBinary, 'test_reduce_' + f + '_matrix', eval("lambda self: self.run_test('def np_{0}_matrix_reduce(a): from {1} import {0} ; return {0}.reduce(a)', numpy.ones((2,5)) - 0.2 , np_{0}_matrix_reduce=[NDArray[float, :, :]])".format(f, ns)))


### PR DESCRIPTION
Currently, only associative operators are supported due to a limitation in
numpy/reduce.hpp

Fix #844