### PR TITLE
types::str: remove get_data since it duplicates chars

### DIFF
--- a/pythran/pythonic/builtins/str/__mod__.hpp
+++ b/pythran/pythonic/builtins/str/__mod__.hpp
@@ -34,21 +34,21 @@ namespace builtins
     template <class T>
     types::str __mod__(types::str const &s, T const &arg)
     {
-      const boost::format fmter(s.get_data());
+      const boost::format fmter(s.chars());
       return (boost::format(fmter) % arg).str();
     }
 
     template <class... Ts>
     types::str __mod__(types::str const &s, std::tuple<Ts...> const &args)
     {
-      boost::format fmter(s.get_data());
+      boost::format fmter(s.chars());
       details::fmt(fmter, args, utils::int_<sizeof...(Ts)>());
       return fmter.str();
     }
     template <size_t N, class T>
     types::str __mod__(types::str const &s, types::array<T, N> const &args)
     {
-      boost::format fmter(s.get_data());
+      boost::format fmter(s.chars());
       details::fmt(fmter, args, utils::int_<N>());
       return fmter.str();
     }

--- a/pythran/pythonic/include/types/str.hpp
+++ b/pythran/pythonic/include/types/str.hpp
@@ -133,20 +133,17 @@ namespace types
 
     types::str &operator+=(types::str const &s);
 
-    container_type &get_data();
-    container_type const &get_data() const;
-
     long size() const;
     iterator begin() const;
     reverse_iterator rbegin() const;
     iterator end() const;
     reverse_iterator rend() const;
     auto c_str() const -> decltype(data->c_str());
-    std::string &chars()
+    container_type &chars()
     {
       return *data;
     }
-    std::string const &chars() const
+    container_type const &chars() const
     {
       return *data;
     }

--- a/pythran/pythonic/numpy/base_repr.hpp
+++ b/pythran/pythonic/numpy/base_repr.hpp
@@ -28,14 +28,14 @@ namespace numpy
     res.resize(ndigits + effective_padding + (number < 0 ? 1 : 0));
 
     // Apply negative sign
-    auto it = res.get_data().begin();
+    auto it = res.chars().begin();
     if (number < 0)
       *it++ = '-';
 
     // Apply padding
     std::fill(it, std::next(it, effective_padding), '0');
 
-    auto rit = res.get_data().rbegin();
+    auto rit = res.chars().rbegin();
     long quotient = std::labs(number);
 
     do {

--- a/pythran/pythonic/numpy/fromstring.hpp
+++ b/pythran/pythonic/numpy/fromstring.hpp
@@ -33,8 +33,7 @@ namespace numpy
         current = next + 1;
         next = string.find_first_of(sep, current);
         typename dtype::type item;
-        std::istringstream iss(
-            string.substr(current, next - current).get_data());
+        std::istringstream iss(string.substr(current, next - current).chars());
         iss >> item;
         res.push_back(item);
       } while (next != types::str::npos && ++numsplit < count);

--- a/pythran/pythonic/types/str.hpp
+++ b/pythran/pythonic/types/str.hpp
@@ -173,7 +173,7 @@ namespace types
   sliced_str<S>::operator long() const
   {
     long out;
-    std::istringstream iss(str(*this).get_data());
+    std::istringstream iss(str(*this).chars());
     iss >> out;
     return out;
   }
@@ -226,7 +226,7 @@ namespace types
   {
     if (slicing.step == 1) {
       data->erase(slicing.lower, slicing.upper);
-      data->insert(slicing.lower, s.get_data());
+      data->insert(slicing.lower, s.chars());
     } else
       assert("! implemented yet");
     return *this;
@@ -355,16 +355,6 @@ namespace types
   {
     *data += *s.data;
     return *this;
-  }
-
-  str::container_type &str::get_data()
-  {
-    return *data;
-  }
-
-  str::container_type const &str::get_data() const
-  {
-    return *data;
   }
 
   long str::size() const
@@ -560,7 +550,7 @@ namespace types
 
   str operator+(str const &self, str const &other)
   {
-    return str(self.get_data() + other.get_data());
+    return str(self.chars() + other.chars());
   }
 
   template <size_t N>
@@ -568,7 +558,7 @@ namespace types
   {
     std::string s;
     s.reserve(self.size() + N);
-    s += self.get_data();
+    s += self.chars();
     s += other;
     return {std::move(s)};
   }
@@ -579,7 +569,7 @@ namespace types
     std::string s;
     s.reserve(other.size() + N);
     s += self;
-    s += other.get_data();
+    s += other.chars();
     return {std::move(s)};
   }
 
@@ -647,7 +637,7 @@ namespace std
   size_t hash<pythonic::types::str>::
   operator()(const pythonic::types::str &x) const
   {
-    return hash<std::string>()(x.get_data());
+    return hash<std::string>()(x.chars());
   }
 
   template <size_t I>


### PR DESCRIPTION
`types::str::get_data` and `types::str::chars` basically does the same thing. Remove `types::str::get_data` and
only use chars in order to avoid duplicated API.