### PR TITLE
Harden handling of third-party imports during init

### DIFF
--- a/pythran/tables.py
+++ b/pythran/tables.py
@@ -4474,27 +4474,6 @@ if sys.version_info < (3, 5):
     del MODULES['operator']['matmul']
     del MODULES['operator']['__matmul__']
 
-# OMP version
-try:
-    import omp
-    omp_version = omp.VERSION
-except (ImportError, AttributeError):
-    omp_version = 45  # Fallback on last version
-
-if omp_version >= 30:
-    MODULES['omp'].update({
-        "set_schedule": FunctionIntr(global_effects=True),
-        "get_schedule": FunctionIntr(global_effects=True),
-        "get_thread_limit": FunctionIntr(global_effects=True),
-        "set_max_active_levels": FunctionIntr(global_effects=True),
-        "get_max_active_levels": FunctionIntr(global_effects=True),
-        "get_level": FunctionIntr(global_effects=True),
-        "get_ancestor_thread_num": FunctionIntr(global_effects=True),
-        "get_team_size": FunctionIntr(global_effects=True),
-        "get_active_level": FunctionIntr(global_effects=True),
-        "in_final": FunctionIntr(global_effects=True),
-    })
-
 # VMSError is only available on VMS
 if 'VMSError' in sys.modules['builtins'].__dict__:
     MODULES['builtins']['VMSError'] = ConstExceptionIntr()
@@ -4507,7 +4486,7 @@ if 'WindowsError' in sys.modules['builtins'].__dict__:
 for module_name in ["omp", "scipy.special", "scipy"]:
     try:
         __import__(module_name)
-    except ImportError:
+    except:
         logger.info(
             "Pythran support disabled for module: {}".format(module_name)
         )
@@ -4518,6 +4497,23 @@ for module_name in ["omp", "scipy.special", "scipy"]:
 for method in list(MODULES['numpy'].keys()):
     if method not in sys.modules['numpy'].__dict__:
         del MODULES['numpy'][method]
+
+# if openmp is available, check its version and populate the API accordingly
+if 'omp' in MODULES:
+    omp_version = getattr(__import__('omp'), 'VERSION', 45)
+    if omp_version >= 30:
+        MODULES['omp'].update({
+            "set_schedule": FunctionIntr(global_effects=True),
+            "get_schedule": FunctionIntr(global_effects=True),
+            "get_thread_limit": FunctionIntr(global_effects=True),
+            "set_max_active_levels": FunctionIntr(global_effects=True),
+            "get_max_active_levels": FunctionIntr(global_effects=True),
+            "get_level": FunctionIntr(global_effects=True),
+            "get_ancestor_thread_num": FunctionIntr(global_effects=True),
+            "get_team_size": FunctionIntr(global_effects=True),
+            "get_active_level": FunctionIntr(global_effects=True),
+            "in_final": FunctionIntr(global_effects=True),
+        })
 
 
 # populate argument description through introspection


### PR DESCRIPTION
There are several ways why omp loading may fail, just make sure this doesn't
stop the init process.

Somehow fix #1769