### PR TITLE
Introduce a new type qualifier, AssignableNoEscape

### DIFF
--- a/pythran/backend.py
+++ b/pythran/backend.py
@@ -412,7 +412,7 @@ class CxxFunction(ast.NodeVisitor):
             elif isinstance(self.types[node.targets[0]],
                             self.types.builder.Assignable):
                 alltargets = '{} {}'.format(
-                    self.types.builder.Assignable(
+                    self.types.builder.AssignableNoEscape(
                         self.types.builder.NamedType(
                             'decltype({})'.format(value))),
                     alltargets)

--- a/pythran/cxxtypes.py
+++ b/pythran/cxxtypes.py
@@ -282,6 +282,15 @@ std::declval<bool>()))
                 return 'typename pythonic::assignable<{0}>::type'.format(
                     self.of.generate(ctx))
 
+        class AssignableNoEscape(DependentType):
+            """
+            Similar to Assignable, but it doesn't escape it's declaration scope
+            """
+
+            def generate(self, ctx):
+                return 'typename pythonic::assignable_noescape<{0}>::type'.format(
+                    self.of.generate(ctx))
+
         class Returnable(DependentType):
             """
             A type which can be returned

--- a/pythran/pythonic/include/numpy/reduce.hpp
+++ b/pythran/pythonic/include/numpy/reduce.hpp
@@ -40,6 +40,13 @@ namespace numpy
   reduce(E const &expr, types::none_type _ = types::none_type());
 
   template <class Op, class E>
+  reduce_result_type<Op, E> reduce(types::numpy_texpr<E> const &expr,
+                                   types::none_type _ = types::none_type())
+  {
+    return reduce<Op>(expr.arg);
+  }
+
+  template <class Op, class E>
   typename std::enable_if<
       std::is_scalar<E>::value || types::is_complex<E>::value, E>::type
   reduce(E const &expr, types::none_type _ = types::none_type());
@@ -69,6 +76,14 @@ namespace numpy
   typename std::enable_if<E::value != 1, reduced_type<E, Op>>::type
   reduce(E const &array, long axis, types::none_type dtype = types::none_type(),
          types::none_type out = types::none_type());
+
+  template <class Op, class E>
+  reduced_type<E, Op> reduce(types::numpy_texpr<E> const &array, long axis,
+                             types::none_type dtype = types::none_type(),
+                             types::none_type out = types::none_type())
+  {
+    return reduce<Op>(array.arg, (axis + 1) % 2);
+  }
 
   template <class Op, class E, class Out>
   typename std::enable_if<E::value != 1, reduced_type<E, Op>>::type

--- a/pythran/pythonic/include/operator_/mul.hpp
+++ b/pythran/pythonic/include/operator_/mul.hpp
@@ -10,7 +10,7 @@ namespace operator_
 {
 
   template <class A, class B>
-  auto mul(A const &a, B const &b) -> decltype(a *b);
+  auto mul(A &&a, B &&b) -> decltype(std::forward<A>(a) * std::forward<B>(b));
 
   DEFINE_ALL_OPERATOR_OVERLOADS_DECL(mul, *)
 

--- a/pythran/pythonic/include/types/assignable.hpp
+++ b/pythran/pythonic/include/types/assignable.hpp
@@ -34,6 +34,26 @@ struct lazy : assignable<T> {
 }; // very conservative
 
 template <class T>
+struct assignable_noescape : assignable<T> {
+};
+
+template <class T>
+struct assignable_noescape<T const> : assignable_noescape<T> {
+};
+
+template <class T>
+struct assignable_noescape<T const &> : assignable_noescape<T> {
+};
+
+template <class T>
+struct assignable_noescape<T &> : assignable_noescape<T> {
+};
+
+template <class T>
+struct assignable_noescape<T &&> : assignable_noescape<T> {
+};
+
+template <class T>
 struct returnable : assignable<T> {
 };
 

--- a/pythran/pythonic/include/types/numpy_expr.hpp
+++ b/pythran/pythonic/include/types/numpy_expr.hpp
@@ -746,8 +746,9 @@ namespace types
 #endif
 
     template <size_t... I, class... S>
-    auto _get(utils::index_sequence<I...> is, S const &... s) const
-        -> decltype(Op{}(std::get<I>(args)(s...)...))
+    auto _get(utils::index_sequence<I...> is, S const &... s) const -> decltype(
+        Op{}(make_subslice(utils::make_index_sequence<sizeof...(S)>{},
+                           std::get<I>(args), *this, std::make_tuple(s...))...))
     {
       return Op{}(make_subslice(utils::make_index_sequence<sizeof...(S)>{},
                                 std::get<I>(args), *this,

--- a/pythran/pythonic/include/types/numpy_gexpr.hpp
+++ b/pythran/pythonic/include/types/numpy_gexpr.hpp
@@ -119,8 +119,7 @@ namespace types
     template <class E, class Sp, class... S>
     typename std::enable_if<
         is_slice<Sp>::value,
-        numpy_gexpr<typename std::decay<E>::type, normalize_t<Sp>,
-                    normalize_t<S>...>>::type
+        numpy_gexpr<E, normalize_t<Sp>, normalize_t<S>...>>::type
     operator()(E &&expr, Sp const &s0, S const &... s)
     {
       return make_gexpr(std::forward<E>(expr), s0, s...);
@@ -868,6 +867,11 @@ namespace types
     }
   };
 }
+
+template <class E, class... S>
+struct assignable_noescape<types::numpy_gexpr<E, S...>> {
+  using type = types::numpy_gexpr<E, S...>;
+};
 
 template <class T, class pS, class... S>
 struct assignable<types::numpy_gexpr<types::ndarray<T, pS> const &, S...>> {

--- a/pythran/pythonic/include/types/numpy_iexpr.hpp
+++ b/pythran/pythonic/include/types/numpy_iexpr.hpp
@@ -370,6 +370,11 @@ namespace types
 }
 
 template <class Arg>
+struct assignable_noescape<types::numpy_iexpr<Arg>> {
+  using type = types::numpy_iexpr<Arg>;
+};
+
+template <class Arg>
 struct assignable<types::numpy_iexpr<Arg>> {
   using type = types::numpy_iexpr<typename assignable<Arg>::type>;
 };

--- a/pythran/pythonic/include/types/numpy_texpr.hpp
+++ b/pythran/pythonic/include/types/numpy_texpr.hpp
@@ -296,6 +296,11 @@ namespace types
 }
 
 template <class Arg>
+struct assignable_noescape<types::numpy_texpr<Arg>> {
+  using type = types::numpy_texpr<Arg>;
+};
+
+template <class Arg>
 struct assignable<types::numpy_texpr<Arg>> {
   using type = types::numpy_texpr<typename assignable<Arg>::type>;
 };

--- a/pythran/pythonic/operator_/mul.hpp
+++ b/pythran/pythonic/operator_/mul.hpp
@@ -12,9 +12,9 @@ namespace operator_
 {
 
   template <class A, class B>
-  auto mul(A const &a, B const &b) -> decltype(a *b)
+  auto mul(A &&a, B &&b) -> decltype(std::forward<A>(a) * std::forward<B>(b))
   {
-    return a * b;
+    return std::forward<A>(a) * std::forward<B>(b);
   }
 
   DEFINE_ALL_OPERATOR_OVERLOADS_IMPL(

--- a/pythran/pythonic/types/numpy_nary_expr.hpp
+++ b/pythran/pythonic/types/numpy_nary_expr.hpp
@@ -35,7 +35,7 @@ namespace functor
       NUMPY_NARY_FUNC_NAME::
       operator()(E &&... args) const
   {
-    return {args...};
+    return {std::forward<E>(args)...};
   }
 }
 


### PR DESCRIPTION
This qualifier makes it possible to take most expression by reference, avoiding
a lot of shared counter manipulation.

Should fix #1668