### PR TITLE
Properly handle empty string during str.split

### DIFF
--- a/pythran/pythonic/builtins/str/split.hpp
+++ b/pythran/pythonic/builtins/str/split.hpp
@@ -22,6 +22,9 @@ namespace builtins
     {
       types::str s = strip(in);
       types::list<types::str> res(0);
+      if (s.empty())
+        return res;
+
       size_t current = 0;
       size_t next = 0;
       long numsplit = 0;
@@ -43,6 +46,9 @@ namespace builtins
     {
       types::str s = strip(in);
       types::list<types::str> res(0);
+      if (s.empty())
+        return res;
+
       size_t current = 0;
       size_t next = 0;
       long numsplit = 0;

--- a/pythran/tests/test_str.py
+++ b/pythran/tests/test_str.py
@@ -103,6 +103,9 @@ class TestStr(TestEnv):
     def test_str_split3(self):
         self.run_test("def str_split3(s): return s.split()", "ThiS  iS\t a TeST", str_split3=[str])
 
+    def test_str_split4(self):
+        self.run_test("def str_split4(s): return s.split()", "", str_split4=[str])
+
     def test_str_format(self):
         self.run_test("def str_format(a): return '%.2f %.2f' % (a, a)", 43.23, str_format=[float])
 


### PR DESCRIPTION
fix #1780