### PR TITLE
Fix several testing issues on m32 architectures

### DIFF
--- a/pythran/pythonic/builtins/range.hpp
+++ b/pythran/pythonic/builtins/range.hpp
@@ -64,7 +64,8 @@ namespace builtins
 
   bool range_iterator::operator<(range_iterator const &other) const
   {
-    return step_ * value_ < step_ * other.value_;
+    const long sign = +1 | (step_ >> (sizeof(long) * CHAR_BIT - 1));
+    return sign * value_ < sign * other.value_;
   }
 
   long range_iterator::operator-(range_iterator const &other) const

--- a/pythran/tests/test_numpy_func0.py
+++ b/pythran/tests/test_numpy_func0.py
@@ -420,7 +420,7 @@ def np_rosen_der(x):
 
     def test_tofile2(self):
         temp_name = tempfile.mkstemp()[1]
-        x = numpy.random.randint(0,2**32,1000).astype(numpy.uint32)
+        x = numpy.random.randint(0,2**31,1000).astype(numpy.uint32)
         try:
             self.run_test("def np_tofile2(x,file): import numpy ; x.tofile(file); return numpy.fromfile(file)", x, temp_name, np_tofile2=[NDArray[numpy.uint32,:], str])
         finally:
@@ -462,7 +462,7 @@ def np_rosen_der(x):
 
     def test_fromfile2(self):
         temp_name = tempfile.mkstemp()[1]
-        x = numpy.random.randint(0,2**32,1000).astype(numpy.uint32)
+        x = numpy.random.randint(0,2**31,1000).astype(numpy.uint32)
         x.tofile(temp_name)
         try:
             self.run_test("def np_fromfile2(file): from numpy import fromfile, uint32 ; return fromfile(file, uint32)", temp_name, np_fromfile2=[str])

--- a/pythran/tests/test_numpy_func2.py
+++ b/pythran/tests/test_numpy_func2.py
@@ -491,7 +491,7 @@ def test_copy0(x):
         self.run_test("def np_asarray4(a):\n from numpy import asarray\n return asarray(a[1:])", [(1,2),(3,4)], np_asarray4=[List[Tuple[int, int]]])
 
     def test_asarray5(self):
-        self.run_test("def np_asarray5(a):\n from numpy import asarray\n return asarray(a)", 1, np_asarray5=[int])
+        self.run_test("def np_asarray5(a):\n from numpy import asarray\n return asarray(a)", 1., np_asarray5=[float])
 
     def test_asarray6(self):
         self.run_test("def np_asarray6(a):\n from numpy import asarray\n return asarray(a, dtype=int)", 1.5, np_asarray6=[float])


### PR DESCRIPTION
- Do not overflow using 2**32
- Be explicit about array type

This is a partial fix for #1639