### PR TITLE
Fix dev version string to be PEP 440 compliant

### DIFF
--- a/docs/CLI.rst
+++ b/docs/CLI.rst
@@ -29,7 +29,7 @@ The generated native ``.so`` module can then be used with the Python interpreter
 Pythran version can be dumped through ``--version``::
 
   $> pythran --version 2>&1
-  0.9.12dev
+  0.9.12.dev0
 
 The module-level ``__pythran__`` variable indicates that the module loaded has been pythranized::
 
@@ -78,13 +78,13 @@ To know more options about Pythran, you can check::
                  [-I include_dir] [-L ldflags] [-D macro_definition]
                  [-U macro_definition] [--config config]
                  input_file
-  
+
   pythran: a python to C++ compiler
-  
+
   positional arguments:
     input_file           the pythran module to compile, either a .py or a .cpp
                          file
-  
+
   optional arguments:
     -h, --help           show this help message and exit
     -o OUTPUT_FILE       path to generated file. Honors %{ext}.
@@ -102,5 +102,5 @@ To know more options about Pythran, you can check::
                          compiler
     -U macro_definition  any macro undef relevant to the underlying C++ compiler
     --config config      config additional params
-  
+
   It's a megablast!

--- a/pythran/tests/test_version.py
+++ b/pythran/tests/test_version.py
@@ -1,0 +1,28 @@
+import re
+
+import pythran
+from pythran.tests import TestEnv
+
+
+class TestVersion(TestEnv):
+    def test_version_check_cython(self):
+        # Cython actually does this check (variable is named
+        # `pythran_is_pre_0_9_6`). Make sure it doesn't break.
+        v = pythran.__version__
+        pre_096 = tuple(map(int, v.split('.')[0:3])) < (0, 9, 6)
+        self.assertFalse(pre_096)
+
+    def test_valid_version_string(self):
+        # Verify that the pythran version is a valid one (note: excludes
+        # .post suffix, and complies to PEP 440. Test taken from NumPy
+        version_pattern = r"^[0-9]+\.[0-9]+\.[0-9]+(|a[0-9]|b[0-9]|rc[0-9])"
+        dev_suffix = r"\.dev0\+[0-9]*\.g[0-9a-f]+"
+
+        # For released versions:
+        res1 = re.match(version_pattern, pythran.__version__)
+        # For dev versions:
+        res2 = re.match(version_pattern + dev_suffix, pythran.__version__)
+
+        self.assertTrue(res1 is not None or res2 is not None,
+                        pythran.__version__)
+

--- a/pythran/version.py
+++ b/pythran/version.py
@@ -1,3 +1,3 @@
-__version__ = '0.9.12dev'
+__version__ = '0.9.12.dev0'
 __url__ = 'https://github.com/serge-sans-paille/pythran'
 __descr__ = 'Ahead of Time compiler for numeric kernels'


### PR DESCRIPTION
Using `0.9.12dev` actually broke SciPy CI, because Cython does this:
```
  pythran_is_pre_0_9_6 = tuple(map(int, pythran.__version__.split('.')[0:3])) < (0, 9, 6)
```
Add tests to check version string is compliant, taken over from NumPy