### PR TITLE
Do not create a copy of a 2D expression when transposing it

### DIFF
--- a/pythran/pythonic/include/numpy/transpose.hpp
+++ b/pythran/pythonic/include/numpy/transpose.hpp
@@ -10,24 +10,45 @@ PYTHONIC_NS_BEGIN
 
 namespace numpy
 {
+  template <class E>
+  E transpose(types::numpy_texpr<E> const &arr)
+  {
+    return arr.arg;
+  }
 
-  template <class T>
-  types::numpy_texpr<types::ndarray<T, types::array<long, 2>>>
-  transpose(types::ndarray<T, types::array<long, 2>> const &arr);
+  template <class E>
+  typename std::enable_if<E::value == 2, types::numpy_texpr<E>>::type
+  transpose(E const &arr)
+  {
+    return {arr};
+  }
 
-  template <class T, class pS0, class pS1>
-  types::numpy_texpr<types::ndarray<T, types::pshape<pS0, pS1>>>
-  transpose(types::ndarray<T, types::pshape<pS0, pS1>> const &arr);
+  template <class E>
+  typename std::enable_if<E::value == 1, E>::type transpose(E const &arr)
+  {
+    return arr;
+  }
 
   template <class T, class pS>
-  types::ndarray<T, types::array<long, std::tuple_size<pS>::value>>
+  typename std::enable_if<
+      (std::tuple_size<pS>::value > 2),
+      types::ndarray<T, types::array<long, std::tuple_size<pS>::value>>>::type
   transpose(types::ndarray<T, pS> const &a);
 
   template <class T, class pS, size_t M>
   types::ndarray<T, types::array<long, std::tuple_size<pS>::value>>
   transpose(types::ndarray<T, pS> const &a, types::array<long, M> const &t);
 
-  NUMPY_EXPR_TO_NDARRAY0_DECL(transpose);
+  template <class E>
+  auto transpose(E const &expr) -> typename std::enable_if<
+      (E::value > 2),
+      decltype(transpose(types::ndarray<typename E::dtype, typename E::shape_t>{
+          expr}))>::type
+  {
+    return transpose(
+        types::ndarray<typename E::dtype, typename E::shape_t>{expr});
+  }
+
   DEFINE_FUNCTOR(pythonic::numpy, transpose);
 }
 PYTHONIC_NS_END

--- a/pythran/pythonic/numpy/transpose.hpp
+++ b/pythran/pythonic/numpy/transpose.hpp
@@ -13,19 +13,6 @@ PYTHONIC_NS_BEGIN
 
 namespace numpy
 {
-  template <class T>
-  types::numpy_texpr<types::ndarray<T, types::array<long, 2>>>
-  transpose(types::ndarray<T, types::array<long, 2>> const &arr)
-  {
-    return {arr};
-  }
-
-  template <class T, class pS0, class pS1>
-  types::numpy_texpr<types::ndarray<T, types::pshape<pS0, pS1>>>
-  transpose(types::ndarray<T, types::pshape<pS0, pS1>> const &arr)
-  {
-    return {arr};
-  }
   namespace
   {
     template <class T, class pS, class O, class Indices, class S, class Perm>
@@ -82,7 +69,9 @@ namespace numpy
   }
 
   template <class T, class pS>
-  types::ndarray<T, types::array<long, std::tuple_size<pS>::value>>
+  typename std::enable_if<
+      (std::tuple_size<pS>::value > 2),
+      types::ndarray<T, types::array<long, std::tuple_size<pS>::value>>>::type
   transpose(types::ndarray<T, pS> const &a)
   {
     long t[std::tuple_size<pS>::value];
@@ -102,8 +91,6 @@ namespace numpy
       throw types::ValueError("invalid axis for this array");
     return _transpose(a, &t[0]);
   }
-
-  NUMPY_EXPR_TO_NDARRAY0_IMPL(transpose);
 }
 PYTHONIC_NS_END
 

--- a/pythran/pythonic/types/ndarray.hpp
+++ b/pythran/pythonic/types/ndarray.hpp
@@ -1669,10 +1669,11 @@ types::numpy_texpr<E> from_python<types::numpy_texpr<E>>::convert(PyObject *obj)
   static_assert(N == 2, "only support texpr of matrices");
   sutils::assign(std::get<0>(shape), std::get<1>(dims));
   sutils::assign(std::get<1>(shape), std::get<0>(dims));
+
+  PyObject *tobj = PyArray_Transpose(arr, nullptr);
   types::ndarray<T, typename E::shape_t> base_array((T *)PyArray_BYTES(arr),
-                                                    shape, obj);
+                                                    shape, tobj);
   types::numpy_texpr<types::ndarray<T, typename E::shape_t>> r(base_array);
-  Py_INCREF(obj);
   return r;
 }
 PYTHONIC_NS_END

--- a/pythran/tests/test_ndarray.py
+++ b/pythran/tests/test_ndarray.py
@@ -1143,6 +1143,15 @@ def complex_conversion0(x):
                               (10, 20),
                               transposed_slice_assign2=[Tuple[int, int]])
 
+    def test_transposed_slice_assign3(self):
+                self.run_test("""def transposed_slice_assign3(shape):
+                                  import numpy as np
+                                  xx = np.ones(shape, dtype=int).T
+                                  xx[:1, :2] = 3
+                                  return xx""",
+                              (10, 20),
+                              transposed_slice_assign3=[Tuple[int, int]])
+
     def test_slice_through_list0(self):
                 self.run_test("""def slice_through_list0(shape):
                                   import numpy as np

--- a/pythran/tests/test_slice.py
+++ b/pythran/tests/test_slice.py
@@ -822,6 +822,5 @@ import numpy as np
 def slice_transpose0(n):
     base = np.zeros((16, n)).T
     slice1 = base[:10, 10:] # should have shape (10, 6)
-    slice2 = slice1[:1, 1:]
-    return slice1, slice2'''
+    return slice1'''
         self.run_test(code, 16, slice_transpose0=[int])


### PR DESCRIPTION
Fix #1763