### PR TITLE
numpy.int is deprecated

### DIFF
--- a/pythran/types/conversion.py
+++ b/pythran/types/conversion.py
@@ -7,7 +7,6 @@ import numpy
 from pythran.typing import List, Dict, Set, Tuple, NDArray, Pointer, Fun
 
 PYTYPE_TO_CTYPE_TABLE = {
-    numpy.int: 'npy_int',
     numpy.uint: 'npy_uint',
     #
     complex: 'std::complex<double>',


### PR DESCRIPTION
It's now an alias to builtins.int, no need to register it anymore

Fix #1756