### PR TITLE
Handle typing of rvalues in a decent way

### DIFF
--- a/pythran/backend.py
+++ b/pythran/backend.py
@@ -916,7 +916,19 @@ class CxxFunction(ast.NodeVisitor):
         return " and ".join(op(x, y) for x, op, y in all_cmps)
 
     def visit_Call(self, node):
-        args = [self.visit(n) for n in node.args]
+        args = []
+        args_cast = []
+        for arg in node.args:
+            args.append(self.visit(arg))
+            if isinstance(arg, ast.Name):
+                args_cast.append("")
+            else:
+                arg_ty = self.types.get(arg, None)
+                if isinstance(arg_ty, self.types.builder.CombinedTypes):
+                    args_cast.append("({})".format(arg_ty))
+                else:
+                    args_cast.append("")
+
         func = self.visit(node.func)
         # special hook for getattr, as we cannot represent it in C++
         if func == 'pythonic::builtins::functor::getattr{}':
@@ -925,7 +937,9 @@ class CxxFunction(ast.NodeVisitor):
                             + node.args[1].value.upper(),
                             args[0]))
         else:
-            return "{}({})".format(func, ", ".join(args))
+            return "{}({})".format(
+                func,
+                ", ".join("{}{}".format(*z) for z in zip(args_cast, args)))
 
     def visit_Constant(self, node):
         if node.value is None:

--- a/pythran/tests/test_typing.py
+++ b/pythran/tests/test_typing.py
@@ -677,3 +677,13 @@ def recursive_interprocedural_typing2(c):
                 else:
                     return np.arange(n)[1:-1]'''
         return self.run_test(code, 6, numpy_array_combiner5=[int])
+
+    def test_typing_rvalue0(self):
+        code = '''
+            def foo(x, n):
+                x.append(n)
+                return x
+            def typing_rvalue0(n):
+                return foo([], n)'''
+        return self.run_test(code, 6, typing_rvalue0=[int])
+


### PR DESCRIPTION
Introduce an explicit cast on rvalues to deal with combiner applied on
non-reference nodes.

Fix #1572