### PR TITLE
Improve PythranBuildExt to support base class customization

### DIFF
--- a/docs/MANUAL.rst
+++ b/docs/MANUAL.rst
@@ -357,7 +357,8 @@ When distributing a Python application with Pythran modules, you can either:
           cmdclass={"build_ext": PythranBuildExt})
 
 ``PythranBuildExt`` is optional, but necessary to build extensions with
-different C++ compilers.
+different C++ compilers. It derives from distuil's ``build_ext`` by default, but
+you can change its base class by using ``PythranBuildExt[base_cls]`` instead.
 
 .. note::
 

--- a/pythran/dist.py
+++ b/pythran/dist.py
@@ -18,13 +18,14 @@ from distutils.command.build_ext import build_ext as LegacyBuildExt
 from numpy.distutils.extension import Extension
 
 
-class PythranBuildExt(LegacyBuildExt, object):
+class PythranBuildExtMixIn(object):
     """Subclass of `distutils.command.build_ext.build_ext` which is required to
     build `PythranExtension` with the configured C++ compiler. It may also be
     subclassed if you want to combine with another build_ext class (NumPy,
     Cython implementations).
 
     """
+
     def build_extension(self, ext):
         StringTypes = str,
 
@@ -105,7 +106,7 @@ class PythranBuildExt(LegacyBuildExt, object):
                     self.compiler.compiler_so[i] = 'x86_64'
 
         try:
-            return super(PythranBuildExt, self).build_extension(ext)
+            return super(PythranBuildExtMixIn, self).build_extension(ext)
         finally:
             # Revert compiler settings
             for key in prev.keys():
@@ -115,6 +116,19 @@ class PythranBuildExt(LegacyBuildExt, object):
             if find_exe is not None:
                 import distutils._msvccompiler as msvc
                 msvc._find_exe = find_exe
+
+
+class PythranBuildExtMeta(type):
+
+    def __getitem__(self, base):
+        class PythranBuildExt(PythranBuildExtMixIn, base):
+            pass
+
+        return PythranBuildExt
+
+
+class PythranBuildExt(PythranBuildExtMixIn, LegacyBuildExt, metaclass=PythranBuildExtMeta):
+    pass
 
 
 class PythranExtension(Extension):

--- a/pythran/tests/test_distutils.py
+++ b/pythran/tests/test_distutils.py
@@ -85,7 +85,6 @@ class TestDistutils(unittest.TestCase):
         shutil.rmtree(os.path.join(cwd, 'test_distutils_packaged', 'demo_install2'))
         shutil.rmtree(os.path.join(cwd, 'test_distutils_packaged', 'build'))
 
-
     def test_setup_sdist_install2(self):
         check_call(['python', 'setup.py', 'sdist', "--dist-dir=sdist2"],
                    cwd=os.path.join(cwd, 'test_distutils_packaged'))
@@ -102,6 +101,43 @@ class TestDistutils(unittest.TestCase):
         tgz = [f for f in os.listdir(dist_path) if f.endswith(".tar.gz")][0]
         check_call(['tar', 'xzf', tgz], cwd=dist_path)
 
+        demo_so = find_so(r"a.*\.so", dist_path)
+        self.assertIsNotNone(demo_so)
+        shutil.rmtree(dist_path)
+
+    def test_setup_build3(self):
+        check_call(['python', 'setup.py', 'build'],
+                   cwd=os.path.join(cwd, 'test_distutils_numpy'))
+        check_call(['python', 'setup.py', 'install', '--prefix=demo_install3'],
+                   cwd=os.path.join(cwd, 'test_distutils_numpy'))
+
+        base = os.path.join(cwd, 'test_distutils_numpy', 'demo_install3',)
+        libdir = os.path.join(base, 'lib')
+        if not os.path.isdir(libdir):
+            libdir = os.path.join(base, 'lib64')
+        check_call(['python', '-c', 'import a'],
+                   cwd=os.path.join(libdir, python_version, 'site-packages',
+                                    'demo3'))
+        check_call(['python', 'setup.py', 'clean'],
+                   cwd=os.path.join(cwd, 'test_distutils_numpy'))
+        shutil.rmtree(os.path.join(cwd, 'test_distutils_numpy', 'demo_install3'))
+        shutil.rmtree(os.path.join(cwd, 'test_distutils_numpy', 'build'))
+
+    def test_setup_sdist_install3(self):
+        check_call(['python', 'setup.py', 'sdist', "--dist-dir=sdist3"],
+                   cwd=os.path.join(cwd, 'test_distutils_numpy'))
+        check_call(['tar', 'xzf', 'demo3-1.0.tar.gz'],
+                   cwd=os.path.join(cwd, 'test_distutils_numpy', 'sdist3'))
+        check_call(['python', 'setup.py', 'install', '--prefix=demo_install3'],
+                   cwd=os.path.join(cwd, 'test_distutils_numpy', 'sdist3', 'demo3-1.0'))
+        shutil.rmtree(os.path.join(cwd, 'test_distutils_numpy', 'sdist3'))
+
+    def test_setup_bdist_install3(self):
+        check_call(['python', 'setup.py', 'bdist', "--dist-dir=bdist"],
+                   cwd=os.path.join(cwd, 'test_distutils_numpy'))
+        dist_path = os.path.join(cwd, 'test_distutils_numpy', 'bdist')
+        tgz = [f for f in os.listdir(dist_path) if f.endswith(".tar.gz")][0]
+        check_call(['tar', 'xzf', tgz], cwd=dist_path)
 
         demo_so = find_so(r"a.*\.so", dist_path)
         self.assertIsNotNone(demo_so)

--- a/pythran/tests/test_distutils_numpy/demo3/a.py
+++ b/pythran/tests/test_distutils_numpy/demo3/a.py
@@ -1,0 +1,3 @@
+#pythran export a()
+import numpy
+def a(): return numpy.ones(1)

--- a/pythran/tests/test_distutils_numpy/setup.py
+++ b/pythran/tests/test_distutils_numpy/setup.py
@@ -1,0 +1,11 @@
+from numpy.distutils.core import setup
+from numpy.distutils.command.build_ext import build_ext as npy_build_ext
+from pythran.dist import PythranExtension, PythranBuildExt
+
+module1 = PythranExtension('demo3.a', sources = ['demo3/a.py'])
+
+setup(name = 'demo3',
+      version = '1.0',
+      description = 'This is a demo package',
+      cmdclass={"build_ext": PythranBuildExt[npy_build_ext]},
+      ext_modules = [module1])


### PR DESCRIPTION
Use a mixture of MixIn and MetaClass to achieve that goal in a pythonic (?) way.

Fix #1692