### PR TITLE
builtins::bin: avoid use of std::osstream

### DIFF
--- a/pythran/pythonic/builtins/bin.hpp
+++ b/pythran/pythonic/builtins/bin.hpp
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 
 PYTHONIC_NS_BEGIN
 
@@ -18,7 +19,23 @@ namespace builtins
   bin(T const &v)
   {
     using UT = typename std::make_unsigned<T>::type;
-    if (v == T{0})
+    if (v < T{0})
+      if (v == std::numeric_limits<T>::min()) {
+        // In this special case, calling -v would overflow so
+        // a special case is needed.
+        types::str res;
+        auto &backend = res.chars();
+        backend.resize(8 * sizeof(T) + 3);
+        auto it = backend.begin();
+        *it++ = '-';
+        *it++ = '0';
+        *it++ = 'b';
+        *it++ = '1';
+        std::fill(it, backend.end(), '0');
+        return res;
+      } else
+        return "-" + bin(-v);
+    else if (v == T{0})
       return "0b0";
     else {
       // Due to rounding errors, we cannot use std::log2(v)

--- a/pythran/pythonic/include/builtins/bin.hpp
+++ b/pythran/pythonic/include/builtins/bin.hpp
@@ -5,12 +5,15 @@
 
 #include "pythonic/include/types/str.hpp"
 
+#include <type_traits>
+
 PYTHONIC_NS_BEGIN
 
 namespace builtins
 {
   template <class T>
-  types::str bin(T const &v);
+  typename std::enable_if<std::is_scalar<T>::value, types::str>::type
+  bin(T const &v);
 
   DEFINE_FUNCTOR(pythonic::builtins, bin);
 }

--- a/pythran/tests/test_base.py
+++ b/pythran/tests/test_base.py
@@ -1,4 +1,6 @@
 import numpy
+import pytest
+import sys
 import unittest
 
 from pythran.tests import TestEnv
@@ -421,6 +423,17 @@ def nested_def(a):
 
     def test_bin(self):
         self.run_test("def bin_(a): return bin(a)", 54321, bin_=[int])
+
+    def test_bin2(self):
+        self.run_test("def bin2_(a): return bin(a)", -543, bin2_=[int])
+
+    @pytest.mark.skipif(sys.platform == "win32",
+                        reason="Windows uses long of 32-bit, this test assumes they are 64-bit")
+    def test_bin3(self):
+        self.run_test("def bin3_(a): return bin(a)", -sys.maxsize - 1, bin3_=[int])
+
+    def test_bin4(self):
+        self.run_test("def bin4_(a): return bin(a)", -1, bin4_=[int])
 
     def test_chr(self):
         self.run_test("def chr_(a): return chr(a)", 42, chr_=[int])


### PR DESCRIPTION
The final length of the string representation can be easily computed
head of time so a stream string is a bit overkill. Prefer a regular
string with storage reserved in advance.

[Quickbench](https://quick-bench.com/q/teJB_p3MpMNwPDqXNnCaPqVng6w) also says this is more efficient (but to be honest, this code will never end up in a critical compute intensive path).