### PR TITLE
Always have numpy_iexpr return a reference

### DIFF
--- a/pythran/pythonic/include/types/numpy_iexpr.hpp
+++ b/pythran/pythonic/include/types/numpy_iexpr.hpp
@@ -368,7 +368,7 @@ namespace types
   template <>
   struct numpy_iexpr_helper<1> {
     template <class T>
-    static typename T::dtype get(T const &e, long i);
+    static typename T::dtype &get(T const &e, long i);
     template <class T>
     static typename T::dtype &get(T &&e, long i);
     template <class T>

--- a/pythran/pythonic/types/numpy_iexpr.hpp
+++ b/pythran/pythonic/types/numpy_iexpr.hpp
@@ -488,7 +488,7 @@ namespace types
   }
 
   template <class T>
-  typename T::dtype numpy_iexpr_helper<1>::get(T const &e, long i)
+  typename T::dtype &numpy_iexpr_helper<1>::get(T const &e, long i)
   {
     return e.buffer[i * e.template strides<T::value - 1>()];
   }

--- a/pythran/tests/test_ndarray.py
+++ b/pythran/tests/test_ndarray.py
@@ -425,6 +425,16 @@ def assign_ndarray(t):
     def test_iexpr2(self):
         self.run_test("def np_iexpr2(a,m): a[m==False] = 1; return a", numpy.arange(10).reshape(5,2), numpy.arange(10).reshape(5,2), np_iexpr2=[NDArray[int, :,:], NDArray[int, :,:]])
 
+    def test_iexpr3(self):
+        code = '''
+import numpy as np
+def np_iexpr3 (x, nbits):
+    out = np.zeros ((len(x), 1<<nbits), dtype=complex)
+    for e in range (len (x)):
+        out[e,x[e]] = 1
+    return out'''
+        self.run_test(code, numpy.arange(16, dtype=numpy.int16), 4, np_iexpr3=[NDArray[numpy.int16, :], int])
+
     def test_item0(self):
         self.run_test("def np_item0(a): return a.item(3)", numpy.array([[3, 1, 7],[2, 8, 3],[8, 5, 3]]), np_item0=[NDArray[int, :,: ]])
 


### PR DESCRIPTION
This is obviously not the best idea when we're holding a const reference, but it
works fine and fix #1787

At some point, We should support setitem / getitem instead of pretending to be
smart with operator[]...