### PR TITLE
Make np.finfo.eps float for complex dtype

### DIFF
--- a/pythran/pythonic/include/types/finfo.hpp
+++ b/pythran/pythonic/include/types/finfo.hpp
@@ -13,6 +13,11 @@ namespace types
   struct finfo {
     T eps() const;
   };
+
+  template <class T>
+  struct finfo<std::complex<T>> {
+    T eps() const;
+  };
 }
 PYTHONIC_NS_END
 
@@ -21,7 +26,8 @@ PYTHONIC_NS_BEGIN
 namespace builtins
 {
   template <class T>
-  T getattr(types::attr::EPS, pythonic::types::finfo<T> const &f);
+  auto getattr(types::attr::EPS, pythonic::types::finfo<T> const &f)
+      -> decltype(f.eps());
 }
 PYTHONIC_NS_END
 /* } */

--- a/pythran/pythonic/types/finfo.hpp
+++ b/pythran/pythonic/types/finfo.hpp
@@ -12,6 +12,12 @@ PYTHONIC_NS_BEGIN
 namespace types
 {
   template <class T>
+  T finfo<std::complex<T>>::eps() const
+  {
+    return std::numeric_limits<T>::epsilon();
+  }
+
+  template <class T>
   T finfo<T>::eps() const
   {
     return std::numeric_limits<T>::epsilon();
@@ -24,7 +30,8 @@ PYTHONIC_NS_BEGIN
 namespace builtins
 {
   template <class T>
-  T getattr(types::attr::EPS, pythonic::types::finfo<T> const &f)
+  auto getattr(types::attr::EPS, pythonic::types::finfo<T> const &f)
+      -> decltype(f.eps())
   {
     return f.eps();
   }

--- a/pythran/tests/test_numpy_func0.py
+++ b/pythran/tests/test_numpy_func0.py
@@ -831,6 +831,9 @@ def np_rosen_der(x):
     def test_finfo1(self):
         self.run_test("def np_finfo1(x): from numpy import finfo ; f = finfo(x.dtype) ; return f.eps", numpy.ones(1), np_finfo1=[NDArray[float,:]])
 
+    def test_finfo2(self):
+        self.run_test("def np_finfo2(z): from numpy import finfo ; f = finfo(z.dtype) ; return f.eps < 1.0", numpy.array([1+1j]), np_finfo2=[NDArray[complex,:]])
+
     def test_fill0(self):
         self.run_test("def np_fill0(x): x.fill(5) ; return x", numpy.ones((2, 3)), np_fill0=[NDArray[float,:,:]])
 


### PR DESCRIPTION
Numpy's `finfo` will first cast its argument dtype to a floating instance, particularly in the case of a complex dtype. We add a specialisation to the template to facilitate this.

@serge-sans-paille I must admit I didn't look around too much for whether partial specialisation is the right pattern to use here (or whether I've done it "properly" -- my template C++ is a bit rusty!), I'm happy to use something more project-specific if that's the way to go instead.