### PR TITLE
Wrap new-delete in unique_ptr

### DIFF
--- a/pythran/pythonic/builtins/str/replace.hpp
+++ b/pythran/pythonic/builtins/str/replace.hpp
@@ -6,6 +6,8 @@
 #include "pythonic/types/str.hpp"
 #include "pythonic/utils/functor.hpp"
 
+#include <memory>
+
 PYTHONIC_NS_BEGIN
 
 namespace builtins
@@ -29,20 +31,19 @@ namespace builtins
         size_t n =
             1 + std::max(self.size(), self.size() * (1 + new_pattern.size()) /
                                           (1 + old_pattern.size()));
-        char *buffer = new char[n];
-        char *iter = buffer;
+        std::unique_ptr<char[]> buffer{new char[n]};
+        char *iter = buffer.get();
         do {
           iter = std::copy(haystack, haystack_next, iter);
           iter = std::copy(new_needle, new_needle_end, iter);
           --count;
           haystack = haystack_next + old_pattern.size();
-          assert(size_t(iter - buffer) < n);
+          assert(size_t(iter - buffer.get()) < n);
         } while (count && (haystack_next = strstr(haystack, needle)));
 
         std::copy(haystack, self.c_str() + self.size() + 1, iter);
 
-        types::str replaced(buffer);
-        delete[] buffer;
+        types::str replaced(buffer.get());
         return replaced;
       }
     }

--- a/pythran/pythonic/numpy/base_repr.hpp
+++ b/pythran/pythonic/numpy/base_repr.hpp
@@ -6,6 +6,8 @@
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/types/ndarray.hpp"
 
+#include <memory>
+
 PYTHONIC_NS_BEGIN
 
 namespace numpy
@@ -42,11 +44,10 @@ namespace numpy
 
   types::str base_repr(long number, long base, long padding)
   {
-    char *mem = new char[sizeof(number) * 8 + 1 + padding];
-    std::fill(mem, mem + padding, '0');
-    details::itoa(number, mem + padding, base);
-    auto res = types::str(mem);
-    delete[] mem;
+    std::unique_ptr<char[]> mem{new char[sizeof(number) * 8 + 1 + padding]};
+    std::fill(mem.get(), mem.get() + padding, '0');
+    details::itoa(number, mem.get() + padding, base);
+    auto res = types::str(mem.get());
     return res;
   }
 }

--- a/pythran/pythonic/numpy/binary_repr.hpp
+++ b/pythran/pythonic/numpy/binary_repr.hpp
@@ -5,6 +5,8 @@
 
 #include "pythonic/numpy/base_repr.hpp"
 
+#include <memory>
+
 PYTHONIC_NS_BEGIN
 
 namespace numpy
@@ -36,10 +38,9 @@ namespace numpy
     if (number >= 0)
       return base_repr(number, 2, width - out.size());
     else {
-      char *mem = new char[width + 1];
-      details::int2bin(number, mem, width);
-      auto res = types::str(mem);
-      delete[] mem;
+      std::unique_ptr<char[]> mem{new char[width + 1]};
+      details::int2bin(number, mem.get(), width);
+      auto res = types::str(mem.get());
       return res;
     }
   }

--- a/pythran/pythonic/numpy/median.hpp
+++ b/pythran/pythonic/numpy/median.hpp
@@ -8,6 +8,7 @@
 #include "pythonic/numpy/asarray.hpp"
 #include "pythonic/numpy/sort.hpp"
 #include <algorithm>
+#include <memory>
 
 PYTHONIC_NS_BEGIN
 
@@ -25,12 +26,12 @@ namespace numpy
           std::accumulate(tmp_shape.begin() + axis, tmp_shape.end(), 1L,
                           std::multiplies<long>());
       long const buffer_size = tmp_shape[axis];
-      T *buffer = new T[buffer_size];
+      std::unique_ptr<T[]> buffer{new T[buffer_size]};
       const long stepper = step / tmp_shape[axis];
       const long n = tmp.flat_size() / tmp_shape[axis] * step;
       long ith = 0, nth = 0;
       for (long i = 0; i < n; i += step) {
-        T *buffer_iter = buffer;
+        T *buffer_iter = buffer.get();
         T const *iter = tmp.buffer + ith;
         T const *iend = iter + step;
         while (iter != iend) {
@@ -38,15 +39,15 @@ namespace numpy
           iter += stepper;
         }
         if (buffer_size % 2 == 1) {
-          std::nth_element(buffer, buffer + buffer_size / 2, buffer_iter,
-                           comparator<T>{});
+          std::nth_element(buffer.get(), buffer.get() + buffer_size / 2,
+                           buffer_iter, comparator<T>{});
           *out++ = buffer[buffer_size / 2];
         } else {
-          std::nth_element(buffer, buffer + buffer_size / 2, buffer_iter,
-                           comparator<T>{});
+          std::nth_element(buffer.get(), buffer.get() + buffer_size / 2,
+                           buffer_iter, comparator<T>{});
           auto t0 = buffer[buffer_size / 2];
-          std::nth_element(buffer, buffer + buffer_size / 2 - 1,
-                           buffer + buffer_size / 2, comparator<T>{});
+          std::nth_element(buffer.get(), buffer.get() + buffer_size / 2 - 1,
+                           buffer.get() + buffer_size / 2, comparator<T>{});
           auto t1 = buffer[buffer_size / 2 - 1];
           *out++ = (t0 + t1) / double(2);
         }
@@ -56,7 +57,6 @@ namespace numpy
           ith = nth;
         }
       }
-      delete[] buffer;
     }
   }
 
@@ -65,17 +65,17 @@ namespace numpy
                                           types::none_type)
   {
     size_t n = arr.flat_size();
-    T *tmp = new T[n];
-    std::copy(arr.buffer, arr.buffer + n, tmp);
-    std::nth_element(tmp, tmp + n / 2, tmp + n, comparator<T>{});
+    std::unique_ptr<T[]> tmp{new T[n]};
+    std::copy(arr.buffer, arr.buffer + n, tmp.get());
+    std::nth_element(tmp.get(), tmp.get() + n / 2, tmp.get() + n,
+                     comparator<T>{});
     T t0 = tmp[n / 2];
     if (n % 2 == 1) {
-      delete[] tmp;
       return t0;
     } else {
-      std::nth_element(tmp, tmp + n / 2 - 1, tmp + n / 2, comparator<T>{});
+      std::nth_element(tmp.get(), tmp.get() + n / 2 - 1, tmp.get() + n / 2,
+                       comparator<T>{});
       T t1 = tmp[n / 2 - 1];
-      delete[] tmp;
       return (t0 + t1) / 2.;
     }
   }

--- a/pythran/pythonic/numpy/sort.hpp
+++ b/pythran/pythonic/numpy/sort.hpp
@@ -4,6 +4,7 @@
 #include "pythonic/include/numpy/sort.hpp"
 
 #include <algorithm>
+#include <memory>
 
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/types/ndarray.hpp"
@@ -96,11 +97,11 @@ namespace numpy
         const long stepper = step / out_shape[axis];
         const long n = flat_size / out_shape[axis];
         long ith = 0, nth = 0;
-        T *buffer = new T[buffer_size];
+        std::unique_ptr<T[]> buffer{new T[buffer_size]};
         for (long i = 0; i < n; i++) {
           for (long j = 0; j < buffer_size; ++j)
             buffer[j] = out.buffer[ith + j * stepper];
-          sorter(buffer, buffer + buffer_size, comparator<T>{});
+          sorter(buffer.get(), buffer.get() + buffer_size, comparator<T>{});
           for (long j = 0; j < buffer_size; ++j)
             out.buffer[ith + j * stepper] = buffer[j];
 
@@ -109,7 +110,6 @@ namespace numpy
             ith = ++nth;
           }
         }
-        delete[] buffer;
       }
     }
   }

--- a/pythran/pythonic/types/file.hpp
+++ b/pythran/pythonic/types/file.hpp
@@ -20,6 +20,7 @@
 #include <string>
 #include <cstdio>
 #include <unistd.h>
+#include <memory>
 
 PYTHONIC_NS_BEGIN
 
@@ -158,11 +159,11 @@ namespace types
     seek(0, SEEK_END);
     size = size < 0 ? tell() - curr_pos : size;
     seek(curr_pos);
-    char *content = new char[size + 1];
+    std::unique_ptr<char[]> content{new char[size + 1]};
     // This part needs a new implementation of types::str(char*) to avoid
     // unnecessary copy.
-    types::str res(content, fread(content, sizeof(char), size, **data));
-    delete[] content;
+    types::str res(content.get(),
+                   fread(content.get(), sizeof(char), size, **data));
     return res;
   }
 


### PR DESCRIPTION
`new` is used in few places to allocate temporary buffers, work and them
and `delete` them shortly after. Some of the operations done between the
new and delete can be non-`noexcept`, so it is safer to use a `unique_ptr`
to ensure memory release even in (improbable) case of exception.