### PR TITLE
Fix bug in unwrap function

### DIFF
--- a/pythran/pythonic/numpy/unwrap.hpp
+++ b/pythran/pythonic/numpy/unwrap.hpp
@@ -10,6 +10,7 @@
 
 #include <pythonic/numpy/maximum.hpp>
 #include <pythonic/numpy/abs.hpp>
+#include <pythonic/numpy/round.hpp>
 
 PYTHONIC_NS_BEGIN
 
@@ -25,7 +26,7 @@ namespace numpy
       for (; ibegin != iend; ++ibegin, ++obegin) {
         if (functor::abs{}(*obegin - *ibegin) > discont)
           *(obegin + 1) =
-              *ibegin + 2 * pi * int((*obegin - *ibegin) / (discont));
+              *ibegin + 2 * pi * functor::round{}((*obegin - *ibegin) / (2*pi));
         else
           *(obegin + 1) = *ibegin;
       }

--- a/pythran/tests/test_numpy_func3.py
+++ b/pythran/tests/test_numpy_func3.py
@@ -332,7 +332,7 @@ def np_trim_zeros2(x):
         self.run_test("def np_unique4(x): from numpy import unique ; return unique(x, True, True, True)", numpy.array([1,1,2,2,2,1,5]), np_unique4=[NDArray[int,:]])
 
     def test_unwrap0(self):
-        self.run_test("def np_unwrap0(x): from numpy import unwrap, pi ; x[:3] += 2*pi; return unwrap(x)", numpy.arange(6, dtype=float), np_unwrap0=[NDArray[float,:]])
+        self.run_test("def np_unwrap0(x): from numpy import unwrap, pi ; x[:3] += 2.6*pi; return unwrap(x)", numpy.arange(6, dtype=float), np_unwrap0=[NDArray[float,:]])
 
     def test_unwrap1(self):
         self.run_test("def np_unwrap1(x): from numpy import unwrap, pi ; x[:3] += 2*pi; return unwrap(x, 4)", numpy.arange(6, dtype=float), np_unwrap1=[NDArray[float,:]])


### PR DESCRIPTION
The formula for unwrapping is y += 2*pi * round((x-y)/(2*pi)) (where x is the previous value)
The current formula was y += 2*pi * int((x-y)/(pi)) which is bad on two counts (pi instead of 2pi and not using round)
