### PR TITLE
Improve OpenMP detection for different platforms and compilers

### DIFF
--- a/omp/__init__.py
+++ b/omp/__init__.py
@@ -2,7 +2,9 @@
 
 from ctypes.util import find_library
 from subprocess import check_output, CalledProcessError
-from numpy.distutils.misc_util import msvc_runtime_major
+from numpy.distutils.misc_util import (
+    msvc_runtime_major, get_shared_lib_extension
+)
 import ctypes
 import os
 import sys
@@ -41,18 +43,45 @@ class OpenMP(object):
             self.libomp = ctypes.CDLL(vcomp_path)
             self.version = 20
 
+    def get_libomp_names(self):
+        """Return list of OpenMP libraries to try, based on platform and
+        compiler detected."""
+        if cxx is None:
+            # Can't tell what compiler we're using, guessing we need libgomp
+            names ['libgomp']
+        else:
+            cmd = [cxx, '--version']
+            try:
+                version_str = os.path.dirname(check_output(cmd).decode().strip())
+            except (OSError, CalledProcessError):
+                version_str = ''
+
+            if 'clang' in version_str:
+                names = ['libomp', 'libiomp5', 'libgomp']
+            elif version_str.startswith('Intel'):
+                names = ['libiomp5']
+            else:
+                # Too many GCC flavors and version strings, make this the default
+                # rather than try to detect if it's GCC
+                names = ['libgomp']
+
+        return [name + get_shared_lib_extension() for name in names]
+
     def init_not_msvc(self):
         """ Find OpenMP library and try to load if using ctype interface. """
         # find_library() does not search automatically LD_LIBRARY_PATH
         paths = os.environ.get('LD_LIBRARY_PATH', '').split(':')
-        for gomp in ('libgomp.so', 'libgomp.dylib'):
-            if cxx is None:
+
+        for libomp_name in self.get_libomp_names():
+            if cxx is None or sys.platform == 'win32':
+                # Note: Clang supports -print-file-name, but not yet for
+                # clang-cl as of v12.0.0 (April '21)
                 continue
-            cmd = [cxx, '-print-file-name=' + gomp]
-            # the subprocess can fail in various ways
-            # in that case just give up that path
+
+            cmd = [cxx, '-print-file-name=' + libomp_name]
+            # the subprocess can fail in various ways in that case just give up
             try:
-                path = os.path.dirname(check_output(cmd).strip())
+                path = os.path.dirname(check_output(cmd).decode().strip())
                 if path:
                     paths.append(path)
             except (OSError, CalledProcessError):


### PR DESCRIPTION
Currently the SciPy on Windows build gives warnings like:
```
clang-cl: warning: unknown argument ignored in clang-cl: '-print-file-name=libgomp.dylib' [-Wunknown-argument]
clang-cl: error: no input files
clang-cl: warning: unknown argument ignored in clang-cl: '-print-file-name=libgomp.so' [-Wunknown-argument]
clang-cl: error: no input files
```
for every Pythran invocation. This should improve that.

Also fix a str/bytes issue that resulted in invalid paths starting with `b/...` because of calling str() on a bytes object.