### PR TITLE
Better document NDEBUG behavior

### DIFF
--- a/docs/MANUAL.rst
+++ b/docs/MANUAL.rst
@@ -383,6 +383,16 @@ they don't match any real Python type. **Any** Pythran type is valid as capsule
 parameter, but beware that non scalar or pointer types only make sense withing
 the Pythran context.
 
+Debug Mode
+----------
+
+Pythran honors the ``NDEBUG`` macro. If set through ``-DNDEBUG`` (which should
+be the default, check ``python-config --cflags``), it disables all ``assert
+statement`` and doesn't perform any runtime check for indexing bounds etc.
+However, if unset through ``-UNDEBUG``, all ``assert`` are executed and
+eventually raise an ``AssertionError``. Additionnaly, many internal checks are
+done and may fail with a C-ish assertion.
+
 Advanced Usage
 --------------
 
@@ -395,8 +405,7 @@ switch that stops the compilation process right after c++ code generation, so
 that you can inspect it.
 
 Want more performance? Big fan of ``-Ofast -march=native``? Pythran
-_automagically_ forwards these switches to the underlying compiler! Pythran is
-sensible to the ``-DNDEBUG`` switch too.
+_automagically_ forwards these switches to the underlying compiler!
 
 Tired of typing the same compiler switches again and again? Store them in
 ``$XDG_CONFIG_HOME/.pythranrc``!

--- a/pythran/pythonic/include/types/ndarray.hpp
+++ b/pythran/pythonic/include/types/ndarray.hpp
@@ -406,6 +406,21 @@ namespace types
     simd_iterator vend(vectorizer) const;
 #endif
 
+#ifndef NDEBUG
+    template <class IndicesTy>
+    bool inbound_indices(IndicesTy const &indices) const
+    {
+      auto const shp = sutils::array(shape());
+      for (size_t i = 0, n = indices.size(); i < n; ++i) {
+        auto const index = indices[i];
+        auto const dim = shp[i];
+        if (0 > index || index >= dim)
+          return false;
+      }
+      return true;
+    }
+#endif
+
     /* slice indexing */
     ndarray<T, sutils::push_front_t<pS, std::integral_constant<long, 1>>>
     operator[](none_type) const;
@@ -496,6 +511,7 @@ namespace types
     {
       if (i < 0)
         i += std::get<0>(_shape);
+      assert(0 <= i && i < std::get<0>(_shape));
       return fast(i);
     }
 
@@ -503,6 +519,7 @@ namespace types
     {
       if (i < 0)
         i += std::get<0>(_shape);
+      assert(0 <= i && i < std::get<0>(_shape));
       return std::move(*this).fast(i);
     }
 

--- a/pythran/pythonic/include/types/tuple.hpp
+++ b/pythran/pythonic/include/types/tuple.hpp
@@ -362,7 +362,7 @@ namespace types
 
     // Element access.
     reference fast(long n);
-    constexpr const_reference fast(long n) const noexcept;
+    const_reference fast(long n) const noexcept;
 #ifdef USE_XSIMD
     using simd_iterator = const_simd_nditerator<array_base>;
     using simd_iterator_nobroadcast = simd_iterator;
@@ -374,7 +374,7 @@ namespace types
 
     reference operator[](long __n);
 
-    constexpr const_reference operator[](long __n) const noexcept;
+    const_reference operator[](long __n) const noexcept;
 
     auto operator[](slice s) const -> decltype(array_base_slicer{}(*this, s))
     {

--- a/pythran/pythonic/include/utils/shared_ref.hpp
+++ b/pythran/pythonic/include/utils/shared_ref.hpp
@@ -48,8 +48,6 @@ namespace utils
     } * mem;
 
   public:
-    // This attributs exists for non-Python code to avoid #ifdef everywhere
-
     // Uninitialized ctor
     shared_ref(no_memory const &) noexcept;
 

--- a/pythran/pythonic/types/list.hpp
+++ b/pythran/pythonic/types/list.hpp
@@ -84,18 +84,27 @@ namespace types
   typename sliced_list<T, S>::const_reference
   sliced_list<T, S>::fast(long i) const
   {
-    return (*data)[slicing.get(i)];
+    assert(0 <= i && i < size());
+    auto const index = slicing.get(i);
+    assert(0 <= index && index < data->size());
+    return (*data)[index];
   }
   template <class T, class S>
   typename sliced_list<T, S>::const_reference sliced_list<T, S>::
   operator[](long i) const
   {
-    return (*data)[slicing.get(i)];
+    assert(i < size());
+    auto const index = slicing.get(i);
+    assert(0 <= index && index < data->size());
+    return (*data)[index];
   }
   template <class T, class S>
   typename sliced_list<T, S>::reference sliced_list<T, S>::operator[](long i)
   {
-    return (*data)[slicing.get(i)];
+    assert(i < size());
+    auto const index = slicing.get(i);
+    assert(0 <= index && index < data->size());
+    return (*data)[index];
   }
   template <class T, class S>
   sliced_list<T, S> sliced_list<T, S>::operator[](contiguous_slice s) const
@@ -139,7 +148,7 @@ namespace types
       data->erase(data->begin() + slicing.lower, data->begin() + slicing.upper);
       data->insert(data->begin() + slicing.lower, seq.begin(), seq.end());
     } else
-      assert(!"! implemented yet");
+      assert(!"not implemented yet");
     return *this;
   }
   template <class T, class S>
@@ -481,11 +490,13 @@ namespace types
   {
     if (n < 0)
       n += data->size();
+    assert(0 <= n && n < data->size());
     return fast(n);
   }
   template <class T>
   typename list<T>::const_reference list<T>::fast(long n) const
   {
+    assert(n < data->size());
     return (*data)[n];
   }
   template <class T>
@@ -493,6 +504,7 @@ namespace types
   {
     if (n < 0)
       n += data->size();
+    assert(0 <= n && n < data->size());
     return fast(n);
   }
 

--- a/pythran/pythonic/types/ndarray.hpp
+++ b/pythran/pythonic/types/ndarray.hpp
@@ -345,10 +345,11 @@ namespace types
                               array<Ty, M> const &indices,
                               pS const &shape) const
   {
-    return noffset<L - 1>{}(strides, indices, shape) +
-           strides[M - L] * ((indices[M - L] < 0)
-                                 ? indices[M - L] + std::get<M - L>(shape)
-                                 : indices[M - L]);
+    auto const index =
+        ((indices[M - L] < 0) ? indices[M - L] + std::get<M - L>(shape)
+                              : indices[M - L]);
+    assert(0 <= index and index < std::get<M - L>(shape));
+    return noffset<L - 1>{}(strides, indices, shape) + strides[M - L] * index;
   }
 
   template <>
@@ -365,8 +366,11 @@ namespace types
                               array<Ty, M> const &indices,
                               pS const &shape) const
   {
-    return (indices[M - 1] < 0) ? indices[M - 1] + std::get<M - 1>(shape)
-                                : indices[M - 1];
+    auto const index = (indices[M - 1] < 0)
+                           ? indices[M - 1] + std::get<M - 1>(shape)
+                           : indices[M - 1];
+    assert(0 <= index && index < std::get<M - 1>(shape));
+    return index;
   }
 
   /* constructors */
@@ -618,6 +622,7 @@ namespace types
   typename std::enable_if<std::is_integral<Ty>::value, T &>::type
   ndarray<T, pS>::fast(array<Ty, value> const &indices)
   {
+    assert(inbound_indices(indices));
     return *(buffer + noffset<std::tuple_size<pS>::value>{}(_strides, indices));
   }
 
@@ -626,6 +631,7 @@ namespace types
   typename std::enable_if<std::is_integral<Ty>::value, T>::type
   ndarray<T, pS>::fast(array<Ty, value> const &indices) const
   {
+    assert(inbound_indices(indices));
     return *(buffer + noffset<std::tuple_size<pS>::value>{}(_strides, indices));
   }
 

--- a/pythran/pythonic/types/tuple.hpp
+++ b/pythran/pythonic/types/tuple.hpp
@@ -220,13 +220,15 @@ namespace types
   template <typename T, size_t N, class V>
   typename array_base<T, N, V>::reference array_base<T, N, V>::fast(long n)
   {
+    assert(n < size());
     return buffer[n];
   }
 
   template <typename T, size_t N, class V>
-  constexpr typename array_base<T, N, V>::const_reference
+  typename array_base<T, N, V>::const_reference
   array_base<T, N, V>::fast(long n) const noexcept
   {
+    assert(n < size());
     return buffer[n];
   }
 
@@ -254,14 +256,18 @@ namespace types
   typename array_base<T, N, V>::reference array_base<T, N, V>::
   operator[](long __n)
   {
-    return buffer[__n < 0 ? (__n + size()) : __n];
+    auto const index = __n < 0 ? (__n + size()) : __n;
+    assert(0 <= index && index < size());
+    return buffer[index];
   }
 
   template <typename T, size_t N, class V>
-  constexpr typename array_base<T, N, V>::const_reference array_base<T, N, V>::
+  typename array_base<T, N, V>::const_reference array_base<T, N, V>::
   operator[](long __n) const noexcept
   {
-    return buffer[__n < 0 ? (__n + size()) : __n];
+    auto const index = __n < 0 ? (__n + size()) : __n;
+    assert(0 <= index && index < size());
+    return buffer[index];
   }
 
   template <typename T, size_t N, class V>

--- a/pythran/pythonic/utils/shared_ref.hpp
+++ b/pythran/pythonic/utils/shared_ref.hpp
@@ -86,12 +86,14 @@ namespace utils
   template <class T>
   T &shared_ref<T>::operator*() const noexcept
   {
+    assert(mem);
     return mem->ptr;
   }
 
   template <class T>
   T *shared_ref<T>::operator->() const noexcept
   {
+    assert(mem);
     return &mem->ptr;
   }
 
@@ -110,12 +112,14 @@ namespace utils
   template <class T>
   void shared_ref<T>::external(extern_type obj_ptr)
   {
+    assert(mem);
     mem->foreign = obj_ptr;
   }
 
   template <class T>
   inline extern_type shared_ref<T>::get_foreign()
   {
+    assert(mem);
     return mem->foreign;
   }
 
@@ -136,6 +140,7 @@ namespace utils
   template <class T>
   void shared_ref<T>::acquire()
   {
+    assert(mem);
     ++mem->count;
   }
 }


### PR DESCRIPTION
Use more asserts throughout the code to check for null pointers and buffer
overflow.

As this behavior is now documented, it should be somehow enforced by more
defensive coding under the protection of NDEBUG.

At some point, it may be interesting to separate checks that also exist in
Python (like IndexError or AssertionError) from internal checks...

This improves the situation wrt #416 but doesn't actually fixes it until the
check split isn't done.