### PR TITLE
Fix global effect computation for partial functions

### DIFF
--- a/pythran/analyses/argument_effects.py
+++ b/pythran/analyses/argument_effects.py
@@ -169,15 +169,24 @@ class ArgumentEffects(ModuleAnalysis):
                     if func_alias not in self.node_to_functioneffect:
                         continue
 
-                    func_alias = self.node_to_functioneffect[func_alias]
-                    predecessors = self.result.predecessors(func_alias)
+                    if func_alias is MODULES['functools']['partial']:
+                        base_func_aliases = self.aliases[node.args[0]]
+                        fe = self.node_to_functioneffect[func_alias]
+                        if len(base_func_aliases) == 1:
+                            base_func_alias = next(iter(base_func_aliases))
+                            fe = self.node_to_functioneffect.get(
+                                base_func_alias,
+                                fe)
+                    else:
+                        fe = self.node_to_functioneffect[func_alias]
+                    predecessors = self.result.predecessors(fe)
                     if self.current_function not in predecessors:
                         self.result.add_edge(
                             self.current_function,
-                            func_alias,
+                            fe,
                             effective_parameters=[],
                             formal_parameters=[])
-                    edge = self.result.edges[self.current_function, func_alias]
+                    edge = self.result.edges[self.current_function, fe]
                     edge["effective_parameters"].append(n)
                     edge["formal_parameters"].append(i)
         self.generic_visit(node)

--- a/pythran/analyses/extended_syntax_check.py
+++ b/pythran/analyses/extended_syntax_check.py
@@ -49,7 +49,7 @@ class ExtendedSyntaxCheck(ModuleAnalysis):
                 raise PythranSyntaxError(
                     ("Cannot modify '{}': global variables are constant "
                      "in pythran.").format(alias.name),
-                    node)
+                    arg.func)
 
     def visit_FunctionDef(self, node):
         if node.name in self.functions:

--- a/pythran/pythonic/include/types/list.hpp
+++ b/pythran/pythonic/include/types/list.hpp
@@ -166,6 +166,9 @@ namespace types
     intptr_t id() const;
 
     long count(T const &x) const;
+    template <class Tp, class Sp>
+    friend std::ostream &operator<<(std::ostream &os,
+                                    sliced_list<Tp, Sp> const &v);
   };
 
   /* list */
@@ -351,6 +354,15 @@ namespace types
     {
       shape_t res;
       details::init_shape(res, *this, utils::int_<value>{});
+      return res;
+    }
+
+    template <class Tp, size_t N, class V>
+    operator array_base<Tp, N, V>() const
+    {
+      assert(size() == N && "consistent size");
+      array_base<Tp, N, V> res;
+      std::copy(begin(), end(), res.begin());
       return res;
     }
   };

--- a/pythran/pythonic/include/types/numpy_iexpr.hpp
+++ b/pythran/pythonic/include/types/numpy_iexpr.hpp
@@ -250,6 +250,17 @@ namespace types
       return {*this, filter};
     }
 
+    template <class F> // indexing through an array of indices -- a view
+    typename std::enable_if<is_numexpr_arg<F>::value &&
+                                !is_array_index<F>::value &&
+                                !std::is_same<bool, typename F::dtype>::value &&
+                                !is_pod_array<F>::value,
+                            numpy_vexpr<numpy_iexpr, F>>::type
+    operator[](F const &filter)
+    {
+      return {*this, filter};
+    }
+
     template <class Ty>
     auto operator[](std::tuple<Ty> const &index) const
         -> decltype((*this)[std::get<0>(index)])

--- a/pythran/pythonic/include/types/tuple.hpp
+++ b/pythran/pythonic/include/types/tuple.hpp
@@ -448,6 +448,11 @@ namespace types
       return (*this)[s];
     }
 
+    bool operator!() const
+    {
+      return N == 0;
+    }
+
     /* array */
     template <class T1, size_t N1, class Version1>
     friend std::ostream &

--- a/pythran/pythonic/types/list.hpp
+++ b/pythran/pythonic/types/list.hpp
@@ -117,6 +117,21 @@ namespace types
   {
     return {data, slicing * s.normalize(this->size())};
   }
+  // io
+  template <class Tp, class Sp>
+  std::ostream &operator<<(std::ostream &os, sliced_list<Tp, Sp> const &v)
+  {
+    os << '[';
+    auto iter = v.begin();
+    if (iter != v.end()) {
+      while (iter + 1 != v.end()) {
+        os << *iter << ", ";
+        ++iter;
+      }
+      os << *iter;
+    }
+    return os << ']';
+  }
 
   // comparison
   template <class T, class S>

--- a/pythran/tests/test_advanced.py
+++ b/pythran/tests/test_advanced.py
@@ -412,3 +412,22 @@ def combiner_on_empty_list():
                 case = 2
             return case'''
         self.run_test(code, 3, reserved_identifier0=[int])
+
+    def test_global_effects_partial0(self):
+        code = '''
+g = [1, 2]
+
+def return_partial(x):
+    def partial(_):
+        return x
+
+    return partial
+
+def call_partial(fct):
+    return return_partial(fct)
+
+all_commands = call_partial(g)
+
+def global_effects_partial0(l):
+    return all_commands(l)'''
+        self.run_test(code, 3, global_effects_partial0=[int])

--- a/pythran/tests/test_typing.py
+++ b/pythran/tests/test_typing.py
@@ -319,9 +319,25 @@ def s_perm(seq):
             new_items += [item + seq for i in range(1)]
         return new_items
 def recursive_interprocedural_typing1(c):
-    l = [1,2,c]
+    l = [1,2] * c
     return s_perm(l)'''
         self.run_test(code, 3, recursive_interprocedural_typing1=[int])
+
+    @unittest.skip("bad typing: recursion and specialized list type")
+    def test_recursive_interprocedural_typing2(self):
+        code = '''
+def s_perm(seq):
+    if not seq:
+        return [[]]
+    else:
+        new_items = []
+        for item in s_perm(seq[:-1]):
+            new_items += [item + seq for i in range(1)]
+        return new_items
+def recursive_interprocedural_typing2(c):
+    l = [1,2,c]
+    return s_perm(l)'''
+        self.run_test(code, 3, recursive_interprocedural_typing2=[int])
 
     def test_print_numpy_types(self):
         self.run_test('''


### PR DESCRIPTION
As a side effect, unveil a few bugs in interprocedural typing, some of them
won't be fixed by this commit but still referenced in a skipped test case.

Fix #1579