### PR TITLE
Use range values to fasten slice computation

### DIFF
--- a/pythran/backend.py
+++ b/pythran/backend.py
@@ -1007,8 +1007,11 @@ class CxxFunction(ast.NodeVisitor):
             args.append(arg)
 
         if node.step is None or (isnum(node.step) and node.step.value == 1):
-            return "pythonic::types::contiguous_slice({},{})".format(args[0],
-                                                                     args[1])
+            if self.all_positive(node.lower) and self.all_positive(node.upper):
+                builder = "pythonic::types::fast_contiguous_slice({},{})"
+            else:
+                builder = "pythonic::types::contiguous_slice({},{})"
+            return builder.format(args[0], args[1])
         else:
             return "pythonic::types::slice({},{},{})".format(*args)
 

--- a/pythran/pythonic/include/types/dynamic_tuple.hpp
+++ b/pythran/pythonic/include/types/dynamic_tuple.hpp
@@ -150,6 +150,12 @@ namespace types
       return {begin() + ns.lower, begin() + ns.upper};
     }
 
+    dynamic_tuple operator[](fast_contiguous_slice const &s) const
+    {
+      auto ns = s.normalize(size());
+      return {begin() + ns.lower, begin() + ns.upper};
+    }
+
     using shape_t = typename shape_builder<dynamic_tuple, value>::type;
     template <size_t I>
     auto shape() const

--- a/pythran/pythonic/include/types/ndarray.hpp
+++ b/pythran/pythonic/include/types/ndarray.hpp
@@ -421,12 +421,17 @@ namespace types
     ndarray<T, sutils::push_front_t<pS, std::integral_constant<long, 1>>>
     operator[](none_type) const;
 
-    numpy_gexpr<ndarray const &, normalized_slice>
-    operator[](slice const &s) const &;
-    numpy_gexpr<ndarray, normalized_slice> operator[](slice const &s) && ;
+    template <class S>
+    typename std::enable_if<is_slice<S>::value,
+                            numpy_gexpr<ndarray const &, normalize_t<S>>>::type
+    operator[](S const &s) const &;
 
-    numpy_gexpr<ndarray const &, contiguous_normalized_slice>
-    operator[](contiguous_slice const &s) const;
+    template <class S>
+        typename std::enable_if<
+            is_slice<S>::value,
+            numpy_gexpr<ndarray const &, normalize_t<S>>>::type
+        operator[](S const &s) &&
+        ;
 
     long size() const;
 

--- a/pythran/pythonic/include/types/ndarray.hpp
+++ b/pythran/pythonic/include/types/ndarray.hpp
@@ -427,9 +427,8 @@ namespace types
     operator[](S const &s) const &;
 
     template <class S>
-        typename std::enable_if<
-            is_slice<S>::value,
-            numpy_gexpr<ndarray const &, normalize_t<S>>>::type
+        typename std::enable_if<is_slice<S>::value,
+                                numpy_gexpr<ndarray, normalize_t<S>>>::type
         operator[](S const &s) &&
         ;
 

--- a/pythran/pythonic/include/types/numpy_broadcast.hpp
+++ b/pythran/pythonic/include/types/numpy_broadcast.hpp
@@ -102,11 +102,10 @@ namespace types
     }
 
     T const &operator[](long i) const;
-    broadcasted const &operator[](slice s) const
-    {
-      return *this;
-    }
-    broadcasted const &operator[](contiguous_slice s) const
+
+    template <class S>
+    typename std::enable_if<is_slice<S>::value, broadcasted const &>::type
+    operator[](S s) const
     {
       return *this;
     }
@@ -126,14 +125,13 @@ namespace types
     simd_iterator vend(vectorizer) const;
 #endif
 
-    broadcasted const &operator()(slice s) const
+    template <class S>
+    typename std::enable_if<is_slice<S>::value, broadcasted const &>::type
+    operator()(S s) const
     {
       return *this;
     }
-    broadcasted const &operator()(contiguous_slice s) const
-    {
-      return *this;
-    }
+
     T operator()(long) const
     {
       return ref;
@@ -143,13 +141,11 @@ namespace types
     auto operator()(long arg0, Arg1 &&arg1, Args &&... args) const
         -> decltype(ref(std::forward<Arg1>(arg1), std::forward<Args>(args)...));
 
-    template <class Arg1, class... Args>
-    auto operator()(slice arg0, Arg1 &&arg1, Args &&... args) const
-        -> decltype(ref(std::forward<Arg1>(arg1), std::forward<Args>(args)...));
+    template <class S, class Arg1, class... Args>
+    auto operator()(S arg0, Arg1 &&arg1, Args &&... args) const
+        -> decltype(ref((arg0.step, std::forward<Arg1>(arg1)),
+                        std::forward<Args>(args)...));
 
-    template <class Arg1, class... Args>
-    auto operator()(contiguous_slice arg0, Arg1 &&arg1, Args &&... args) const
-        -> decltype(ref(std::forward<Arg1>(arg1), std::forward<Args>(args)...));
     long flat_size() const;
   };
 
@@ -292,11 +288,10 @@ namespace types
     dtype operator[](long) const;
     template <size_t N>
     dtype operator[](array<long, N>) const;
-    broadcast operator[](slice) const
-    {
-      return *this;
-    }
-    broadcast operator[](contiguous_slice) const
+
+    template <class S>
+    typename std::enable_if<is_slice<S>::value, broadcast const &>::type
+    operator[](S) const
     {
       return *this;
     }

--- a/pythran/pythonic/include/types/numpy_expr.hpp
+++ b/pythran/pythonic/include/types/numpy_expr.hpp
@@ -800,13 +800,11 @@ namespace types
     {
       return Op{}(std::get<I>(args)[s]...);
     }
-    auto operator[](slice s) const -> decltype(
-        (*this)._index(s, utils::make_index_sequence<sizeof...(Args)>{}))
-    {
-      return _index(s, utils::make_index_sequence<sizeof...(Args)>{});
-    }
-    auto operator[](contiguous_slice s) const -> decltype(
-        (*this)._index(s, utils::make_index_sequence<sizeof...(Args)>{}))
+    template <class S>
+    auto operator[](S s) const
+        -> decltype((*this)
+                        ._index((s.lower, s),
+                                utils::make_index_sequence<sizeof...(Args)>{}))
     {
       return _index(s, utils::make_index_sequence<sizeof...(Args)>{});
     }

--- a/pythran/pythonic/include/types/numpy_gexpr.hpp
+++ b/pythran/pythonic/include/types/numpy_gexpr.hpp
@@ -587,7 +587,7 @@ namespace types
                                   const_nditerator<numpy_gexpr>,
                                   dtype const *>::type;
 
-    typename std::remove_reference<Arg>::type arg;
+    Arg arg;
 
     std::tuple<S...> slices;
 
@@ -700,6 +700,9 @@ namespace types
     numpy_gexpr &operator=(E const &expr);
 
     numpy_gexpr &operator=(numpy_gexpr const &expr);
+
+    template <class Argp>
+    numpy_gexpr &operator=(numpy_gexpr<Argp, S...> const &expr);
 
     template <class Op, class E>
     typename std::enable_if<may_overlap_gexpr<E>::value, numpy_gexpr &>::type
@@ -864,19 +867,14 @@ namespace types
   };
 }
 
-template <class Arg, class... S>
-struct returnable<types::numpy_gexpr<Arg, S...>> {
-  using type = types::numpy_gexpr<typename returnable<Arg>::type, S...>;
-};
-
 template <class T, class pS, class... S>
 struct assignable<types::numpy_gexpr<types::ndarray<T, pS> const &, S...>> {
-  using type = types::numpy_gexpr<types::ndarray<T, pS> const &, S...>;
+  using type = types::numpy_gexpr<types::ndarray<T, pS>, S...>;
 };
 
 template <class T, class pS, class... S>
 struct assignable<types::numpy_gexpr<types::ndarray<T, pS> &, S...>> {
-  using type = types::numpy_gexpr<types::ndarray<T, pS> &, S...>;
+  using type = types::numpy_gexpr<types::ndarray<T, pS>, S...>;
 };
 
 template <class Arg, class... S>
@@ -885,16 +883,10 @@ struct assignable<types::numpy_gexpr<Arg, S...>> {
 };
 
 template <class Arg, class... S>
-struct lazy<types::numpy_gexpr<Arg, S...>> {
-  using type =
-      types::numpy_gexpr<typename lazy<Arg>::type, typename lazy<S>::type...>;
+struct lazy<types::numpy_gexpr<Arg, S...>>
+    : assignable<types::numpy_gexpr<Arg, S...>> {
 };
 
-template <class Arg, class... S>
-struct lazy<types::numpy_gexpr<Arg const &, S...>> {
-  using type = types::numpy_gexpr<typename lazy<Arg>::type const &,
-                                  typename lazy<S>::type...>;
-};
 PYTHONIC_NS_END
 /* type inference stuff  {*/
 #include "pythonic/include/types/combined.hpp"

--- a/pythran/pythonic/include/types/numpy_gexpr.hpp
+++ b/pythran/pythonic/include/types/numpy_gexpr.hpp
@@ -45,9 +45,9 @@ namespace types
 
   template <>
   struct to_slice<none_type> {
-    using type = contiguous_slice;
+    using type = fast_contiguous_slice;
     static constexpr bool is_new_axis = true;
-    contiguous_slice operator()(none_type);
+    fast_contiguous_slice operator()(none_type);
   };
 
   template <class T>
@@ -116,33 +116,28 @@ namespace types
               std::get<Is>(s).normalize(expr.template shape<Is>())...};
     }
 
-    template <class E, class... S>
-    numpy_gexpr<typename std::decay<E>::type, normalized_slice,
-                normalize_t<S>...>
-    operator()(E &&expr, slice const &s0, S const &... s)
-    {
-      return fwd(std::forward<E>(expr), std::make_tuple(s0, s...),
-                 utils::make_index_sequence<sizeof...(S) + 1>());
-    }
-
-    template <class E, class... S>
-    numpy_gexpr<typename std::decay<E>::type, contiguous_normalized_slice,
-                normalize_t<S>...>
-    operator()(E &&expr, contiguous_slice const &s0, S const &... s)
+    template <class E, class Sp, class... S>
+    typename std::enable_if<
+        is_slice<Sp>::value,
+        numpy_gexpr<typename std::decay<E>::type, normalize_t<Sp>,
+                    normalize_t<S>...>>::type
+    operator()(E &&expr, Sp const &s0, S const &... s)
     {
       return make_gexpr(std::forward<E>(expr), s0, s...);
     }
 
     template <class E, class F, class... S>
-    numpy_gexpr<ndarray<typename std::decay<E>::type::dtype,
-                        array<long, std::decay<E>::type::value>>,
-                contiguous_normalized_slice, normalize_t<S>...>
+    typename std::enable_if<
+        !is_slice<F>::value,
+        numpy_gexpr<ndarray<typename std::decay<E>::type::dtype,
+                            array<long, std::decay<E>::type::value>>,
+                    contiguous_normalized_slice, normalize_t<S>...>>::type
     operator()(E &&expr, F const &s0, S const &... s)
     {
       return numpy_vexpr<ndarray<typename std::decay<E>::type::dtype,
                                  array<long, std::decay<E>::type::value>>,
                          F>{std::forward<E>(expr), s0}(
-          contiguous_slice(none_type{}, none_type{}), s...);
+          fast_contiguous_slice(none_type{}, none_type{}), s...);
     }
   };
 
@@ -549,7 +544,7 @@ namespace types
     // It contains compacted sorted slices value in lower, step && upper is
     // the same as shape.
     // indices for long index are store in the indices array.
-    // position for slice && long value in the extended slice can be found
+    // position for slice and long value in the extended slice can be found
     // through the S... template
     // && compacted values as we know that first S is a slice.
 
@@ -799,10 +794,9 @@ namespace types
     template <class... Sp>
     auto operator()(Sp const &... s) const -> decltype(make_gexpr(*this, s...));
 
-    auto operator[](contiguous_slice const &s0) const
-        -> decltype(make_gexpr(*this, s0));
-
-    auto operator[](slice const &s0) const -> decltype(make_gexpr(*this, s0));
+    template <class Sp>
+    auto operator[](Sp const &s) const -> typename std::enable_if<
+        is_slice<Sp>::value, decltype(make_gexpr(*this, (s.lower, s)))>::type;
 
     template <size_t M>
     auto fast(array<long, M> const &indices) const

--- a/pythran/pythonic/include/types/numpy_iexpr.hpp
+++ b/pythran/pythonic/include/types/numpy_iexpr.hpp
@@ -227,13 +227,12 @@ namespace types
     template <class vectorizer>
     simd_iterator vend(vectorizer) const;
 #endif
-    template <class... S>
-    numpy_gexpr<numpy_iexpr, normalized_slice, normalize_t<S>...>
-    operator()(slice const &s0, S const &... s) const;
 
-    template <class... S>
-    numpy_gexpr<numpy_iexpr, contiguous_normalized_slice, normalize_t<S>...>
-    operator()(contiguous_slice const &s0, S const &... s) const;
+    template <class Sp, class... S>
+    typename std::enable_if<
+        is_slice<Sp>::value,
+        numpy_gexpr<numpy_iexpr, normalize_t<Sp>, normalize_t<S>...>>::type
+    operator()(Sp const &s0, S const &... s) const;
 
     template <class... S>
     auto operator()(long s0, S const &... s) const
@@ -251,10 +250,10 @@ namespace types
     auto operator[](long i) const & -> decltype(this->fast(i));
     auto operator[](long i) & -> decltype(this->fast(i));
     auto operator[](long i) && -> decltype(std::move(*this).fast(i));
-    numpy_gexpr<numpy_iexpr, normalized_slice>
-    operator[](slice const &s0) const;
-    numpy_gexpr<numpy_iexpr, contiguous_normalized_slice>
-    operator[](contiguous_slice const &s0) const;
+    template <class Sp>
+    typename std::enable_if<is_slice<Sp>::value,
+                            numpy_gexpr<numpy_iexpr, normalize_t<Sp>>>::type
+    operator[](Sp const &s0) const;
 
     dtype const &operator[](array<long, value> const &indices) const;
     dtype &operator[](array<long, value> const &indices);

--- a/pythran/pythonic/include/types/numpy_iexpr.hpp
+++ b/pythran/pythonic/include/types/numpy_iexpr.hpp
@@ -61,7 +61,7 @@ namespace types
                                   const_nditerator<numpy_iexpr>,
                                   dtype const *>::type;
 
-    typename std::decay<Arg>::type arg;
+    Arg arg;
     dtype *buffer;
     using shape_t =
         sutils::pop_head_t<typename std::remove_reference<Arg>::type::shape_t>;
@@ -374,12 +374,12 @@ struct assignable<types::numpy_iexpr<Arg>> {
 
 template <class T, class pS>
 struct assignable<types::numpy_iexpr<types::ndarray<T, pS> &>> {
-  using type = types::numpy_iexpr<types::ndarray<T, pS> &>;
+  using type = types::numpy_iexpr<types::ndarray<T, pS>>;
 };
 
 template <class T, class pS>
-struct assignable<types::numpy_iexpr<types::ndarray<T, pS> const &>> {
-  using type = types::numpy_iexpr<types::ndarray<T, pS> const &>;
+struct assignable<types::numpy_iexpr<types::ndarray<T, pS>>> {
+  using type = types::numpy_iexpr<types::ndarray<T, pS>>;
 };
 
 template <class Arg>
@@ -388,14 +388,9 @@ struct returnable<types::numpy_iexpr<Arg>> {
 };
 
 template <class Arg>
-struct lazy<types::numpy_iexpr<Arg>> {
-  using type = types::numpy_iexpr<typename lazy<Arg>::type>;
+struct lazy<types::numpy_iexpr<Arg>> : assignable<types::numpy_iexpr<Arg>> {
 };
 
-template <class Arg>
-struct lazy<types::numpy_iexpr<Arg const &>> {
-  using type = types::numpy_iexpr<typename lazy<Arg>::type const &>;
-};
 PYTHONIC_NS_END
 
 /* type inference stuff  {*/

--- a/pythran/pythonic/include/types/numpy_texpr.hpp
+++ b/pythran/pythonic/include/types/numpy_texpr.hpp
@@ -63,13 +63,13 @@ namespace types
     }
 
     auto fast(long i) const
-        -> decltype(this->arg(contiguous_slice(pythonic::builtins::None,
-                                               pythonic::builtins::None),
+        -> decltype(this->arg(fast_contiguous_slice(pythonic::builtins::None,
+                                                    pythonic::builtins::None),
                               i));
 
     auto fast(long i)
-        -> decltype(this->arg(contiguous_slice(pythonic::builtins::None,
-                                               pythonic::builtins::None),
+        -> decltype(this->arg(fast_contiguous_slice(pythonic::builtins::None,
+                                                    pythonic::builtins::None),
                               i));
     auto fast(array<long, value> const &indices)
         -> decltype(arg.fast(array<long, 2>{{indices[1], indices[0]}}))
@@ -182,20 +182,16 @@ namespace types
                                     std::get<0>(indices)}];
     }
 
-    auto operator[](contiguous_slice const &s0) const -> numpy_texpr<
-        decltype(this->arg(contiguous_slice(pythonic::builtins::None,
-                                            pythonic::builtins::None),
-                           s0))>;
-    auto
-    operator[](contiguous_slice const &s0) -> numpy_texpr<decltype(this->arg(
-        contiguous_slice(pythonic::builtins::None, pythonic::builtins::None),
-        s0))>;
-    auto operator[](slice const &s0) const -> numpy_texpr<decltype(this->arg(
-        contiguous_slice(pythonic::builtins::None, pythonic::builtins::None),
-        s0))>;
-    auto operator[](slice const &s0) -> numpy_texpr<decltype(this->arg(
-        contiguous_slice(pythonic::builtins::None, pythonic::builtins::None),
-        s0))>;
+    template <class S>
+    auto operator[](S const &s0) const -> numpy_texpr<
+        decltype(this->arg(fast_contiguous_slice(pythonic::builtins::None,
+                                                 pythonic::builtins::None),
+                           (s0.step, s0)))>;
+    template <class S>
+    auto operator[](S const &s0) -> numpy_texpr<
+        decltype(this->arg(fast_contiguous_slice(pythonic::builtins::None,
+                                                 pythonic::builtins::None),
+                           (s0.step, s0)))>;
 
     template <class S, size_t... I>
     auto _reverse_index(S const &indices, utils::index_sequence<I...>) const

--- a/pythran/pythonic/include/types/numpy_vexpr.hpp
+++ b/pythran/pythonic/include/types/numpy_vexpr.hpp
@@ -103,15 +103,16 @@ namespace types
     {
       return data_.fast(view_[i]);
     }
-    numpy_gexpr<numpy_vexpr, normalized_slice> operator[](slice s) const
+
+    template <class S>
+    typename std::enable_if<
+        is_slice<S>::value,
+        numpy_gexpr<numpy_vexpr, decltype(std::declval<S>().normalize(1))>>
+    operator[](S s) const
     {
       return {*this, s.normalize(size())};
     }
-    numpy_gexpr<numpy_vexpr, contiguous_normalized_slice>
-    operator[](contiguous_slice s) const
-    {
-      return {*this, s.normalize(size())};
-    }
+
     /* element filtering */
     template <class E> // indexing through an array of boolean -- a mask
     typename std::enable_if<
@@ -123,7 +124,7 @@ namespace types
 
     template <class E> // indexing through an array of boolean -- a mask
     typename std::enable_if<
-        is_numexpr_arg<E>::value &&
+        !is_slice<E>::value && is_numexpr_arg<E>::value &&
             std::is_same<bool, typename E::dtype>::value &&
             !is_pod_array<F>::value,
         numpy_vexpr<numpy_vexpr, ndarray<long, pshape<long>>>>::type

--- a/pythran/pythonic/include/types/str.hpp
+++ b/pythran/pythonic/include/types/str.hpp
@@ -71,8 +71,9 @@ namespace types
     // accessor
     str operator[](long i) const;
     str fast(long i) const;
-    sliced_str<slice> operator[](slice const &s) const;
-    sliced_str<contiguous_slice> operator[](contiguous_slice const &s) const;
+    template <class Sp>
+    typename std::enable_if<is_slice<Sp>::value, sliced_str<Sp>>::type
+    operator[](Sp const &s) const;
 
     // conversion
     operator long() const;
@@ -171,14 +172,16 @@ namespace types
     template <class S>
     bool operator==(sliced_str<S> const &other) const;
 
-    sliced_str<slice> operator()(slice const &s) const;
-    sliced_str<contiguous_slice> operator()(contiguous_slice const &s) const;
+    template <class S>
+    typename std::enable_if<is_slice<S>::value, sliced_str<S>>::type
+    operator()(S const &s) const;
 
     str operator[](long i) const;
     str fast(long i) const;
 
-    sliced_str<slice> operator[](slice const &s) const;
-    sliced_str<contiguous_slice> operator[](contiguous_slice const &s) const;
+    template <class S>
+    typename std::enable_if<is_slice<S>::value, sliced_str<S>>::type
+    operator[](S const &s) const;
 
     explicit operator bool() const;
     long count(types::str const &sub) const;

--- a/pythran/pythonic/include/types/tuple.hpp
+++ b/pythran/pythonic/include/types/tuple.hpp
@@ -280,13 +280,12 @@ namespace types
                                 contiguous_slice const &s);
 
     template <class T, size_t N>
-    sliced_list<T, slice> operator()(static_list<T, N> const &b, slice const &s)
-    {
-      return {b, s};
-    }
-    template <class T, size_t N>
-    sliced_list<T, contiguous_slice> operator()(static_list<T, N> const &b,
-                                                contiguous_slice const &s)
+    dynamic_tuple<T> operator()(array<T, N> const &b,
+                                fast_contiguous_slice const &s);
+
+    template <class T, size_t N, class S>
+    typename std::enable_if<is_slice<S>::value, sliced_list<T, S>>::type
+    operator()(static_list<T, N> const &b, S const &s)
     {
       return {b, s};
     }
@@ -401,13 +400,9 @@ namespace types
 
     const_reference operator[](long __n) const noexcept;
 
-    auto operator[](slice s) const -> decltype(array_base_slicer{}(*this, s))
-    {
-      return array_base_slicer{}(*this, s);
-    }
-
-    auto operator[](contiguous_slice s) const
-        -> decltype(array_base_slicer{}(*this, s))
+    template <class S>
+    auto operator[](S s) const
+        -> decltype(array_base_slicer{}(*this, (s.lower, s)))
     {
       return array_base_slicer{}(*this, s);
     }

--- a/pythran/pythonic/types/list.hpp
+++ b/pythran/pythonic/types/list.hpp
@@ -106,17 +106,18 @@ namespace types
     assert(0 <= index && index < data->size());
     return (*data)[index];
   }
+
   template <class T, class S>
-  sliced_list<T, S> sliced_list<T, S>::operator[](contiguous_slice s) const
+  template <class Sp>
+  typename std::enable_if<
+      is_slice<Sp>::value,
+      sliced_list<T, decltype(std::declval<S>() * std::declval<Sp>())>>::type
+      sliced_list<T, S>::
+      operator[](Sp s) const
   {
     return {data, slicing * s.normalize(this->size())};
   }
-  template <class T, class S>
-  sliced_list<T, decltype(std::declval<S>() * std::declval<slice>())>
-      sliced_list<T, S>::operator[](slice s) const
-  {
-    return {data, slicing * s.normalize(this->size())};
-  }
+
   // io
   template <class Tp, class Sp>
   std::ostream &operator<<(std::ostream &os, sliced_list<Tp, Sp> const &v)
@@ -524,15 +525,12 @@ namespace types
   }
 
   template <class T>
-  sliced_list<T, slice> list<T>::operator[](slice const &s) const
+  template <class Sp>
+  typename std::enable_if<is_slice<Sp>::value, sliced_list<T, Sp>>::type
+      list<T>::
+      operator[](Sp const &s) const
   {
-    return sliced_list<T, slice>(*this, s);
-  }
-  template <class T>
-  sliced_list<T, contiguous_slice> list<T>::
-  operator[](contiguous_slice const &s) const
-  {
-    return sliced_list<T, contiguous_slice>(*this, s);
+    return {*this, s};
   }
 
   // modifiers

--- a/pythran/pythonic/types/ndarray.hpp
+++ b/pythran/pythonic/types/ndarray.hpp
@@ -699,24 +699,25 @@ namespace types
   }
 
   template <class T, class pS>
-  numpy_gexpr<ndarray<T, pS> const &, normalized_slice> ndarray<T, pS>::
-  operator[](slice const &s) const &
+  template <class S>
+  typename std::enable_if<
+      is_slice<S>::value,
+      numpy_gexpr<ndarray<T, pS> const &, normalize_t<S>>>::type
+      ndarray<T, pS>::
+      operator[](S const &s) const &
   {
     return make_gexpr(*this, s);
   }
 
   template <class T, class pS>
-  numpy_gexpr<ndarray<T, pS>, normalized_slice> ndarray<T, pS>::
-  operator[](slice const &s) &&
+  template <class S>
+  typename std::enable_if<
+      is_slice<S>::value,
+      numpy_gexpr<ndarray<T, pS> const &, normalize_t<S>>>::type
+      ndarray<T, pS>::
+      operator[](S const &s) &&
   {
     return make_gexpr(std::move(*this), s);
-  }
-
-  template <class T, class pS>
-  numpy_gexpr<ndarray<T, pS> const &, contiguous_normalized_slice>
-      ndarray<T, pS>::operator[](contiguous_slice const &s) const
-  {
-    return make_gexpr(*this, s);
   }
 
   template <class T, class pS>

--- a/pythran/pythonic/types/ndarray.hpp
+++ b/pythran/pythonic/types/ndarray.hpp
@@ -711,9 +711,8 @@ namespace types
 
   template <class T, class pS>
   template <class S>
-  typename std::enable_if<
-      is_slice<S>::value,
-      numpy_gexpr<ndarray<T, pS> const &, normalize_t<S>>>::type
+  typename std::enable_if<is_slice<S>::value,
+                          numpy_gexpr<ndarray<T, pS>, normalize_t<S>>>::type
       ndarray<T, pS>::
       operator[](S const &s) &&
   {

--- a/pythran/pythonic/types/numpy_broadcast.hpp
+++ b/pythran/pythonic/types/numpy_broadcast.hpp
@@ -58,19 +58,10 @@ namespace types
   }
 
   template <class T>
-  template <class Arg1, class... Args>
-  auto broadcasted<T>::operator()(slice arg0, Arg1 &&arg1,
-                                  Args &&... args) const
-      -> decltype(ref(std::forward<Arg1>(arg1), std::forward<Args>(args)...))
-  {
-    return {ref(std::forward<Arg1>(arg1), std::forward<Args>(args)...)};
-  }
-
-  template <class T>
-  template <class Arg1, class... Args>
-  auto broadcasted<T>::operator()(contiguous_slice arg0, Arg1 &&arg1,
-                                  Args &&... args) const
-      -> decltype(ref(std::forward<Arg1>(arg1), std::forward<Args>(args)...))
+  template <class S, class Arg1, class... Args>
+  auto broadcasted<T>::operator()(S arg0, Arg1 &&arg1, Args &&... args) const
+      -> decltype(ref((arg0.step, std::forward<Arg1>(arg1)),
+                      std::forward<Args>(args)...))
   {
     return {ref(std::forward<Arg1>(arg1), std::forward<Args>(args)...)};
   }

--- a/pythran/pythonic/types/numpy_gexpr.hpp
+++ b/pythran/pythonic/types/numpy_gexpr.hpp
@@ -86,7 +86,7 @@ namespace types
     return value;
   }
 
-  contiguous_slice to_slice<none_type>::operator()(none_type)
+  fast_contiguous_slice to_slice<none_type>::operator()(none_type)
   {
     return {0, 1};
   }
@@ -648,17 +648,12 @@ namespace types
   }
 
   template <class Arg, class... S>
-  auto numpy_gexpr<Arg, S...>::operator[](contiguous_slice const &s0) const
-      -> decltype(make_gexpr(*this, s0))
+  template <class Sp>
+  auto numpy_gexpr<Arg, S...>::operator[](Sp const &s) const ->
+      typename std::enable_if<is_slice<Sp>::value,
+                              decltype(make_gexpr(*this, (s.lower, s)))>::type
   {
-    return make_gexpr(*this, s0);
-  }
-
-  template <class Arg, class... S>
-  auto numpy_gexpr<Arg, S...>::operator[](slice const &s0) const
-      -> decltype(make_gexpr(*this, s0))
-  {
-    return make_gexpr(*this, s0);
+    return make_gexpr(*this, s);
   }
 
   template <class Arg, class... S>

--- a/pythran/pythonic/types/numpy_gexpr.hpp
+++ b/pythran/pythonic/types/numpy_gexpr.hpp
@@ -425,6 +425,24 @@ namespace types
   }
 
   template <class Arg, class... S>
+  template <class Argp>
+  numpy_gexpr<Arg, S...> &numpy_gexpr<Arg, S...>::
+  operator=(numpy_gexpr<Argp, S...> const &expr)
+  {
+    if (buffer == nullptr) {
+      // arg = expr.arg;
+      const_cast<typename std::decay<Arg>::type &>(arg) = expr.arg;
+      slices = expr.slices;
+      buffer = arg.buffer + (expr.buffer - expr.arg.buffer);
+      _shape = expr._shape;
+      _strides = expr._strides;
+      return *this;
+    } else {
+      return _copy(expr);
+    }
+  }
+
+  template <class Arg, class... S>
   template <class Op, class E>
   typename std::enable_if<!may_overlap_gexpr<E>::value,
                           numpy_gexpr<Arg, S...> &>::type

--- a/pythran/pythonic/types/numpy_iexpr.hpp
+++ b/pythran/pythonic/types/numpy_iexpr.hpp
@@ -353,32 +353,22 @@ namespace types
   }
 
   template <class Arg>
-  numpy_gexpr<numpy_iexpr<Arg>, normalized_slice> numpy_iexpr<Arg>::
-  operator[](slice const &s0) const
+  template <class Sp>
+  typename std::enable_if<is_slice<Sp>::value,
+                          numpy_gexpr<numpy_iexpr<Arg>, normalize_t<Sp>>>::type
+      numpy_iexpr<Arg>::
+      operator[](Sp const &s0) const
   {
     return make_gexpr(*this, s0);
   }
 
   template <class Arg>
-  numpy_gexpr<numpy_iexpr<Arg>, contiguous_normalized_slice> numpy_iexpr<Arg>::
-  operator[](contiguous_slice const &s0) const
-  {
-    return make_gexpr(*this, s0);
-  }
-
-  template <class Arg>
-  template <class... S>
-  numpy_gexpr<numpy_iexpr<Arg>, normalized_slice, normalize_t<S>...>
-      numpy_iexpr<Arg>::operator()(slice const &s0, S const &... s) const
-  {
-    return make_gexpr(*this, s0, s...);
-  }
-
-  template <class Arg>
-  template <class... S>
-  numpy_gexpr<numpy_iexpr<Arg>, contiguous_normalized_slice, normalize_t<S>...>
-      numpy_iexpr<Arg>::operator()(contiguous_slice const &s0,
-                                   S const &... s) const
+  template <class Sp, class... S>
+  typename std::enable_if<
+      is_slice<Sp>::value,
+      numpy_gexpr<numpy_iexpr<Arg>, normalize_t<Sp>, normalize_t<S>...>>::type
+      numpy_iexpr<Arg>::
+      operator()(Sp const &s0, S const &... s) const
   {
     return make_gexpr(*this, s0, s...);
   }

--- a/pythran/pythonic/types/numpy_texpr.hpp
+++ b/pythran/pythonic/types/numpy_texpr.hpp
@@ -55,8 +55,10 @@ namespace types
   }
 
   template <class E>
-  auto numpy_texpr_2<E>::fast(long i) const -> decltype(this->arg(
-      contiguous_slice(pythonic::builtins::None, pythonic::builtins::None), i))
+  auto numpy_texpr_2<E>::fast(long i) const
+      -> decltype(this->arg(fast_contiguous_slice(pythonic::builtins::None,
+                                                  pythonic::builtins::None),
+                            i))
   {
     return arg(
         contiguous_slice(pythonic::builtins::None, pythonic::builtins::None),
@@ -64,8 +66,10 @@ namespace types
   }
 
   template <class E>
-  auto numpy_texpr_2<E>::fast(long i) -> decltype(this->arg(
-      contiguous_slice(pythonic::builtins::None, pythonic::builtins::None), i))
+  auto numpy_texpr_2<E>::fast(long i)
+      -> decltype(this->arg(fast_contiguous_slice(pythonic::builtins::None,
+                                                  pythonic::builtins::None),
+                            i))
   {
     return arg(
         contiguous_slice(pythonic::builtins::None, pythonic::builtins::None),
@@ -107,47 +111,27 @@ namespace types
   }
 
   template <class E>
-  auto numpy_texpr_2<E>::operator[](contiguous_slice const &s0) const
-      -> numpy_texpr<decltype(this->arg(
-          contiguous_slice(pythonic::builtins::None, pythonic::builtins::None),
-          s0))>
+  template <class S>
+  auto numpy_texpr_2<E>::
+  operator[](S const &s0) const -> numpy_texpr<decltype(this->arg(
+      fast_contiguous_slice(pythonic::builtins::None, pythonic::builtins::None),
+      (s0.step, s0)))>
   {
-    return {arg(
-        contiguous_slice(pythonic::builtins::None, pythonic::builtins::None),
-        s0)};
+    return {arg(fast_contiguous_slice(pythonic::builtins::None,
+                                      pythonic::builtins::None),
+                s0)};
   }
 
   template <class E>
-  auto numpy_texpr_2<E>::operator[](contiguous_slice const &s0)
-      -> numpy_texpr<decltype(this->arg(
-          contiguous_slice(pythonic::builtins::None, pythonic::builtins::None),
-          s0))>
+  template <class S>
+  auto numpy_texpr_2<E>::
+  operator[](S const &s0) -> numpy_texpr<decltype(this->arg(
+      fast_contiguous_slice(pythonic::builtins::None, pythonic::builtins::None),
+      (s0.step, s0)))>
   {
-    return {arg(
-        contiguous_slice(pythonic::builtins::None, pythonic::builtins::None),
-        s0)};
-  }
-
-  template <class E>
-  auto numpy_texpr_2<E>::operator[](slice const &s0) const
-      -> numpy_texpr<decltype(this->arg(
-          contiguous_slice(pythonic::builtins::None, pythonic::builtins::None),
-          s0))>
-  {
-    return {arg(
-        contiguous_slice(pythonic::builtins::None, pythonic::builtins::None),
-        s0)};
-  }
-
-  template <class E>
-  auto numpy_texpr_2<E>::operator[](slice const &s0)
-      -> numpy_texpr<decltype(this->arg(
-          contiguous_slice(pythonic::builtins::None, pythonic::builtins::None),
-          s0))>
-  {
-    return {arg(
-        contiguous_slice(pythonic::builtins::None, pythonic::builtins::None),
-        s0)};
+    return {arg(fast_contiguous_slice(pythonic::builtins::None,
+                                      pythonic::builtins::None),
+                s0)};
   }
 
   /* element filtering */

--- a/pythran/pythonic/types/numpy_vexpr.hpp
+++ b/pythran/pythonic/types/numpy_vexpr.hpp
@@ -110,7 +110,7 @@ namespace types
   template <class T, class F>
   template <class E> // indexing through an array of boolean -- a mask
   typename std::enable_if<
-      is_numexpr_arg<E>::value &&
+      !is_slice<E>::value && is_numexpr_arg<E>::value &&
           std::is_same<bool, typename E::dtype>::value &&
           !is_pod_array<F>::value,
       numpy_vexpr<numpy_vexpr<T, F>, ndarray<long, pshape<long>>>>::type

--- a/pythran/pythonic/types/str.hpp
+++ b/pythran/pythonic/types/str.hpp
@@ -150,16 +150,12 @@ namespace types
   }
 
   template <class S>
-  sliced_str<slice> sliced_str<S>::operator[](slice const &s) const
+  template <class Sp>
+  typename std::enable_if<is_slice<Sp>::value, sliced_str<Sp>>::type
+      sliced_str<S>::
+      operator[](Sp const &s) const
   {
-    return sliced_str<slice>(*this, s.normalize(size()));
-  }
-
-  template <class S>
-  sliced_str<contiguous_slice> sliced_str<S>::
-  operator[](contiguous_slice const &s) const
-  {
-    return sliced_str<contiguous_slice>(*this, s.normalize(size()));
+    return {*this, s.normalize(size())};
   }
 
   // conversion
@@ -499,12 +495,9 @@ namespace types
     return true;
   }
 
-  sliced_str<slice> str::operator()(slice const &s) const
-  {
-    return operator[](s);
-  }
-
-  sliced_str<contiguous_slice> str::operator()(contiguous_slice const &s) const
+  template <class S>
+  typename std::enable_if<is_slice<S>::value, sliced_str<S>>::type str::
+  operator()(S const &s) const
   {
     return operator[](s);
   }
@@ -521,14 +514,11 @@ namespace types
     return str((*data)[i]);
   }
 
-  sliced_str<slice> str::operator[](slice const &s) const
+  template <class S>
+  typename std::enable_if<is_slice<S>::value, sliced_str<S>>::type str::
+  operator[](S const &s) const
   {
-    return sliced_str<slice>(*this, s.normalize(size()));
-  }
-
-  sliced_str<contiguous_slice> str::operator[](contiguous_slice const &s) const
-  {
-    return sliced_str<contiguous_slice>(*this, s.normalize(size()));
+    return {*this, s.normalize(size())};
   }
 
   str::operator bool() const

--- a/pythran/pythonic/types/tuple.hpp
+++ b/pythran/pythonic/types/tuple.hpp
@@ -419,6 +419,13 @@ namespace types
     contiguous_normalized_slice cns = s.normalize(b.size());
     return {&b[cns.lower], &b[cns.upper]};
   }
+  template <class T, size_t N>
+  dynamic_tuple<T> array_base_slicer::operator()(array<T, N> const &b,
+                                                 fast_contiguous_slice const &s)
+  {
+    contiguous_normalized_slice cns = s.normalize(b.size());
+    return {&b[cns.lower], &b[cns.upper]};
+  }
 }
 PYTHONIC_NS_END
 

--- a/pythran/pythonic/utils/pdqsort.hpp
+++ b/pythran/pythonic/utils/pdqsort.hpp
@@ -3,22 +3,28 @@
 
     Copyright (c) 2015 Orson Peters
 
-    This software is provided 'as-is', without any express or implied warranty. In no event will the
-    authors be held liable for any damages arising from the use of this software.
+    This software is provided 'as-is', without any express or implied warranty.
+   In no event will the
+    authors be held liable for any damages arising from the use of this
+   software.
 
-    Permission is granted to anyone to use this software for any purpose, including commercial
-    applications, and to alter it and redistribute it freely, subject to the following restrictions:
+    Permission is granted to anyone to use this software for any purpose,
+   including commercial
+    applications, and to alter it and redistribute it freely, subject to the
+   following restrictions:
 
-    1. The origin of this software must not be misrepresented; you must not claim that you wrote the
-       original software. If you use this software in a product, an acknowledgment in the product
+    1. The origin of this software must not be misrepresented; you must not
+   claim that you wrote the
+       original software. If you use this software in a product, an
+   acknowledgment in the product
        documentation would be appreciated but is not required.
 
-    2. Altered source versions must be plainly marked as such, and must not be misrepresented as
+    2. Altered source versions must be plainly marked as such, and must not be
+   misrepresented as
        being the original software.
 
     3. This notice may not be removed or altered from any source distribution.
 */
-
 
 #ifndef PDQSORT_HPP
 #define PDQSORT_HPP
@@ -30,514 +36,654 @@
 #include <iterator>
 
 #if __cplusplus >= 201103L
-    #include <cstdint>
-    #include <type_traits>
-    #define PDQSORT_PREFER_MOVE(x) std::move(x)
+#include <cstdint>
+#include <type_traits>
+#define PDQSORT_PREFER_MOVE(x) std::move(x)
 #else
-    #define PDQSORT_PREFER_MOVE(x) (x)
+#define PDQSORT_PREFER_MOVE(x) (x)
 #endif
 
+namespace pdqsort_detail
+{
+  enum {
+    // Partitions below this size are sorted using insertion sort.
+    insertion_sort_threshold = 24,
 
-namespace pdqsort_detail {
-    enum {
-        // Partitions below this size are sorted using insertion sort.
-        insertion_sort_threshold = 24,
+    // Partitions above this size use Tukey's ninther to select the pivot.
+    ninther_threshold = 128,
 
-        // Partitions above this size use Tukey's ninther to select the pivot.
-        ninther_threshold = 128,
+    // When we detect an already sorted partition, attempt an insertion sort
+    // that allows this
+    // amount of element moves before giving up.
+    partial_insertion_sort_limit = 8,
 
-        // When we detect an already sorted partition, attempt an insertion sort that allows this
-        // amount of element moves before giving up.
-        partial_insertion_sort_limit = 8,
+    // Must be multiple of 8 due to loop unrolling, and < 256 to fit in unsigned
+    // char.
+    block_size = 64,
 
-        // Must be multiple of 8 due to loop unrolling, and < 256 to fit in unsigned char.
-        block_size = 64,
+    // Cacheline size, assumes power of two.
+    cacheline_size = 64
 
-        // Cacheline size, assumes power of two.
-        cacheline_size = 64
-
-    };
+  };
 
 #if __cplusplus >= 201103L
-    template<class T> struct is_default_compare : std::false_type { };
-    template<class T> struct is_default_compare<std::less<T>> : std::true_type { };
-    template<class T> struct is_default_compare<std::greater<T>> : std::true_type { };
+  template <class T>
+  struct is_default_compare : std::false_type {
+  };
+  template <class T>
+  struct is_default_compare<std::less<T>> : std::true_type {
+  };
+  template <class T>
+  struct is_default_compare<std::greater<T>> : std::true_type {
+  };
 #endif
 
-    // Returns floor(log2(n)), assumes n > 0.
-    template<class T>
-    inline int log2(T n) {
-        int log = 0;
-        while (n >>= 1) ++log;
-        return log;
+  // Returns floor(log2(n)), assumes n > 0.
+  template <class T>
+  inline int log2(T n)
+  {
+    int log = 0;
+    while (n >>= 1)
+      ++log;
+    return log;
+  }
+
+  // Sorts [begin, end) using insertion sort with the given comparison function.
+  template <class Iter, class Compare>
+  inline void insertion_sort(Iter begin, Iter end, Compare comp)
+  {
+    typedef typename std::iterator_traits<Iter>::value_type T;
+    if (begin == end)
+      return;
+
+    for (Iter cur = begin + 1; cur != end; ++cur) {
+      Iter sift = cur;
+      Iter sift_1 = cur - 1;
+
+      // Compare first so we can avoid 2 moves for an element already positioned
+      // correctly.
+      if (comp(*sift, *sift_1)) {
+        T tmp = PDQSORT_PREFER_MOVE(*sift);
+
+        do {
+          *sift-- = PDQSORT_PREFER_MOVE(*sift_1);
+        } while (sift != begin && comp(tmp, *--sift_1));
+
+        *sift = PDQSORT_PREFER_MOVE(tmp);
+      }
+    }
+  }
+
+  // Sorts [begin, end) using insertion sort with the given comparison function.
+  // Assumes
+  // *(begin - 1) is an element smaller than or equal to any element in [begin,
+  // end).
+  template <class Iter, class Compare>
+  inline void unguarded_insertion_sort(Iter begin, Iter end, Compare comp)
+  {
+    typedef typename std::iterator_traits<Iter>::value_type T;
+    if (begin == end)
+      return;
+
+    for (Iter cur = begin + 1; cur != end; ++cur) {
+      Iter sift = cur;
+      Iter sift_1 = cur - 1;
+
+      // Compare first so we can avoid 2 moves for an element already positioned
+      // correctly.
+      if (comp(*sift, *sift_1)) {
+        T tmp = PDQSORT_PREFER_MOVE(*sift);
+
+        do {
+          *sift-- = PDQSORT_PREFER_MOVE(*sift_1);
+        } while (comp(tmp, *--sift_1));
+
+        *sift = PDQSORT_PREFER_MOVE(tmp);
+      }
+    }
+  }
+
+  // Attempts to use insertion sort on [begin, end). Will return false if more
+  // than
+  // partial_insertion_sort_limit elements were moved, and abort sorting.
+  // Otherwise it will
+  // successfully sort and return true.
+  template <class Iter, class Compare>
+  inline bool partial_insertion_sort(Iter begin, Iter end, Compare comp)
+  {
+    typedef typename std::iterator_traits<Iter>::value_type T;
+    if (begin == end)
+      return true;
+
+    std::size_t limit = 0;
+    for (Iter cur = begin + 1; cur != end; ++cur) {
+      Iter sift = cur;
+      Iter sift_1 = cur - 1;
+
+      // Compare first so we can avoid 2 moves for an element already positioned
+      // correctly.
+      if (comp(*sift, *sift_1)) {
+        T tmp = PDQSORT_PREFER_MOVE(*sift);
+
+        do {
+          *sift-- = PDQSORT_PREFER_MOVE(*sift_1);
+        } while (sift != begin && comp(tmp, *--sift_1));
+
+        *sift = PDQSORT_PREFER_MOVE(tmp);
+        limit += cur - sift;
+      }
+
+      if (limit > partial_insertion_sort_limit)
+        return false;
     }
 
-    // Sorts [begin, end) using insertion sort with the given comparison function.
-    template<class Iter, class Compare>
-    inline void insertion_sort(Iter begin, Iter end, Compare comp) {
-        typedef typename std::iterator_traits<Iter>::value_type T;
-        if (begin == end) return;
+    return true;
+  }
 
-        for (Iter cur = begin + 1; cur != end; ++cur) {
-            Iter sift = cur;
-            Iter sift_1 = cur - 1;
+  template <class Iter, class Compare>
+  inline void sort2(Iter a, Iter b, Compare comp)
+  {
+    if (comp(*b, *a))
+      std::iter_swap(a, b);
+  }
 
-            // Compare first so we can avoid 2 moves for an element already positioned correctly.
-            if (comp(*sift, *sift_1)) {
-                T tmp = PDQSORT_PREFER_MOVE(*sift);
+  // Sorts the elements *a, *b and *c using comparison function comp.
+  template <class Iter, class Compare>
+  inline void sort3(Iter a, Iter b, Iter c, Compare comp)
+  {
+    sort2(a, b, comp);
+    sort2(b, c, comp);
+    sort2(a, b, comp);
+  }
 
-                do { *sift-- = PDQSORT_PREFER_MOVE(*sift_1); }
-                while (sift != begin && comp(tmp, *--sift_1));
-
-                *sift = PDQSORT_PREFER_MOVE(tmp);
-            }
-        }
-    }
-
-    // Sorts [begin, end) using insertion sort with the given comparison function. Assumes
-    // *(begin - 1) is an element smaller than or equal to any element in [begin, end).
-    template<class Iter, class Compare>
-    inline void unguarded_insertion_sort(Iter begin, Iter end, Compare comp) {
-        typedef typename std::iterator_traits<Iter>::value_type T;
-        if (begin == end) return;
-
-        for (Iter cur = begin + 1; cur != end; ++cur) {
-            Iter sift = cur;
-            Iter sift_1 = cur - 1;
-
-            // Compare first so we can avoid 2 moves for an element already positioned correctly.
-            if (comp(*sift, *sift_1)) {
-                T tmp = PDQSORT_PREFER_MOVE(*sift);
-
-                do { *sift-- = PDQSORT_PREFER_MOVE(*sift_1); }
-                while (comp(tmp, *--sift_1));
-
-                *sift = PDQSORT_PREFER_MOVE(tmp);
-            }
-        }
-    }
-
-    // Attempts to use insertion sort on [begin, end). Will return false if more than
-    // partial_insertion_sort_limit elements were moved, and abort sorting. Otherwise it will
-    // successfully sort and return true.
-    template<class Iter, class Compare>
-    inline bool partial_insertion_sort(Iter begin, Iter end, Compare comp) {
-        typedef typename std::iterator_traits<Iter>::value_type T;
-        if (begin == end) return true;
-        
-        std::size_t limit = 0;
-        for (Iter cur = begin + 1; cur != end; ++cur) {
-            Iter sift = cur;
-            Iter sift_1 = cur - 1;
-
-            // Compare first so we can avoid 2 moves for an element already positioned correctly.
-            if (comp(*sift, *sift_1)) {
-                T tmp = PDQSORT_PREFER_MOVE(*sift);
-
-                do { *sift-- = PDQSORT_PREFER_MOVE(*sift_1); }
-                while (sift != begin && comp(tmp, *--sift_1));
-
-                *sift = PDQSORT_PREFER_MOVE(tmp);
-                limit += cur - sift;
-            }
-            
-            if (limit > partial_insertion_sort_limit) return false;
-        }
-
-        return true;
-    }
-
-    template<class Iter, class Compare>
-    inline void sort2(Iter a, Iter b, Compare comp) {
-        if (comp(*b, *a)) std::iter_swap(a, b);
-    }
-
-    // Sorts the elements *a, *b and *c using comparison function comp.
-    template<class Iter, class Compare>
-    inline void sort3(Iter a, Iter b, Iter c, Compare comp) {
-        sort2(a, b, comp);
-        sort2(b, c, comp);
-        sort2(a, b, comp);
-    }
-
-    template<class T>
-    inline T* align_cacheline(T* p) {
+  template <class T>
+  inline T *align_cacheline(T *p)
+  {
 #if defined(UINTPTR_MAX) && __cplusplus >= 201103L
-        std::uintptr_t ip = reinterpret_cast<std::uintptr_t>(p);
+    std::uintptr_t ip = reinterpret_cast<std::uintptr_t>(p);
 #else
-        std::size_t ip = reinterpret_cast<std::size_t>(p);
+    std::size_t ip = reinterpret_cast<std::size_t>(p);
 #endif
-        ip = (ip + cacheline_size - 1) & -cacheline_size;
-        return reinterpret_cast<T*>(ip);
+    ip = (ip + cacheline_size - 1) & -cacheline_size;
+    return reinterpret_cast<T *>(ip);
+  }
+
+  template <class Iter>
+  inline void swap_offsets(Iter first, Iter last, unsigned char *offsets_l,
+                           unsigned char *offsets_r, int num, bool use_swaps)
+  {
+    typedef typename std::iterator_traits<Iter>::value_type T;
+    if (use_swaps) {
+      // This case is needed for the descending distribution, where we need
+      // to have proper swapping for pdqsort to remain O(n).
+      for (int i = 0; i < num; ++i) {
+        std::iter_swap(first + offsets_l[i], last - offsets_r[i]);
+      }
+    } else if (num > 0) {
+      Iter l = first + offsets_l[0];
+      Iter r = last - offsets_r[0];
+      T tmp(PDQSORT_PREFER_MOVE(*l));
+      *l = PDQSORT_PREFER_MOVE(*r);
+      for (int i = 1; i < num; ++i) {
+        l = first + offsets_l[i];
+        *r = PDQSORT_PREFER_MOVE(*l);
+        r = last - offsets_r[i];
+        *l = PDQSORT_PREFER_MOVE(*r);
+      }
+      *r = PDQSORT_PREFER_MOVE(tmp);
+    }
+  }
+
+  // Partitions [begin, end) around pivot *begin using comparison function comp.
+  // Elements equal
+  // to the pivot are put in the right-hand partition. Returns the position of
+  // the pivot after
+  // partitioning and whether the passed sequence already was correctly
+  // partitioned. Assumes the
+  // pivot is a median of at least 3 elements and that [begin, end) is at least
+  // insertion_sort_threshold long. Uses branchless partitioning.
+  template <class Iter, class Compare>
+  inline std::pair<Iter, bool> partition_right_branchless(Iter begin, Iter end,
+                                                          Compare comp)
+  {
+    typedef typename std::iterator_traits<Iter>::value_type T;
+
+    // Move pivot into local for speed.
+    T pivot(PDQSORT_PREFER_MOVE(*begin));
+    Iter first = begin;
+    Iter last = end;
+
+    // Find the first element greater than or equal than the pivot (the median
+    // of 3 guarantees
+    // this exists).
+    while (comp(*++first, pivot))
+      ;
+
+    // Find the first element strictly smaller than the pivot. We have to guard
+    // this search if
+    // there was no element before *first.
+    if (first - 1 == begin)
+      while (first < last && !comp(*--last, pivot))
+        ;
+    else
+      while (!comp(*--last, pivot))
+        ;
+
+    // If the first pair of elements that should be swapped to partition are the
+    // same element,
+    // the passed in sequence already was correctly partitioned.
+    bool already_partitioned = first >= last;
+    if (!already_partitioned) {
+      std::iter_swap(first, last);
+      ++first;
     }
 
-    template<class Iter>
-    inline void swap_offsets(Iter first, Iter last,
-                             unsigned char* offsets_l, unsigned char* offsets_r,
-                             int num, bool use_swaps) {
-        typedef typename std::iterator_traits<Iter>::value_type T;
-        if (use_swaps) {
-            // This case is needed for the descending distribution, where we need
-            // to have proper swapping for pdqsort to remain O(n).
-            for (int i = 0; i < num; ++i) {
-                std::iter_swap(first + offsets_l[i], last - offsets_r[i]);
-            }
-        } else if (num > 0) {
-            Iter l = first + offsets_l[0]; Iter r = last - offsets_r[0];
-            T tmp(PDQSORT_PREFER_MOVE(*l)); *l = PDQSORT_PREFER_MOVE(*r);
-            for (int i = 1; i < num; ++i) {
-                l = first + offsets_l[i]; *r = PDQSORT_PREFER_MOVE(*l);
-                r = last - offsets_r[i]; *l = PDQSORT_PREFER_MOVE(*r);
-            }
-            *r = PDQSORT_PREFER_MOVE(tmp);
+    // The following branchless partitioning is derived from "BlockQuicksort:
+    // How Branch
+    // Mispredictions don’t affect Quicksort" by Stefan Edelkamp and Armin
+    // Weiss.
+    unsigned char offsets_l_storage[block_size + cacheline_size];
+    unsigned char offsets_r_storage[block_size + cacheline_size];
+    unsigned char *offsets_l = align_cacheline(offsets_l_storage);
+    unsigned char *offsets_r = align_cacheline(offsets_r_storage);
+    int num_l, num_r, start_l, start_r;
+    num_l = num_r = start_l = start_r = 0;
+
+    while (last - first > 2 * block_size) {
+      // Fill up offset blocks with elements that are on the wrong side.
+      if (num_l == 0) {
+        start_l = 0;
+        Iter it = first;
+        for (unsigned char i = 0; i < block_size;) {
+          offsets_l[num_l] = i++;
+          num_l += !comp(*it, pivot);
+          ++it;
+          offsets_l[num_l] = i++;
+          num_l += !comp(*it, pivot);
+          ++it;
+          offsets_l[num_l] = i++;
+          num_l += !comp(*it, pivot);
+          ++it;
+          offsets_l[num_l] = i++;
+          num_l += !comp(*it, pivot);
+          ++it;
+          offsets_l[num_l] = i++;
+          num_l += !comp(*it, pivot);
+          ++it;
+          offsets_l[num_l] = i++;
+          num_l += !comp(*it, pivot);
+          ++it;
+          offsets_l[num_l] = i++;
+          num_l += !comp(*it, pivot);
+          ++it;
+          offsets_l[num_l] = i++;
+          num_l += !comp(*it, pivot);
+          ++it;
         }
+      }
+      if (num_r == 0) {
+        start_r = 0;
+        Iter it = last;
+        for (unsigned char i = 0; i < block_size;) {
+          offsets_r[num_r] = ++i;
+          num_r += comp(*--it, pivot);
+          offsets_r[num_r] = ++i;
+          num_r += comp(*--it, pivot);
+          offsets_r[num_r] = ++i;
+          num_r += comp(*--it, pivot);
+          offsets_r[num_r] = ++i;
+          num_r += comp(*--it, pivot);
+          offsets_r[num_r] = ++i;
+          num_r += comp(*--it, pivot);
+          offsets_r[num_r] = ++i;
+          num_r += comp(*--it, pivot);
+          offsets_r[num_r] = ++i;
+          num_r += comp(*--it, pivot);
+          offsets_r[num_r] = ++i;
+          num_r += comp(*--it, pivot);
+        }
+      }
+
+      // Swap elements and update block sizes and first/last boundaries.
+      int num = std::min(num_l, num_r);
+      swap_offsets(first, last, offsets_l + start_l, offsets_r + start_r, num,
+                   num_l == num_r);
+      num_l -= num;
+      num_r -= num;
+      start_l += num;
+      start_r += num;
+      if (num_l == 0)
+        first += block_size;
+      if (num_r == 0)
+        last -= block_size;
     }
 
-    // Partitions [begin, end) around pivot *begin using comparison function comp. Elements equal
-    // to the pivot are put in the right-hand partition. Returns the position of the pivot after
-    // partitioning and whether the passed sequence already was correctly partitioned. Assumes the
-    // pivot is a median of at least 3 elements and that [begin, end) is at least
-    // insertion_sort_threshold long. Uses branchless partitioning.
-    template<class Iter, class Compare>
-    inline std::pair<Iter, bool> partition_right_branchless(Iter begin, Iter end, Compare comp) {
-        typedef typename std::iterator_traits<Iter>::value_type T;
-
-        // Move pivot into local for speed.
-        T pivot(PDQSORT_PREFER_MOVE(*begin));
-        Iter first = begin;
-        Iter last = end;
-
-        // Find the first element greater than or equal than the pivot (the median of 3 guarantees
-        // this exists).
-        while (comp(*++first, pivot));
-
-        // Find the first element strictly smaller than the pivot. We have to guard this search if
-        // there was no element before *first.
-        if (first - 1 == begin) while (first < last && !comp(*--last, pivot));
-        else                    while (                !comp(*--last, pivot));
-
-        // If the first pair of elements that should be swapped to partition are the same element,
-        // the passed in sequence already was correctly partitioned.
-        bool already_partitioned = first >= last;
-        if (!already_partitioned) {
-            std::iter_swap(first, last);
-            ++first;
-        }
-
-        // The following branchless partitioning is derived from "BlockQuicksort: How Branch
-        // Mispredictions don’t affect Quicksort" by Stefan Edelkamp and Armin Weiss.
-        unsigned char offsets_l_storage[block_size + cacheline_size];
-        unsigned char offsets_r_storage[block_size + cacheline_size];
-        unsigned char* offsets_l = align_cacheline(offsets_l_storage);
-        unsigned char* offsets_r = align_cacheline(offsets_r_storage);
-        int num_l, num_r, start_l, start_r;
-        num_l = num_r = start_l = start_r = 0;
-        
-        while (last - first > 2 * block_size) {
-            // Fill up offset blocks with elements that are on the wrong side.
-            if (num_l == 0) {
-                start_l = 0;
-                Iter it = first;
-                for (unsigned char i = 0; i < block_size;) {
-                    offsets_l[num_l] = i++; num_l += !comp(*it, pivot); ++it;
-                    offsets_l[num_l] = i++; num_l += !comp(*it, pivot); ++it;
-                    offsets_l[num_l] = i++; num_l += !comp(*it, pivot); ++it;
-                    offsets_l[num_l] = i++; num_l += !comp(*it, pivot); ++it;
-                    offsets_l[num_l] = i++; num_l += !comp(*it, pivot); ++it;
-                    offsets_l[num_l] = i++; num_l += !comp(*it, pivot); ++it;
-                    offsets_l[num_l] = i++; num_l += !comp(*it, pivot); ++it;
-                    offsets_l[num_l] = i++; num_l += !comp(*it, pivot); ++it;
-                }
-            }
-            if (num_r == 0) {
-                start_r = 0;
-                Iter it = last;
-                for (unsigned char i = 0; i < block_size;) {
-                    offsets_r[num_r] = ++i; num_r += comp(*--it, pivot);
-                    offsets_r[num_r] = ++i; num_r += comp(*--it, pivot);
-                    offsets_r[num_r] = ++i; num_r += comp(*--it, pivot);
-                    offsets_r[num_r] = ++i; num_r += comp(*--it, pivot);
-                    offsets_r[num_r] = ++i; num_r += comp(*--it, pivot);
-                    offsets_r[num_r] = ++i; num_r += comp(*--it, pivot);
-                    offsets_r[num_r] = ++i; num_r += comp(*--it, pivot);
-                    offsets_r[num_r] = ++i; num_r += comp(*--it, pivot);
-                }
-            }
-
-            // Swap elements and update block sizes and first/last boundaries.
-            int num = std::min(num_l, num_r);
-            swap_offsets(first, last, offsets_l + start_l, offsets_r + start_r,
-                         num, num_l == num_r);
-            num_l -= num; num_r -= num;
-            start_l += num; start_r += num;
-            if (num_l == 0) first += block_size;
-            if (num_r == 0) last -= block_size;
-        }
-
-        int l_size = 0, r_size = 0;
-        int unknown_left = (int)(last - first) - ((num_r || num_l) ? block_size : 0);
-        if (num_r) {
-            // Handle leftover block by assigning the unknown elements to the other block.
-            l_size = unknown_left;
-            r_size = block_size;
-        } else if (num_l) {
-            l_size = block_size;
-            r_size = unknown_left;
-        } else {
-            // No leftover block, split the unknown elements in two blocks.
-            l_size = unknown_left/2;
-            r_size = unknown_left - l_size;
-        }
-
-        // Fill offset buffers if needed.
-        if (unknown_left && !num_l) {
-            start_l = 0;
-            Iter it = first;
-            for (unsigned char i = 0; i < l_size;) {
-                offsets_l[num_l] = i++; num_l += !comp(*it, pivot); ++it;
-            }
-        }
-        if (unknown_left && !num_r) {
-            start_r = 0;
-            Iter it = last;
-            for (unsigned char i = 0; i < r_size;) {
-                offsets_r[num_r] = ++i; num_r += comp(*--it, pivot);
-            }
-        }
-
-        int num = std::min(num_l, num_r);
-        swap_offsets(first, last, offsets_l + start_l, offsets_r + start_r, num, num_l == num_r);
-        num_l -= num; num_r -= num;
-        start_l += num; start_r += num;
-        if (num_l == 0) first += l_size;
-        if (num_r == 0) last -= r_size;
-        
-        // We have now fully identified [first, last)'s proper position. Swap the last elements.
-        if (num_l) {
-            offsets_l += start_l;
-            while (num_l--) std::iter_swap(first + offsets_l[num_l], --last);
-            first = last;
-        }
-        if (num_r) {
-            offsets_r += start_r;
-            while (num_r--) std::iter_swap(last - offsets_r[num_r], first), ++first;
-            last = first;
-        }
-
-        // Put the pivot in the right place.
-        Iter pivot_pos = first - 1;
-        *begin = PDQSORT_PREFER_MOVE(*pivot_pos);
-        *pivot_pos = PDQSORT_PREFER_MOVE(pivot);
-
-        return std::make_pair(pivot_pos, already_partitioned);
+    int l_size = 0, r_size = 0;
+    int unknown_left =
+        (int)(last - first) - ((num_r || num_l) ? block_size : 0);
+    if (num_r) {
+      // Handle leftover block by assigning the unknown elements to the other
+      // block.
+      l_size = unknown_left;
+      r_size = block_size;
+    } else if (num_l) {
+      l_size = block_size;
+      r_size = unknown_left;
+    } else {
+      // No leftover block, split the unknown elements in two blocks.
+      l_size = unknown_left / 2;
+      r_size = unknown_left - l_size;
     }
 
-    // Partitions [begin, end) around pivot *begin using comparison function comp. Elements equal
-    // to the pivot are put in the right-hand partition. Returns the position of the pivot after
-    // partitioning and whether the passed sequence already was correctly partitioned. Assumes the
-    // pivot is a median of at least 3 elements and that [begin, end) is at least
-    // insertion_sort_threshold long.
-    template<class Iter, class Compare>
-    inline std::pair<Iter, bool> partition_right(Iter begin, Iter end, Compare comp) {
-        typedef typename std::iterator_traits<Iter>::value_type T;
-        
-        // Move pivot into local for speed.
-        T pivot(PDQSORT_PREFER_MOVE(*begin));
-
-        Iter first = begin;
-        Iter last = end;
-
-        // Find the first element greater than or equal than the pivot (the median of 3 guarantees
-        // this exists).
-        while (comp(*++first, pivot));
-
-        // Find the first element strictly smaller than the pivot. We have to guard this search if
-        // there was no element before *first.
-        if (first - 1 == begin) while (first < last && !comp(*--last, pivot));
-        else                    while (                !comp(*--last, pivot));
-
-        // If the first pair of elements that should be swapped to partition are the same element,
-        // the passed in sequence already was correctly partitioned.
-        bool already_partitioned = first >= last;
-        
-        // Keep swapping pairs of elements that are on the wrong side of the pivot. Previously
-        // swapped pairs guard the searches, which is why the first iteration is special-cased
-        // above.
-        while (first < last) {
-            std::iter_swap(first, last);
-            while (comp(*++first, pivot));
-            while (!comp(*--last, pivot));
-        }
-
-        // Put the pivot in the right place.
-        Iter pivot_pos = first - 1;
-        *begin = PDQSORT_PREFER_MOVE(*pivot_pos);
-        *pivot_pos = PDQSORT_PREFER_MOVE(pivot);
-
-        return std::make_pair(pivot_pos, already_partitioned);
+    // Fill offset buffers if needed.
+    if (unknown_left && !num_l) {
+      start_l = 0;
+      Iter it = first;
+      for (unsigned char i = 0; i < l_size;) {
+        offsets_l[num_l] = i++;
+        num_l += !comp(*it, pivot);
+        ++it;
+      }
+    }
+    if (unknown_left && !num_r) {
+      start_r = 0;
+      Iter it = last;
+      for (unsigned char i = 0; i < r_size;) {
+        offsets_r[num_r] = ++i;
+        num_r += comp(*--it, pivot);
+      }
     }
 
-    // Similar function to the one above, except elements equal to the pivot are put to the left of
-    // the pivot and it doesn't check or return if the passed sequence already was partitioned.
-    // Since this is rarely used (the many equal case), and in that case pdqsort already has O(n)
-    // performance, no block quicksort is applied here for simplicity.
-    template<class Iter, class Compare>
-    inline Iter partition_left(Iter begin, Iter end, Compare comp) {
-        typedef typename std::iterator_traits<Iter>::value_type T;
+    int num = std::min(num_l, num_r);
+    swap_offsets(first, last, offsets_l + start_l, offsets_r + start_r, num,
+                 num_l == num_r);
+    num_l -= num;
+    num_r -= num;
+    start_l += num;
+    start_r += num;
+    if (num_l == 0)
+      first += l_size;
+    if (num_r == 0)
+      last -= r_size;
 
-        T pivot(PDQSORT_PREFER_MOVE(*begin));
-        Iter first = begin;
-        Iter last = end;
-        
-        while (comp(pivot, *--last));
-
-        if (last + 1 == end) while (first < last && !comp(pivot, *++first));
-        else                 while (                !comp(pivot, *++first));
-
-        while (first < last) {
-            std::iter_swap(first, last);
-            while (comp(pivot, *--last));
-            while (!comp(pivot, *++first));
-        }
-
-        Iter pivot_pos = last;
-        *begin = PDQSORT_PREFER_MOVE(*pivot_pos);
-        *pivot_pos = PDQSORT_PREFER_MOVE(pivot);
-
-        return pivot_pos;
+    // We have now fully identified [first, last)'s proper position. Swap the
+    // last elements.
+    if (num_l) {
+      offsets_l += start_l;
+      while (num_l--)
+        std::iter_swap(first + offsets_l[num_l], --last);
+      first = last;
+    }
+    if (num_r) {
+      offsets_r += start_r;
+      while (num_r--)
+        std::iter_swap(last - offsets_r[num_r], first), ++first;
+      last = first;
     }
 
+    // Put the pivot in the right place.
+    Iter pivot_pos = first - 1;
+    *begin = PDQSORT_PREFER_MOVE(*pivot_pos);
+    *pivot_pos = PDQSORT_PREFER_MOVE(pivot);
 
-    template<class Iter, class Compare, bool Branchless>
-    inline void pdqsort_loop(Iter begin, Iter end, Compare comp, int bad_allowed, bool leftmost = true) {
-        typedef typename std::iterator_traits<Iter>::difference_type diff_t;
+    return std::make_pair(pivot_pos, already_partitioned);
+  }
 
-        // Use a while loop for tail recursion elimination.
-        while (true) {
-            diff_t size = end - begin;
+  // Partitions [begin, end) around pivot *begin using comparison function comp.
+  // Elements equal
+  // to the pivot are put in the right-hand partition. Returns the position of
+  // the pivot after
+  // partitioning and whether the passed sequence already was correctly
+  // partitioned. Assumes the
+  // pivot is a median of at least 3 elements and that [begin, end) is at least
+  // insertion_sort_threshold long.
+  template <class Iter, class Compare>
+  inline std::pair<Iter, bool> partition_right(Iter begin, Iter end,
+                                               Compare comp)
+  {
+    typedef typename std::iterator_traits<Iter>::value_type T;
 
-            // Insertion sort is faster for small arrays.
-            if (size < insertion_sort_threshold) {
-                if (leftmost) insertion_sort(begin, end, comp);
-                else unguarded_insertion_sort(begin, end, comp);
-                return;
-            }
+    // Move pivot into local for speed.
+    T pivot(PDQSORT_PREFER_MOVE(*begin));
 
-            // Choose pivot as median of 3 or pseudomedian of 9.
-            diff_t s2 = size / 2;
-            if (size > ninther_threshold) {
-                sort3(begin, begin + s2, end - 1, comp);
-                sort3(begin + 1, begin + (s2 - 1), end - 2, comp);
-                sort3(begin + 2, begin + (s2 + 1), end - 3, comp);
-                sort3(begin + (s2 - 1), begin + s2, begin + (s2 + 1), comp);
-                std::iter_swap(begin, begin + s2);
-            } else sort3(begin + s2, begin, end - 1, comp);
+    Iter first = begin;
+    Iter last = end;
 
-            // If *(begin - 1) is the end of the right partition of a previous partition operation
-            // there is no element in [begin, end) that is smaller than *(begin - 1). Then if our
-            // pivot compares equal to *(begin - 1) we change strategy, putting equal elements in
-            // the left partition, greater elements in the right partition. We do not have to
-            // recurse on the left partition, since it's sorted (all equal).
-            if (!leftmost && !comp(*(begin - 1), *begin)) {
-                begin = partition_left(begin, end, comp) + 1;
-                continue;
-            }
+    // Find the first element greater than or equal than the pivot (the median
+    // of 3 guarantees
+    // this exists).
+    while (comp(*++first, pivot))
+      ;
 
-            // Partition and get results.
-            std::pair<Iter, bool> part_result =
-                Branchless ? partition_right_branchless(begin, end, comp)
-                           : partition_right(begin, end, comp);
-            Iter pivot_pos = part_result.first;
-            bool already_partitioned = part_result.second;
+    // Find the first element strictly smaller than the pivot. We have to guard
+    // this search if
+    // there was no element before *first.
+    if (first - 1 == begin)
+      while (first < last && !comp(*--last, pivot))
+        ;
+    else
+      while (!comp(*--last, pivot))
+        ;
 
-            // Check for a highly unbalanced partition.
-            diff_t l_size = pivot_pos - begin;
-            diff_t r_size = end - (pivot_pos + 1);
-            bool highly_unbalanced = l_size < size / 8 || r_size < size / 8;
+    // If the first pair of elements that should be swapped to partition are the
+    // same element,
+    // the passed in sequence already was correctly partitioned.
+    bool already_partitioned = first >= last;
 
-            // If we got a highly unbalanced partition we shuffle elements to break many patterns.
-            if (highly_unbalanced) {
-                // If we had too many bad partitions, switch to heapsort to guarantee O(n log n).
-                if (--bad_allowed == 0) {
-                    std::make_heap(begin, end, comp);
-                    std::sort_heap(begin, end, comp);
-                    return;
-                }
-
-                if (l_size >= insertion_sort_threshold) {
-                    std::iter_swap(begin,             begin + l_size / 4);
-                    std::iter_swap(pivot_pos - 1, pivot_pos - l_size / 4);
-
-                    if (l_size > ninther_threshold) {
-                        std::iter_swap(begin + 1,         begin + (l_size / 4 + 1));
-                        std::iter_swap(begin + 2,         begin + (l_size / 4 + 2));
-                        std::iter_swap(pivot_pos - 2, pivot_pos - (l_size / 4 + 1));
-                        std::iter_swap(pivot_pos - 3, pivot_pos - (l_size / 4 + 2));
-                    }
-                }
-                
-                if (r_size >= insertion_sort_threshold) {
-                    std::iter_swap(pivot_pos + 1, pivot_pos + (1 + r_size / 4));
-                    std::iter_swap(end - 1,                   end - r_size / 4);
-                    
-                    if (r_size > ninther_threshold) {
-                        std::iter_swap(pivot_pos + 2, pivot_pos + (2 + r_size / 4));
-                        std::iter_swap(pivot_pos + 3, pivot_pos + (3 + r_size / 4));
-                        std::iter_swap(end - 2,             end - (1 + r_size / 4));
-                        std::iter_swap(end - 3,             end - (2 + r_size / 4));
-                    }
-                }
-            } else {
-                // If we were decently balanced and we tried to sort an already partitioned
-                // sequence try to use insertion sort.
-                if (already_partitioned && partial_insertion_sort(begin, pivot_pos, comp)
-                                        && partial_insertion_sort(pivot_pos + 1, end, comp)) return;
-            }
-                
-            // Sort the left partition first using recursion and do tail recursion elimination for
-            // the right-hand partition.
-            pdqsort_loop<Iter, Compare, Branchless>(begin, pivot_pos, comp, bad_allowed, leftmost);
-            begin = pivot_pos + 1;
-            leftmost = false;
-        }
+    // Keep swapping pairs of elements that are on the wrong side of the pivot.
+    // Previously
+    // swapped pairs guard the searches, which is why the first iteration is
+    // special-cased
+    // above.
+    while (first < last) {
+      std::iter_swap(first, last);
+      while (comp(*++first, pivot))
+        ;
+      while (!comp(*--last, pivot))
+        ;
     }
+
+    // Put the pivot in the right place.
+    Iter pivot_pos = first - 1;
+    *begin = PDQSORT_PREFER_MOVE(*pivot_pos);
+    *pivot_pos = PDQSORT_PREFER_MOVE(pivot);
+
+    return std::make_pair(pivot_pos, already_partitioned);
+  }
+
+  // Similar function to the one above, except elements equal to the pivot are
+  // put to the left of
+  // the pivot and it doesn't check or return if the passed sequence already was
+  // partitioned.
+  // Since this is rarely used (the many equal case), and in that case pdqsort
+  // already has O(n)
+  // performance, no block quicksort is applied here for simplicity.
+  template <class Iter, class Compare>
+  inline Iter partition_left(Iter begin, Iter end, Compare comp)
+  {
+    typedef typename std::iterator_traits<Iter>::value_type T;
+
+    T pivot(PDQSORT_PREFER_MOVE(*begin));
+    Iter first = begin;
+    Iter last = end;
+
+    while (comp(pivot, *--last))
+      ;
+
+    if (last + 1 == end)
+      while (first < last && !comp(pivot, *++first))
+        ;
+    else
+      while (!comp(pivot, *++first))
+        ;
+
+    while (first < last) {
+      std::iter_swap(first, last);
+      while (comp(pivot, *--last))
+        ;
+      while (!comp(pivot, *++first))
+        ;
+    }
+
+    Iter pivot_pos = last;
+    *begin = PDQSORT_PREFER_MOVE(*pivot_pos);
+    *pivot_pos = PDQSORT_PREFER_MOVE(pivot);
+
+    return pivot_pos;
+  }
+
+  template <class Iter, class Compare, bool Branchless>
+  inline void pdqsort_loop(Iter begin, Iter end, Compare comp, int bad_allowed,
+                           bool leftmost = true)
+  {
+    typedef typename std::iterator_traits<Iter>::difference_type diff_t;
+
+    // Use a while loop for tail recursion elimination.
+    while (true) {
+      diff_t size = end - begin;
+
+      // Insertion sort is faster for small arrays.
+      if (size < insertion_sort_threshold) {
+        if (leftmost)
+          insertion_sort(begin, end, comp);
+        else
+          unguarded_insertion_sort(begin, end, comp);
+        return;
+      }
+
+      // Choose pivot as median of 3 or pseudomedian of 9.
+      diff_t s2 = size / 2;
+      if (size > ninther_threshold) {
+        sort3(begin, begin + s2, end - 1, comp);
+        sort3(begin + 1, begin + (s2 - 1), end - 2, comp);
+        sort3(begin + 2, begin + (s2 + 1), end - 3, comp);
+        sort3(begin + (s2 - 1), begin + s2, begin + (s2 + 1), comp);
+        std::iter_swap(begin, begin + s2);
+      } else
+        sort3(begin + s2, begin, end - 1, comp);
+
+      // If *(begin - 1) is the end of the right partition of a previous
+      // partition operation
+      // there is no element in [begin, end) that is smaller than *(begin - 1).
+      // Then if our
+      // pivot compares equal to *(begin - 1) we change strategy, putting equal
+      // elements in
+      // the left partition, greater elements in the right partition. We do not
+      // have to
+      // recurse on the left partition, since it's sorted (all equal).
+      if (!leftmost && !comp(*(begin - 1), *begin)) {
+        begin = partition_left(begin, end, comp) + 1;
+        continue;
+      }
+
+      // Partition and get results.
+      std::pair<Iter, bool> part_result =
+          Branchless ? partition_right_branchless(begin, end, comp)
+                     : partition_right(begin, end, comp);
+      Iter pivot_pos = part_result.first;
+      bool already_partitioned = part_result.second;
+
+      // Check for a highly unbalanced partition.
+      diff_t l_size = pivot_pos - begin;
+      diff_t r_size = end - (pivot_pos + 1);
+      bool highly_unbalanced = l_size < size / 8 || r_size < size / 8;
+
+      // If we got a highly unbalanced partition we shuffle elements to break
+      // many patterns.
+      if (highly_unbalanced) {
+        // If we had too many bad partitions, switch to heapsort to guarantee
+        // O(n log n).
+        if (--bad_allowed == 0) {
+          std::make_heap(begin, end, comp);
+          std::sort_heap(begin, end, comp);
+          return;
+        }
+
+        if (l_size >= insertion_sort_threshold) {
+          std::iter_swap(begin, begin + l_size / 4);
+          std::iter_swap(pivot_pos - 1, pivot_pos - l_size / 4);
+
+          if (l_size > ninther_threshold) {
+            std::iter_swap(begin + 1, begin + (l_size / 4 + 1));
+            std::iter_swap(begin + 2, begin + (l_size / 4 + 2));
+            std::iter_swap(pivot_pos - 2, pivot_pos - (l_size / 4 + 1));
+            std::iter_swap(pivot_pos - 3, pivot_pos - (l_size / 4 + 2));
+          }
+        }
+
+        if (r_size >= insertion_sort_threshold) {
+          std::iter_swap(pivot_pos + 1, pivot_pos + (1 + r_size / 4));
+          std::iter_swap(end - 1, end - r_size / 4);
+
+          if (r_size > ninther_threshold) {
+            std::iter_swap(pivot_pos + 2, pivot_pos + (2 + r_size / 4));
+            std::iter_swap(pivot_pos + 3, pivot_pos + (3 + r_size / 4));
+            std::iter_swap(end - 2, end - (1 + r_size / 4));
+            std::iter_swap(end - 3, end - (2 + r_size / 4));
+          }
+        }
+      } else {
+        // If we were decently balanced and we tried to sort an already
+        // partitioned
+        // sequence try to use insertion sort.
+        if (already_partitioned &&
+            partial_insertion_sort(begin, pivot_pos, comp) &&
+            partial_insertion_sort(pivot_pos + 1, end, comp))
+          return;
+      }
+
+      // Sort the left partition first using recursion and do tail recursion
+      // elimination for
+      // the right-hand partition.
+      pdqsort_loop<Iter, Compare, Branchless>(begin, pivot_pos, comp,
+                                              bad_allowed, leftmost);
+      begin = pivot_pos + 1;
+      leftmost = false;
+    }
+  }
 }
 
-
-template<class Iter, class Compare>
-inline void pdqsort(Iter begin, Iter end, Compare comp) {
-    if (begin == end) return;
+template <class Iter, class Compare>
+inline void pdqsort(Iter begin, Iter end, Compare comp)
+{
+  if (begin == end)
+    return;
 
 #if __cplusplus >= 201103L
-    pdqsort_detail::pdqsort_loop<Iter, Compare,
-        pdqsort_detail::is_default_compare<typename std::decay<Compare>::type>::value &&
-        std::is_arithmetic<typename std::iterator_traits<Iter>::value_type>::value>(
-        begin, end, comp, pdqsort_detail::log2(end - begin));
+  pdqsort_detail::pdqsort_loop<
+      Iter, Compare, pdqsort_detail::is_default_compare<
+                         typename std::decay<Compare>::type>::value &&
+                         std::is_arithmetic<typename std::iterator_traits<
+                             Iter>::value_type>::value>(
+      begin, end, comp, pdqsort_detail::log2(end - begin));
 #else
-    pdqsort_detail::pdqsort_loop<Iter, Compare, false>(
-        begin, end, comp, pdqsort_detail::log2(end - begin));
+  pdqsort_detail::pdqsort_loop<Iter, Compare, false>(
+      begin, end, comp, pdqsort_detail::log2(end - begin));
 #endif
 }
 
-template<class Iter>
-inline void pdqsort(Iter begin, Iter end) {
-    typedef typename std::iterator_traits<Iter>::value_type T;
-    pdqsort(begin, end, std::less<T>());
+template <class Iter>
+inline void pdqsort(Iter begin, Iter end)
+{
+  typedef typename std::iterator_traits<Iter>::value_type T;
+  pdqsort(begin, end, std::less<T>());
 }
 
-template<class Iter, class Compare>
-inline void pdqsort_branchless(Iter begin, Iter end, Compare comp) {
-    if (begin == end) return;
-    pdqsort_detail::pdqsort_loop<Iter, Compare, true>(
-        begin, end, comp, pdqsort_detail::log2(end - begin));
+template <class Iter, class Compare>
+inline void pdqsort_branchless(Iter begin, Iter end, Compare comp)
+{
+  if (begin == end)
+    return;
+  pdqsort_detail::pdqsort_loop<Iter, Compare, true>(
+      begin, end, comp, pdqsort_detail::log2(end - begin));
 }
 
-template<class Iter>
-inline void pdqsort_branchless(Iter begin, Iter end) {
-    typedef typename std::iterator_traits<Iter>::value_type T;
-    pdqsort_branchless(begin, end, std::less<T>());
+template <class Iter>
+inline void pdqsort_branchless(Iter begin, Iter end)
+{
+  typedef typename std::iterator_traits<Iter>::value_type T;
+  pdqsort_branchless(begin, end, std::less<T>());
 }
-
 
 #undef PDQSORT_PREFER_MOVE
 


### PR DESCRIPTION
This introduces a new type of slices, fast_contiguous_slice, with faster
methods. A direct consequence is the rewrite of most slicing methods to
accommodate this new type.

Fix #1603