### PR TITLE
Fix pythonic interface for numpy.finfo

### DIFF
--- a/pythran/pythonic/include/types/finfo.hpp
+++ b/pythran/pythonic/include/types/finfo.hpp
@@ -21,8 +21,7 @@ PYTHONIC_NS_BEGIN
 namespace builtins
 {
   template <class T>
-  T getattr(pythonic::types::finfo<T> const &f,
-            std::integral_constant<size_t, types::attr::EPS>);
+  T getattr(types::attr::EPS, pythonic::types::finfo<T> const &f);
 }
 PYTHONIC_NS_END
 /* } */

--- a/pythran/pythonic/types/finfo.hpp
+++ b/pythran/pythonic/types/finfo.hpp
@@ -24,8 +24,7 @@ PYTHONIC_NS_BEGIN
 namespace builtins
 {
   template <class T>
-  T getattr(pythonic::types::finfo<T> const &f,
-            std::integral_constant<size_t, types::attr::EPS>)
+  T getattr(types::attr::EPS, pythonic::types::finfo<T> const &f)
   {
     return f.eps();
   }

--- a/pythran/tests/test_numpy_func0.py
+++ b/pythran/tests/test_numpy_func0.py
@@ -828,6 +828,9 @@ def np_rosen_der(x):
     def test_finfo0(self):
         self.run_test("def np_finfo0(): from numpy import finfo, float64 ; x = finfo(float64) ; return x.eps", np_finfo0=[])
 
+    def test_finfo1(self):
+        self.run_test("def np_finfo1(x): from numpy import finfo ; f = finfo(x.dtype) ; return f.eps", numpy.ones(1), np_finfo1=[NDArray[float,:]])
+
     def test_fill0(self):
         self.run_test("def np_fill0(x): x.fill(5) ; return x", numpy.ones((2, 3)), np_fill0=[NDArray[float,:,:]])
 


### PR DESCRIPTION
Looks like this was still using an older `getattr` API, and wasn't being caught by the test because it gets optimised away.