### PR TITLE
Avoid logging.basicConfig

### DIFF
--- a/pythran/log.py
+++ b/pythran/log.py
@@ -1,5 +1,7 @@
 import logging
+
 logger = logging.getLogger("pythran")
+stream = logging.StreamHandler()
 
 # Initialize logging
 try:
@@ -15,10 +17,16 @@ try:
             'CRITICAL': 'red',
         }
     )
-    stream = logging.StreamHandler()
-    stream.setFormatter(formatter)
-    logger.addHandler(stream)
 except ImportError:
     # No color available, use default config
-    logging.basicConfig(format='%(levelname)s: %(message)s')
+    formatter = logging.Formatter("%(levelname)s: %(message)s")
+    color_disabled = True
+else:
+    color_disabled = False
+
+stream.setFormatter(formatter)
+logger.addHandler(stream)
+
+if color_disabled:
     logger.info("Disabling color, you really want to install colorlog.")
+


### PR DESCRIPTION
I think it's better to avoid `logging.basicConfig` and to set a handle only to pythran's logger so that other loggers are not affected.
Otherwise, when ones creates another logger after `import pythran`, the logger already has a handle inherited from root.