### PR TITLE
numpy::base_repr: improve implementation

### DIFF
--- a/pythran/pythonic/include/types/str.hpp
+++ b/pythran/pythonic/include/types/str.hpp
@@ -133,6 +133,7 @@ namespace types
 
     types::str &operator+=(types::str const &s);
 
+    container_type &get_data();
     container_type const &get_data() const;
 
     long size() const;

--- a/pythran/pythonic/types/str.hpp
+++ b/pythran/pythonic/types/str.hpp
@@ -357,6 +357,11 @@ namespace types
     return *this;
   }
 
+  str::container_type &str::get_data()
+  {
+    return *data;
+  }
+
   str::container_type const &str::get_data() const
   {
     return *data;

--- a/pythran/tests/test_numpy_func2.py
+++ b/pythran/tests/test_numpy_func2.py
@@ -412,6 +412,15 @@ def test_copy0(x):
     def test_base_repr4(self):
         self.run_test("def np_base_repr4(a): from numpy import base_repr ; return base_repr(a, 16)", 32, np_base_repr4=[int])
 
+    def test_base_repr5(self):
+        self.run_test("def np_base_repr5(a): from numpy import base_repr ; return base_repr(a)", -5, np_base_repr5=[int])
+
+    def test_base_repr6(self):
+        self.run_test("def np_base_repr6(a): from numpy import base_repr ; return base_repr(a)", 0, np_base_repr6=[int])
+
+    def test_base_repr7(self):
+        self.run_test("def np_base_repr7(a): from numpy import base_repr ; return base_repr(a,5)", 0, np_base_repr7=[int])
+
     def test_average0(self):
         self.run_test("def np_average0(a): from numpy import average ; return average(a)", numpy.arange(10), np_average0=[NDArray[int,:]])
 


### PR DESCRIPTION
Improve the numpy.base_repr implementation by:

- avoiding extra buffer allocation
- only allocate the required memory