### PR TITLE
numpy.median: Do not mutate argument inplace

### DIFF
--- a/pythran/pythonic/numpy/median.hpp
+++ b/pythran/pythonic/numpy/median.hpp
@@ -67,16 +67,14 @@ namespace numpy
     size_t n = arr.flat_size();
     T *tmp = new T[n];
     std::copy(arr.buffer, arr.buffer + n, tmp);
-    std::nth_element(arr.buffer, arr.buffer + n / 2, arr.buffer + n,
-                     comparator<T>{});
-    T t0 = arr.buffer[n / 2];
+    std::nth_element(tmp, tmp + n / 2, tmp + n, comparator<T>{});
+    T t0 = tmp[n / 2];
     if (n % 2 == 1) {
       delete[] tmp;
       return t0;
     } else {
-      std::nth_element(arr.buffer, arr.buffer + n / 2 - 1, arr.buffer + n / 2,
-                       comparator<T>{});
-      T t1 = arr.buffer[n / 2 - 1];
+      std::nth_element(tmp, tmp + n / 2 - 1, tmp + n / 2, comparator<T>{});
+      T t1 = tmp[n / 2 - 1];
       delete[] tmp;
       return (t0 + t1) / 2.;
     }

--- a/pythran/tests/test_numpy_func0.py
+++ b/pythran/tests/test_numpy_func0.py
@@ -258,6 +258,9 @@ def np_rosen_der(x):
     def test_median5(self):
         self.run_test("def np_median5(a): from numpy import median ; return median(a, -1)", numpy.array([[[1], [2], [3]], [[4],[5],[6]]]), np_median5=[NDArray[int,:,:,:]])
 
+    def test_median6(self):
+        self.run_test("def np_median6(l): from numpy import median ; return l + median(l)", numpy.array([3, 1]), np_median6=[NDArray[int, :]])
+
     def test_mean0(self):
         self.run_test("def np_mean0(a): from numpy import mean ; return mean(a)", numpy.array([[1, 2], [3, 4]]), np_mean0=[NDArray[int,:,:]])
 


### PR DESCRIPTION
Makes sure that the argument is not mutated in place in the
re-implementation fo numpy.median.

Fixes  #1588