### PR TITLE
Explicitly insert cast on rvalue tuple when needed

### DIFF
--- a/pythran/backend.py
+++ b/pythran/backend.py
@@ -910,7 +910,12 @@ class CxxFunction(ast.NodeVisitor):
 
     def visit_Tuple(self, node):
         elts = [self.visit(elt) for elt in node.elts]
-        return "pythonic::types::make_tuple({0})".format(", ".join(elts))
+        tuple_type = self.types[node]
+        result = "pythonic::types::make_tuple({0})".format(", ".join(elts))
+        if isinstance(tuple_type, self.types.builder.CombinedTypes):
+            return '({}){}'.format(tuple_type.generate(self.lctx), result)
+        else:
+            return result
 
     def visit_Compare(self, node):
         left = self.visit(node.left)

--- a/pythran/config.py
+++ b/pythran/config.py
@@ -17,20 +17,6 @@ def get_paths_cfg(
         platform_file='pythran-{}.cfg'.format(sys.platform),
         user_file='.pythranrc'
 ):
-    """
-    >>> os.environ['HOME'] = '/tmp/test'
-    >>> get_paths_cfg()['user']
-    '/tmp/test/.pythranrc'
-    >>> os.environ['HOME'] = '/tmp/test'
-    >>> os.environ['XDG_CONFIG_HOME'] = '/tmp/test2'
-    >>> get_paths_cfg()['user']
-    '/tmp/test2/.pythranrc'
-    >>> os.environ['HOME'] = '/tmp/test'
-    >>> os.environ['XDG_CONFIG_HOME'] = '/tmp/test2'
-    >>> os.environ['PYTHRANRC'] = '/tmp/test3/pythranrc'
-    >>> get_paths_cfg()['user']
-    '/tmp/test3/pythranrc'
-    """
     sys_config_dir = os.path.dirname(__file__)
     sys_config_path = os.path.join(sys_config_dir, sys_file)
 

--- a/pythran/tests/__init__.py
+++ b/pythran/tests/__init__.py
@@ -203,12 +203,13 @@ class TestEnv(unittest.TestCase):
             if not check_exception or e.args[0] == err_msg:
                 raise
             return type(e)
-        finally:
-            # Clean temporary DLL
-            # FIXME: We can't remove this file while it is used in an import
-            # through the exec statement (Windows constraints...)
-            if sys.platform != "win32":
-                os.remove(module_path)
+
+    def cleanup_pythran(self, module_path):
+        # Clean temporary DLL
+        # FIXME: We can't remove this file while it is used in an import
+        # through the exec statement (Windows constraints...)
+        if sys.platform != "win32":
+            os.remove(module_path)
 
     def run_test_case(self, code, module_name, runas, module_dir=None, **interface):
         """
@@ -258,6 +259,7 @@ class TestEnv(unittest.TestCase):
 
             python_ref = self.run_python(code, runas)
             pythran_res = self.run_pythran(modname, cxx_compiled, runas)
+            self.cleanup_pythran(cxx_compiled)
 
             print("Python result: ", python_ref)
             print("Pythran result: ", pythran_res)
@@ -328,6 +330,7 @@ class TestEnv(unittest.TestCase):
                 thread.start()
             for thread in threads:
                 thread.join()
+        self.cleanup_pythran(cxx_compiled)
 
 
     @staticmethod

--- a/pythran/tests/test_typing.py
+++ b/pythran/tests/test_typing.py
@@ -677,3 +677,17 @@ def recursive_interprocedural_typing2(c):
                 else:
                     return np.arange(n)[1:-1]'''
         return self.run_test(code, 6, numpy_array_combiner5=[int])
+
+    def test_numpy_array_in_tuple0(self):
+        code = '''
+import numpy as np
+
+
+def Test_reset(self, P, Q):
+    print('In SHAPE', P, Q)
+    self[0][0] = np.zeros((P, Q))
+    print('Out SHAPE', self[0][0].shape)
+
+def numpy_array_in_tuple0(n):
+    Test_reset(([np.zeros((1, 1))],), 64, n)'''
+        return self.run_test(code, 6, numpy_array_in_tuple0=[int])


### PR DESCRIPTION
This make it possible to correctly type tuples that are not bound to a variable.

Fix #1682
Fix #1459