### PR TITLE
Document how to pass config options to PythranExtension

### DIFF
--- a/docs/MANUAL.rst
+++ b/docs/MANUAL.rst
@@ -360,6 +360,10 @@ When distributing a Python application with Pythran modules, you can either:
 different C++ compilers. It derives from distuil's ``build_ext`` by default, but
 you can change its base class by using ``PythranBuildExt[base_cls]`` instead.
 
+* all configuration options supported in ``.pythranrc`` can also be passed
+  through the optional ``config`` argument, in the form of a list, e.g.
+  ``config=['compiler.blas=openblas']``
+
 .. note::
 
     There's no strong compatibility guarantee between Pythran version at C++ level. As a

--- a/pythran/run.py
+++ b/pythran/run.py
@@ -37,6 +37,7 @@ def compile_flags(args):
         'extra_compile_args': args.extra_flags,
         'library_dirs': args.libraries_dir,
         'extra_link_args': args.extra_flags,
+        'config': args.config,
     }
     for param in ('opts', ):
         val = getattr(args, param, None)


### PR DESCRIPTION
This make it possible to avoid usage of pythranrc.
Also sneak a fix config option passing from CLI :-)

Fix #1691