### PR TITLE
Prevent folding of numpy.dtype.type when used as a function

### DIFF
--- a/pythran/tables.py
+++ b/pythran/tables.py
@@ -164,7 +164,7 @@ REDUCED_BINARY_UFUNC = {"accumulate": FunctionIntr(),
 
 CLASSES = {
     "dtype": {
-        "type": ConstMethodIntr(),
+        "type": MethodIntr(),
     },
     "list": {
         "append": MethodIntr(signature=Fun[[List[T0], T0], None]),

--- a/pythran/tests/test_ndarray.py
+++ b/pythran/tests/test_ndarray.py
@@ -1103,8 +1103,6 @@ def complex_conversion0(x):
             5.,
             built_slice_indexing=[NDArray[float, :], int, int, float])
 
-    @unittest.skipIf(LooseVersion(numpy.__version__) >= '1.20',
-                     "numpy.dtype.type changed in 1.20.0")
     def test_dtype_type(self):
         self.run_test('''
             def dtype_type(x):


### PR DESCRIPTION
Fix #1777