### PR TITLE
Basic support for f-strings (fix #1675)

### DIFF
--- a/pythran/middlend.py
+++ b/pythran/middlend.py
@@ -12,7 +12,8 @@ from pythran.transformations import (ExpandBuiltins, ExpandImports,
                                      UnshadowParameters, RemoveNamedArguments,
                                      ExpandGlobals, NormalizeIsNone,
                                      NormalizeIfElse,
-                                     NormalizeStaticIf, SplitStaticExpression)
+                                     NormalizeStaticIf, SplitStaticExpression,
+                                     RemoveFStrings)
 
 
 def refine(pm, node, optimizations):
@@ -22,6 +23,7 @@ def refine(pm, node, optimizations):
     pm.apply(ExpandGlobals, node)
     pm.apply(ExpandImportAll, node)
     pm.apply(NormalizeTuples, node)
+    pm.apply(RemoveFStrings, node)
     pm.apply(ExpandBuiltins, node)
     pm.apply(ExpandImports, node)
     pm.apply(NormalizeMethodCalls, node)

--- a/pythran/tests/test_base.py
+++ b/pythran/tests/test_base.py
@@ -179,6 +179,9 @@ def fibo2(n): return fibo2(n-1) + fibo2(n-2) if n > 1 else n
     def test_print_tuple(self):
         self.run_test("def print_tuple(a,b,c,d): t = (a,b,c,d,'e',1.5,); print(t)", [1.,2.,3.1],3,True, "d", print_tuple=[List[float], int, bool, str])
 
+    def test_fstring(self):
+        self.run_test("def fstring(a,b,c): return f'a: {a: 4d}; b: {b:.2f}; c: {c:s}'", 2, 6.28, "c", fstring=[int, float, str])
+
     def test_assign(self):
         self.run_test("def assign(a): b=2*a ; return b", 1, assign=[int])
 

--- a/pythran/transformations/__init__.py
+++ b/pythran/transformations/__init__.py
@@ -31,3 +31,4 @@ from .remove_lambdas import RemoveLambdas
 from .remove_nested_functions import RemoveNestedFunctions
 from .unshadow_parameters import UnshadowParameters
 from .remove_named_arguments import RemoveNamedArguments
+from .remove_fstrings import RemoveFStrings

--- a/pythran/transformations/remove_fstrings.py
+++ b/pythran/transformations/remove_fstrings.py
@@ -1,0 +1,47 @@
+"""Turns f-strings to format syntax with modulus"""
+
+import gast as ast
+
+from pythran.passmanager import Transformation
+from pythran.syntax import PythranSyntaxError
+
+
+class RemoveFStrings(Transformation, ast.NodeTransformer):
+    """Turns f-strings to format syntax with modulus
+
+    >>> import gast as ast
+    >>> from pythran import passmanager, backend
+    >>> node = ast.parse("f'a = {1+1:4d}; b = {b:s};'")
+    >>> pm = passmanager.PassManager("test")
+    >>> _, node = pm.apply(RemoveFStrings, node)
+    >>> print(pm.dump(backend.Python, node))
+    ('a = %4d; b = %s;' % ((1 + 1), b))
+    """
+
+    def visit_JoinedStr(self, node):
+        if not any(
+            isinstance(value, ast.FormattedValue) for value in node.values
+        ):
+            # nothing to do (not a f-string)
+            return node
+        base_str = ""
+        elements = []
+        for value in node.values:
+            if isinstance(value, ast.Constant):
+                base_str += value.value.replace("%", "%%")
+            elif isinstance(value, ast.FormattedValue):
+                base_str += "%"
+                if value.format_spec is None:
+                    raise PythranSyntaxError(
+                        "f-strings without format specifier not supported", value
+                    )
+                base_str += value.format_spec.values[0].value
+                elements.append(value.value)
+            else:
+                raise NotImplementedError
+
+        return ast.BinOp(
+            left=ast.Constant(value=base_str, kind=None),
+            op=ast.Mod(),
+            right=ast.Tuple(elts=elements, ctx=ast.Load()),
+        )


### PR DESCRIPTION
Pythran could support some f-strings by converting them into standard formatting with `%`.

It's a naive implementation to see what it's going to break (and increase our CI-based heater).

What would be the correct way to inform the user that something in the code is not supported?

