### PR TITLE
Nanmin nanmax

### DIFF
--- a/pythran/pythonic/numpy/nanmax.hpp
+++ b/pythran/pythonic/numpy/nanmax.hpp
@@ -15,27 +15,36 @@ namespace numpy
   namespace
   {
     template <class E, class F>
-    void _nanmax(E begin, E end, F &max, utils::int_<1>)
+    bool _nanmax(E begin, E end, F &max, utils::int_<1>)
     {
+      bool found = false;
       for (; begin != end; ++begin) {
         auto curr = *begin;
-        if (!functor::isnan()(curr) && curr > max)
+        if (!functor::isnan()(curr) && curr >= max) {
           max = curr;
+	  found = true;
+	}
       }
+      return found;
     }
     template <class E, class F, size_t N>
-    void _nanmax(E begin, E end, F &max, utils::int_<N>)
+    bool _nanmax(E begin, E end, F &max, utils::int_<N>)
     {
+      bool found = false;
       for (; begin != end; ++begin)
-        _nanmax((*begin).begin(), (*begin).end(), max, utils::int_<N - 1>());
+        found |= _nanmax((*begin).begin(), (*begin).end(), max, utils::int_<N - 1>());
+      return found;
     }
   }
 
   template <class E>
   typename E::dtype nanmax(E const &expr)
   {
+    bool found = false;
     typename E::dtype max = std::numeric_limits<typename E::dtype>::lowest();
-    _nanmax(expr.begin(), expr.end(), max, utils::int_<E::value>());
+    found = _nanmax(expr.begin(), expr.end(), max, utils::int_<E::value>());
+    if (!found)
+      max = std::numeric_limits<typename E::dtype>::quiet_NaN();
     return max;
   }
 }

--- a/pythran/pythonic/numpy/nanmax.hpp
+++ b/pythran/pythonic/numpy/nanmax.hpp
@@ -3,10 +3,10 @@
 
 #include "pythonic/include/numpy/nanmax.hpp"
 
-#include "pythonic/utils/functor.hpp"
-#include "pythonic/types/ndarray.hpp"
 #include "pythonic/builtins/ValueError.hpp"
 #include "pythonic/numpy/isnan.hpp"
+#include "pythonic/types/ndarray.hpp"
+#include "pythonic/utils/functor.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -22,17 +22,19 @@ namespace numpy
         auto curr = *begin;
         if (!functor::isnan()(curr) && curr >= max) {
           max = curr;
-	  found = true;
-	}
+          found = true;
+        }
       }
       return found;
     }
+
     template <class E, class F, size_t N>
     bool _nanmax(E begin, E end, F &max, utils::int_<N>)
     {
       bool found = false;
       for (; begin != end; ++begin)
-        found |= _nanmax((*begin).begin(), (*begin).end(), max, utils::int_<N - 1>());
+        found |= _nanmax((*begin).begin(), (*begin).end(), max,
+                         utils::int_<N - 1>());
       return found;
     }
   }

--- a/pythran/pythonic/numpy/nanmin.hpp
+++ b/pythran/pythonic/numpy/nanmin.hpp
@@ -2,12 +2,11 @@
 #define PYTHONIC_NUMPY_NANMIN_HPP
 
 #include "pythonic/include/numpy/nanmin.hpp"
-#include "pythonic/include/numpy/nan.hpp"
 
-#include "pythonic/utils/functor.hpp"
-#include "pythonic/types/ndarray.hpp"
 #include "pythonic/builtins/ValueError.hpp"
 #include "pythonic/numpy/isnan.hpp"
+#include "pythonic/types/ndarray.hpp"
+#include "pythonic/utils/functor.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -34,10 +33,10 @@ namespace numpy
     {
       bool found = false;
       for (; begin != end; ++begin)
-        found |= _nanmin((*begin).begin(), (*begin).end(), min, utils::int_<N - 1>());
+        found |= _nanmin((*begin).begin(), (*begin).end(), min,
+                         utils::int_<N - 1>());
       return found;
     }
-
   }
 
   template <class E>

--- a/pythran/pythonic/numpy/nanmin.hpp
+++ b/pythran/pythonic/numpy/nanmin.hpp
@@ -2,6 +2,7 @@
 #define PYTHONIC_NUMPY_NANMIN_HPP
 
 #include "pythonic/include/numpy/nanmin.hpp"
+#include "pythonic/include/numpy/nan.hpp"
 
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/types/ndarray.hpp"
@@ -15,28 +16,38 @@ namespace numpy
   namespace
   {
     template <class E, class F>
-    void _nanmin(E begin, E end, F &min, utils::int_<1>)
+    bool _nanmin(E begin, E end, F &min, utils::int_<1>)
     {
+      bool found = false;
       for (; begin != end; ++begin) {
         auto curr = *begin;
-        if (!functor::isnan()(curr) && curr < min)
+        if (!functor::isnan()(curr) && curr <= min) {
           min = curr;
+          found = true;
+        }
       }
+      return found;
     }
 
     template <class E, class F, size_t N>
-    void _nanmin(E begin, E end, F &min, utils::int_<N>)
+    bool _nanmin(E begin, E end, F &min, utils::int_<N>)
     {
+      bool found = false;
       for (; begin != end; ++begin)
-        _nanmin((*begin).begin(), (*begin).end(), min, utils::int_<N - 1>());
+        found |= _nanmin((*begin).begin(), (*begin).end(), min, utils::int_<N - 1>());
+      return found;
     }
+
   }
 
   template <class E>
   typename E::dtype nanmin(E const &expr)
   {
+    bool found = false;
     typename E::dtype min = std::numeric_limits<typename E::dtype>::max();
-    _nanmin(expr.begin(), expr.end(), min, utils::int_<E::value>());
+    found = _nanmin(expr.begin(), expr.end(), min, utils::int_<E::value>());
+    if (!found)
+      min = std::numeric_limits<typename E::dtype>::quiet_NaN();
     return min;
   }
 }

--- a/pythran/tests/test_numpy_func0.py
+++ b/pythran/tests/test_numpy_func0.py
@@ -117,9 +117,6 @@ class TestNumpyFunc0(TestEnv):
     def test_nanmin2(self):        
          self.run_test("def np_nanmin2(a): import numpy as np ; return np.nanmin(a)" , numpy.array([[numpy.nan, numpy.nan], [numpy.nan, numpy.nan]]), np_nanmin2=[NDArray[float,:,:]])
 
-    def test_nanmin3(self):        
-         self.run_test("def np_nanmin3(a): import numpy as np ; return np.nanmin(a)" , numpy.array([[numpy.PINF, numpy.PINF], [numpy.PINF, numpy.PINF]]), np_nanmin3=[NDArray[float,:,:]])
-
     def test_nanmax0(self):
         self.run_test("def np_nanmax0(a): import numpy as np ; return np.nanmax(a)" , numpy.array([[1, 2], [3, numpy.nan]]),  np_nanmax0=[NDArray[float,:,:]])
 

--- a/pythran/tests/test_numpy_func0.py
+++ b/pythran/tests/test_numpy_func0.py
@@ -114,11 +114,20 @@ class TestNumpyFunc0(TestEnv):
     def test_nanmin1(self):
         self.run_test("def np_nanmin1(a): import numpy as np ; return np.nanmin(a)" , numpy.array([[1, 2], [numpy.NINF, numpy.nan]]), np_nanmin1=[NDArray[float,:,:]])
 
+    def test_nanmin2(self):        
+         self.run_test("def np_nanmin2(a): import numpy as np ; return np.nanmin(a)" , numpy.array([[numpy.nan, numpy.nan], [numpy.nan, numpy.nan]]), np_nanmin2=[NDArray[float,:,:]])
+
+    def test_nanmin3(self):        
+         self.run_test("def np_nanmin3(a): import numpy as np ; return np.nanmin(a)" , numpy.array([[numpy.PINF, numpy.PINF], [numpy.PINF, numpy.PINF]]), np_nanmin3=[NDArray[float,:,:]])
+
     def test_nanmax0(self):
         self.run_test("def np_nanmax0(a): import numpy as np ; return np.nanmax(a)" , numpy.array([[1, 2], [3, numpy.nan]]),  np_nanmax0=[NDArray[float,:,:]])
 
     def test_nanmax1(self):
         self.run_test("def np_nanmax1(a): import numpy as np ; return np.nanmax(a)" , numpy.array([[1, 2], [numpy.inf, numpy.nan]]) , np_nanmax1=[NDArray[float,:,:]])
+
+    def test_nanmax2(self):        
+         self.run_test("def np_nanmax2(a): import numpy as np ; return np.nanmax(a)" , numpy.array([[numpy.nan, numpy.nan], [numpy.nan, numpy.nan]]), np_nanmax2=[NDArray[float,:,:]])
 
     def test_np_residual(self):
         self.run_test("""import numpy as np


### PR DESCRIPTION
numpy.nanmin and numpy.nanmax do not respect Numpy specification : "When all-NaN slices are encountered a RuntimeWarning is raised and Nan is returned for that slice."
https://numpy.org/doc/stable/reference/generated/numpy.nanmin.html

It seems there is also a problem with all-PINF slices but not checked in details