### PR TITLE
Forward .real and .imag into numpy_vexpr

### DIFF
--- a/pythran/pythonic/include/types/ndarray.hpp
+++ b/pythran/pythonic/include/types/ndarray.hpp
@@ -853,6 +853,14 @@ namespace builtins
     return {getattr(types::attr::REAL{}, a.arg)};
   }
 
+  template <class T, class F>
+  auto getattr(types::attr::REAL, types::numpy_vexpr<T, F> const &a) -> decltype(
+      types::numpy_vexpr<decltype(getattr(types::attr::REAL{}, a.data_)), F>{
+          getattr(types::attr::REAL{}, a.data_), a.view_})
+  {
+    return {getattr(types::attr::REAL{}, a.data_), a.view_};
+  }
+
   template <class E, class... S>
   auto getattr(types::attr::REAL, types::numpy_gexpr<E, S...> const &a)
       -> decltype(
@@ -886,6 +894,14 @@ namespace builtins
           getattr(types::attr::IMAG{}, a.arg)})
   {
     return {getattr(types::attr::IMAG{}, a.arg)};
+  }
+
+  template <class T, class F>
+  auto getattr(types::attr::IMAG, types::numpy_vexpr<T, F> const &a) -> decltype(
+      types::numpy_vexpr<decltype(getattr(types::attr::IMAG{}, a.data_)), F>{
+          getattr(types::attr::IMAG{}, a.data_), a.view_})
+  {
+    return {getattr(types::attr::IMAG{}, a.data_), a.view_};
   }
 
   template <class E, class... S>

--- a/pythran/tests/test_ndarray.py
+++ b/pythran/tests/test_ndarray.py
@@ -77,6 +77,16 @@ class TestNdarray(TestEnv):
                       1j * numpy.arange(10, dtype=numpy.complex128),
                       ndarray_imag_fun_read=[NDArray[complex, :]])
 
+    def test_ndarray_real_vexpr_read(self):
+        self.run_test('def ndarray_real_vexpr_read(a): import numpy as np ; return a[np.argsort(a)].real',
+                      numpy.arange(10, dtype=numpy.complex128),
+                      ndarray_real_vexpr_read=[NDArray[complex, :]])
+
+    def test_ndarray_imag_vexpr_read(self):
+        self.run_test('def ndarray_imag_vexpr_read(a): import numpy as np ; return a[np.argsort(a)].imag',
+                      1j * numpy.arange(10, dtype=numpy.complex128),
+                      ndarray_imag_vexpr_read=[NDArray[complex, :]])
+
     def test_numpy_augassign0(self):
         self.run_test('def numpy_augassign0(a): a+=1; return a',
                       numpy.arange(100).reshape((10, 10)),


### PR DESCRIPTION
This is implemented for most other ndarray derivatives, but not a plain view. We should be able to transform the underlying object in the same way as e.g. `numpy_iexpr`.

1. Not sure if we should necessarily be accessing `data_` and `view_` on the `numpy_vexpr` directly, but it does seem to fit the same pattern as the other expressions.
2. I guess it's only really `.real` and `.imag` that need this specialisation, but the same pattern is applied a few times -- maybe it'd benefit from an interface to change the view across `iexpr`, `gexpr`, `texpr` and `vexpr`?