### PR TITLE
Fix combiner between nested structures

### DIFF
--- a/pythran/analyses/aliases.py
+++ b/pythran/analyses/aliases.py
@@ -441,7 +441,8 @@ class Aliases(ModuleAnalysis):
                             continue
                     # FIXME: what if the index is a slice variable...
                     aliases.add(alias.containee)
-                elif isinstance(getattr(alias, 'ctx', None), ast.Param):
+                elif isinstance(getattr(alias, 'ctx', None), (ast.Param,
+                                                              ast.Store)):
                     aliases.add(ast.Subscript(alias, node.slice, node.ctx))
             if not aliases:
                 aliases = None

--- a/pythran/cxxtypes.py
+++ b/pythran/cxxtypes.py
@@ -22,6 +22,12 @@ class ordered_set(object):
     def __iter__(self):
         return iter(self.values)
 
+    def __len__(self):
+        return len(self.values)
+
+    def __getitem__(self, index):
+        return self.values[index]
+
 
 class TypeBuilder(object):
     '''
@@ -181,6 +187,20 @@ std::declval<bool>()))
                     return builder.UnknownType
                 else:
                     return InstantiatedType(self.fun, self.name, arguments)
+
+        class LType(Type):
+            def __init__(self, base, node):
+                super(LType, self).__init__(node=node)
+                self.isrec = False
+                self.orig = base
+                self.final_type = base
+
+            def generate(self, ctx):
+                if self.isrec:
+                    return self.orig.generate(ctx)
+                else:
+                    self.isrec = True
+                    return self.final_type.generate(ctx)
 
         class InstantiatedType(Type):
             """

--- a/pythran/cxxtypes.py
+++ b/pythran/cxxtypes.py
@@ -464,6 +464,25 @@ std::declval<bool>()))
             def generate(self, ctx):
                 return 'indexable<{0}>'.format(ctx(self.of))
 
+        class IndexableContainerType(Type):
+            '''
+            Type of any container of stuff of the same type,
+            indexable by another type
+            '''
+            def __init__(self, of_key, of_val):
+                super(IndexableContainerType, self).__init__(of_key=of_key,
+                                                             of_val=of_val)
+
+            def iscombined(self):
+                return any((of.iscombined()
+                            for of in (self.of_key, self.of_val)))
+
+            def generate(self, ctx):
+                return ('indexable_container<'
+                        '{0}, typename std::remove_reference<{1}>::type'
+                        '>'
+                        .format(ctx(self.of_key), ctx(self.of_val)))
+
         class ExpressionType(Type):
 
             """

--- a/pythran/pythonic/include/types/combined.hpp
+++ b/pythran/pythonic/include/types/combined.hpp
@@ -23,9 +23,11 @@ struct __combined<T> {
 
 template <class T0, class T1, class T2, class... Types>
 struct __combined<T0, T1, T2, Types...> {
-  using type =
-      typename __combined<typename __combined<T0, T1>::type,
-                          typename __combined<T2, Types...>::type>::type;
+  // This is less efficient that doing a binary split, but it's not equivalent
+  // as the lhs dominates the rhs (a.k.a __combined is neither commutative nor
+  // associative)
+  using type = typename __combined<typename __combined<T0, T1>::type, T2,
+                                   Types...>::type;
 };
 
 template <class T0, class T1>
@@ -40,7 +42,7 @@ struct __combined<T0, T1> {
   static decltype(std::declval<F0>() + std::declval<F1>())
   get(std::integral_constant<bool, false>);
 
-  // operator+ does ! exists -> pick first one, better than error
+  // operator+ does not exists -> pick first one, better than error
   // note that this is needed because broadcasting is too complex to be modeled
   // by our clumsy type inference scheme
   // so we sometime endup with __combined<indexable_container<...>, int> which

--- a/pythran/pythonic/include/types/list.hpp
+++ b/pythran/pythonic/include/types/list.hpp
@@ -251,6 +251,8 @@ namespace types
     list<T> &operator=(list<F> const &other);
     list<T> &operator=(list<T> const &other);
     list<T> &operator=(empty_list const &);
+    template <class Tp, size_t N, class V>
+    list<T> &operator=(array_base<Tp, N, V> const &);
     template <class Tp, class S>
     list<T> &operator=(sliced_list<Tp, S> const &other);
 
@@ -640,6 +642,16 @@ template <class T, size_t N, class V>
 struct __combined<pythonic::types::empty_list,
                   pythonic::types::array_base<T, N, V>> {
   typedef pythonic::types::list<T> type;
+};
+template <class T, size_t N, class V, class Tp>
+struct __combined<pythonic::types::array_base<T, N, V>,
+                  pythonic::types::list<Tp>> {
+  typedef pythonic::types::list<typename __combined<T, Tp>::type> type;
+};
+template <class T, size_t N, class V, class Tp>
+struct __combined<pythonic::types::list<Tp>,
+                  pythonic::types::array_base<T, N, V>> {
+  typedef pythonic::types::list<typename __combined<T, Tp>::type> type;
 };
 
 /* } */

--- a/pythran/pythonic/include/types/ndarray.hpp
+++ b/pythran/pythonic/include/types/ndarray.hpp
@@ -854,9 +854,10 @@ namespace builtins
   }
 
   template <class T, class F>
-  auto getattr(types::attr::REAL, types::numpy_vexpr<T, F> const &a) -> decltype(
-      types::numpy_vexpr<decltype(getattr(types::attr::REAL{}, a.data_)), F>{
-          getattr(types::attr::REAL{}, a.data_), a.view_})
+  auto getattr(types::attr::REAL, types::numpy_vexpr<T, F> const &a)
+      -> decltype(
+          types::numpy_vexpr<decltype(getattr(types::attr::REAL{}, a.data_)),
+                             F>{getattr(types::attr::REAL{}, a.data_), a.view_})
   {
     return {getattr(types::attr::REAL{}, a.data_), a.view_};
   }
@@ -897,9 +898,10 @@ namespace builtins
   }
 
   template <class T, class F>
-  auto getattr(types::attr::IMAG, types::numpy_vexpr<T, F> const &a) -> decltype(
-      types::numpy_vexpr<decltype(getattr(types::attr::IMAG{}, a.data_)), F>{
-          getattr(types::attr::IMAG{}, a.data_), a.view_})
+  auto getattr(types::attr::IMAG, types::numpy_vexpr<T, F> const &a)
+      -> decltype(
+          types::numpy_vexpr<decltype(getattr(types::attr::IMAG{}, a.data_)),
+                             F>{getattr(types::attr::IMAG{}, a.data_), a.view_})
   {
     return {getattr(types::attr::IMAG{}, a.data_), a.view_};
   }

--- a/pythran/pythonic/include/types/tuple.hpp
+++ b/pythran/pythonic/include/types/tuple.hpp
@@ -776,25 +776,25 @@ struct __combined<pythonic::types::array_base<T, N, V>, container<K>> {
       pythonic::types::array_base<typename __combined<T, K>::type, N, V>;
 };
 
-template <class K, class V, class T, size_t N>
+template <class K, class V, class T, size_t N, class AV>
 struct __combined<indexable_container<K, V>,
-                  pythonic::types::array_base<T, N, V>> {
+                  pythonic::types::array_base<T, N, AV>> {
   using type =
-      pythonic::types::array_base<typename __combined<V, T>::type, N, V>;
+      pythonic::types::array_base<typename __combined<V, T>::type, N, AV>;
 };
 
-template <class K, class V, class T, size_t N>
-struct __combined<pythonic::types::array_base<T, N, V>,
+template <class K, class V, class T, size_t N, class AV>
+struct __combined<pythonic::types::array_base<T, N, AV>,
                   indexable_container<K, V>> {
   using type =
-      pythonic::types::array_base<typename __combined<T, V>::type, N, V>;
+      pythonic::types::array_base<typename __combined<T, V>::type, N, AV>;
 };
 
 template <class... t0, class... t1>
 struct __combined<std::tuple<t0...>, std::tuple<t1...>> {
-  using type = std::tuple<typename __combined<t0, t1>::type...>; // no further
-                                                                 // combination
+  using type = std::tuple<typename __combined<t0, t1>::type...>;
 };
+
 template <class t, class... t0>
 struct __combined<std::tuple<t0...>, container<t>> {
   using type = std::tuple<t0...>;
@@ -803,6 +803,26 @@ struct __combined<std::tuple<t0...>, container<t>> {
 template <class t, class... t0>
 struct __combined<container<t>, std::tuple<t0...>> {
   using type = std::tuple<t0...>;
+};
+
+template <long I, class t, class... t0>
+struct __combined<std::tuple<t0...>,
+                  indexable_container<std::integral_constant<long, I>, t>> {
+  using holder = std::tuple<t0...>;
+  template <size_t... Is>
+  static std::tuple<typename std::conditional<
+      I == Is, typename __combined<
+                   t, typename std::tuple_element<Is, holder>::type>::type,
+      typename std::tuple_element<Is, holder>::type>::type...>
+      make_type(pythonic::utils::index_sequence<Is...>);
+  static auto make_type() -> decltype(
+      make_type(pythonic::utils::make_index_sequence<sizeof...(t0)>()));
+  using type = decltype(make_type());
+};
+
+template <class k, class t, class... t0>
+struct __combined<indexable_container<k, t>, std::tuple<t0...>>
+    : __combined<std::tuple<t0...>, indexable_container<k, t>> {
 };
 
 template <class t, size_t n, class... types>

--- a/pythran/pythonic/types/list.hpp
+++ b/pythran/pythonic/types/list.hpp
@@ -331,6 +331,13 @@ namespace types
     return *this;
   }
   template <class T>
+  template <class Tp, size_t N, class V>
+  list<T> &list<T>::operator=(array_base<Tp, N, V> const &other)
+  {
+    data = utils::shared_ref<container_type>(other.begin(), other.end());
+    return *this;
+  }
+  template <class T>
   template <class Tp, class S>
   list<T> &list<T>::operator=(sliced_list<Tp, S> const &other)
   {

--- a/pythran/tests/test_cases.py
+++ b/pythran/tests/test_cases.py
@@ -23,6 +23,10 @@ if LooseVersion(numpy.__version__) >= '1.20':
     del TestCases.test_train_eq_run0
     del TestCases.test_train_eq_run1
 
+# too template intensive for old g++
+if os.environ.get('CXX', None) == 'g++-5':
+    del TestCases.test_loopy_jacob_run0
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This requires a complex interplay between alias analyses, type inference and
combiners.

In `a[1][2]`, `a` is now considered as an indexable container indexed by an
integral constant, which make it possible to properly model tuple accesses;

This should fix #1754