### PR TITLE
Handle static dispatching based on keyword signature

### DIFF
--- a/pythran/pythonic/__dispatch__/sort.hpp
+++ b/pythran/pythonic/__dispatch__/sort.hpp
@@ -1,0 +1,38 @@
+#ifndef PYTHONIC_DISPATCH_SORT_HPP
+#define PYTHONIC_DISPATCH_SORT_HPP
+
+#include "pythonic/include/__dispatch__/sort.hpp"
+
+#include "pythonic/builtins/list/sort.hpp"
+#include "pythonic/numpy/sort.hpp"
+
+PYTHONIC_NS_BEGIN
+
+namespace __dispatch__
+{
+
+  template <class T, class... Args>
+  auto sort(types::list<T> &l, Args &&... args)
+      -> decltype(pythonic::builtins::list::sort(l,
+                                                 std::forward<Args>(args)...))
+  {
+    return pythonic::builtins::list::sort(l, std::forward<Args>(args)...);
+  }
+  template <class T, class... Args>
+  auto sort(types::list<T> &&l, Args &&... args)
+      -> decltype(pythonic::builtins::list::sort(std::move(l),
+                                                 std::forward<Args>(args)...))
+  {
+    return pythonic::builtins::list::sort(std::move(l),
+                                          std::forward<Args>(args)...);
+  }
+  template <class Any, class... Args>
+  types::none_type sort(Any &&any, Args &&... args)
+  {
+    return pythonic::numpy::ndarray::sort(std::forward<Any>(any),
+                                          std::forward<Args>(args)...);
+  }
+}
+PYTHONIC_NS_END
+
+#endif

--- a/pythran/pythonic/include/__dispatch__/sort.hpp
+++ b/pythran/pythonic/include/__dispatch__/sort.hpp
@@ -1,0 +1,27 @@
+#ifndef PYTHONIC_INCLUDE_DISPATCH_SORT_HPP
+#define PYTHONIC_INCLUDE_DISPATCH_SORT_HPP
+
+#include "pythonic/include/builtins/list/sort.hpp"
+#include "pythonic/include/numpy/sort.hpp"
+
+PYTHONIC_NS_BEGIN
+
+namespace __dispatch__
+{
+
+  template <class T, class... Args>
+  auto sort(types::list<T> &l, Args &&... args)
+      -> decltype(pythonic::builtins::list::sort(l,
+                                                 std::forward<Args>(args)...));
+  template <class T, class... Args>
+  auto sort(types::list<T> &&l, Args &&... args)
+      -> decltype(pythonic::builtins::list::sort(std::move(l),
+                                                 std::forward<Args>(args)...));
+  template <class Any, class... Args>
+  types::none_type sort(Any &&any, Args &&... args);
+
+  DEFINE_FUNCTOR(pythonic::__dispatch__, sort);
+}
+PYTHONIC_NS_END
+
+#endif

--- a/pythran/pythonic/include/numpy/ndarray/sort.hpp
+++ b/pythran/pythonic/include/numpy/ndarray/sort.hpp
@@ -1,0 +1,26 @@
+#ifndef PYTHONIC_INCLUDE_NUMPY_NDARRAY_SORT_HPP
+#define PYTHONIC_INCLUDE_NUMPY_NDARRAY_SORT_HPP
+
+#include "pythonic/include/numpy/sort.hpp"
+
+PYTHONIC_NS_BEGIN
+
+namespace numpy
+{
+  namespace ndarray
+  {
+    template <class E>
+    types::none_type sort(E &&expr, types::none_type);
+
+    template <class E>
+    types::none_type sort(E &&expr, long axis, types::none_type = {});
+
+    template <class E>
+    types::none_type sort(E &&expr, long axis, types::str const &kind);
+
+    DEFINE_FUNCTOR(pythonic::numpy::ndarray, sort);
+  }
+}
+PYTHONIC_NS_END
+
+#endif

--- a/pythran/pythonic/numpy/median.hpp
+++ b/pythran/pythonic/numpy/median.hpp
@@ -40,14 +40,15 @@ namespace numpy
         }
         if (buffer_size % 2 == 1) {
           std::nth_element(buffer.get(), buffer.get() + buffer_size / 2,
-                           buffer_iter, comparator<T>{});
+                           buffer_iter, ndarray::comparator<T>{});
           *out++ = buffer[buffer_size / 2];
         } else {
           std::nth_element(buffer.get(), buffer.get() + buffer_size / 2,
-                           buffer_iter, comparator<T>{});
+                           buffer_iter, ndarray::comparator<T>{});
           auto t0 = buffer[buffer_size / 2];
           std::nth_element(buffer.get(), buffer.get() + buffer_size / 2 - 1,
-                           buffer.get() + buffer_size / 2, comparator<T>{});
+                           buffer.get() + buffer_size / 2,
+                           ndarray::comparator<T>{});
           auto t1 = buffer[buffer_size / 2 - 1];
           *out++ = (t0 + t1) / double(2);
         }
@@ -68,13 +69,13 @@ namespace numpy
     std::unique_ptr<T[]> tmp{new T[n]};
     std::copy(arr.buffer, arr.buffer + n, tmp.get());
     std::nth_element(tmp.get(), tmp.get() + n / 2, tmp.get() + n,
-                     comparator<T>{});
+                     ndarray::comparator<T>{});
     T t0 = tmp[n / 2];
     if (n % 2 == 1) {
       return t0;
     } else {
       std::nth_element(tmp.get(), tmp.get() + n / 2 - 1, tmp.get() + n / 2,
-                       comparator<T>{});
+                       ndarray::comparator<T>{});
       T t1 = tmp[n / 2 - 1];
       return (t0 + t1) / 2.;
     }

--- a/pythran/pythonic/numpy/ndarray/sort.hpp
+++ b/pythran/pythonic/numpy/ndarray/sort.hpp
@@ -1,0 +1,153 @@
+#ifndef PYTHONIC_NUMPY_NDARRAY_SORT_HPP
+#define PYTHONIC_NUMPY_NDARRAY_SORT_HPP
+
+#include "pythonic/include/numpy/ndarray/sort.hpp"
+
+#include <algorithm>
+#include <memory>
+
+#include "pythonic/utils/functor.hpp"
+#include "pythonic/types/ndarray.hpp"
+#include "pythonic/types/str.hpp"
+#include "pythonic/numpy/array.hpp"
+#include "pythonic/utils/pdqsort.hpp"
+
+PYTHONIC_NS_BEGIN
+
+namespace numpy
+{
+  namespace ndarray
+  {
+    namespace
+    {
+      struct quicksorter {
+        template <class... Args>
+        void operator()(Args &&... args)
+        {
+          pdqsort(std::forward<Args>(args)...);
+        }
+      };
+      struct mergesorter {
+        template <class It, class Cmp = std::less<typename It::value_type>>
+        void operator()(It first, It last, Cmp cmp = Cmp())
+        {
+          if (last - first > 1) {
+            It middle = first + (last - first) / 2;
+            operator()(first, middle, cmp);
+            operator()(middle, last, cmp);
+            std::inplace_merge(first, middle, last, cmp);
+          }
+        }
+      };
+      struct heapsorter {
+        template <class... Args>
+        void operator()(Args &&... args)
+        {
+          return std::sort_heap(std::forward<Args>(args)...);
+        }
+      };
+      struct stablesorter {
+        template <class... Args>
+        void operator()(Args &&... args)
+        {
+          return std::stable_sort(std::forward<Args>(args)...);
+        }
+      };
+
+      template <class T>
+      struct _comp;
+      template <class T>
+      struct _comp<std::complex<T>> {
+        bool operator()(std::complex<T> const &i,
+                        std::complex<T> const &j) const
+        {
+          if (std::real(i) == std::real(j))
+            return std::imag(i) < std::imag(j);
+          else
+            return std::real(i) < std::real(j);
+        }
+      };
+
+      template <class T>
+      using comparator =
+          typename std::conditional<types::is_complex<T>::value, _comp<T>,
+                                    std::less<T>>::type;
+
+      template <class T, class pS, class Sorter>
+      typename std::enable_if<std::tuple_size<pS>::value == 1, void>::type
+      _sort(types::ndarray<T, pS> &out, long axis, Sorter sorter)
+      {
+        sorter(out.begin(), out.end(), comparator<T>{});
+      }
+
+      template <class T, class pS, class Sorter>
+      typename std::enable_if<std::tuple_size<pS>::value != 1, void>::type
+      _sort(types::ndarray<T, pS> &out, long axis, Sorter sorter)
+      {
+        constexpr auto N = std::tuple_size<pS>::value;
+        if (axis < 0)
+          axis += N;
+        long const flat_size = out.flat_size();
+        if (axis == N - 1) {
+          const long step = out.template shape<N - 1>();
+          for (T *out_iter = out.buffer, *end_iter = out.buffer + flat_size;
+               out_iter != end_iter; out_iter += step)
+            sorter(out_iter, out_iter + step, comparator<T>{});
+        } else {
+          auto out_shape = sutils::getshape(out);
+          const long step =
+              std::accumulate(out_shape.begin() + axis, out_shape.end(), 1L,
+                              std::multiplies<long>());
+          long const buffer_size = out_shape[axis];
+          const long stepper = step / out_shape[axis];
+          const long n = flat_size / out_shape[axis];
+          long ith = 0, nth = 0;
+          std::unique_ptr<T[]> buffer{new T[buffer_size]};
+          for (long i = 0; i < n; i++) {
+            for (long j = 0; j < buffer_size; ++j)
+              buffer[j] = out.buffer[ith + j * stepper];
+            sorter(buffer.get(), buffer.get() + buffer_size, comparator<T>{});
+            for (long j = 0; j < buffer_size; ++j)
+              out.buffer[ith + j * stepper] = buffer[j];
+
+            ith += step;
+            if (ith >= flat_size) {
+              ith = ++nth;
+            }
+          }
+        }
+      }
+    }
+
+    template <class E>
+    types::none_type sort(E &&expr, long axis, types::none_type)
+    {
+      _sort(expr, axis, quicksorter());
+      return {};
+    }
+
+    template <class E>
+    types::none_type sort(E &&expr, types::none_type)
+    {
+      _sort(expr, 0, quicksorter());
+      return {};
+    }
+
+    template <class E>
+    types::none_type sort(E &&expr, long axis, types::str const &kind)
+    {
+      if (kind == "quicksort")
+        _sort(expr, axis, quicksorter());
+      else if (kind == "mergesort")
+        _sort(expr, axis, mergesorter());
+      else if (kind == "heapsort")
+        _sort(expr, axis, heapsorter());
+      else if (kind == "stable")
+        _sort(expr, axis, stablesorter());
+      return {};
+    }
+  }
+}
+PYTHONIC_NS_END
+
+#endif

--- a/pythran/pythonic/numpy/sort.hpp
+++ b/pythran/pythonic/numpy/sort.hpp
@@ -2,124 +2,18 @@
 #define PYTHONIC_NUMPY_SORT_HPP
 
 #include "pythonic/include/numpy/sort.hpp"
-
-#include <algorithm>
-#include <memory>
-
-#include "pythonic/utils/functor.hpp"
-#include "pythonic/types/ndarray.hpp"
-#include "pythonic/types/str.hpp"
-#include "pythonic/numpy/array.hpp"
-#include "pythonic/utils/pdqsort.hpp"
+#include "pythonic/numpy/ndarray/sort.hpp"
 
 PYTHONIC_NS_BEGIN
 namespace numpy
 {
-  namespace
-  {
-    struct quicksorter {
-      template <class... Args>
-      void operator()(Args &&... args)
-      {
-        pdqsort(std::forward<Args>(args)...);
-      }
-    };
-    struct mergesorter {
-      template <class It, class Cmp = std::less<typename It::value_type>>
-      void operator()(It first, It last, Cmp cmp = Cmp())
-      {
-        if (last - first > 1) {
-          It middle = first + (last - first) / 2;
-          operator()(first, middle, cmp);
-          operator()(middle, last, cmp);
-          std::inplace_merge(first, middle, last, cmp);
-        }
-      }
-    };
-    struct heapsorter {
-      template <class... Args>
-      void operator()(Args &&... args)
-      {
-        return std::sort_heap(std::forward<Args>(args)...);
-      }
-    };
-    struct stablesorter {
-      template <class... Args>
-      void operator()(Args &&... args)
-      {
-        return std::stable_sort(std::forward<Args>(args)...);
-      }
-    };
-
-    template <class T>
-    struct _comp;
-    template <class T>
-    struct _comp<std::complex<T>> {
-      bool operator()(std::complex<T> const &i, std::complex<T> const &j) const
-      {
-        if (std::real(i) == std::real(j))
-          return std::imag(i) < std::imag(j);
-        else
-          return std::real(i) < std::real(j);
-      }
-    };
-
-    template <class T>
-    using comparator = typename std::conditional<types::is_complex<T>::value,
-                                                 _comp<T>, std::less<T>>::type;
-
-    template <class T, class pS, class Sorter>
-    typename std::enable_if<std::tuple_size<pS>::value == 1, void>::type
-    _sort(types::ndarray<T, pS> &out, long axis, Sorter sorter)
-    {
-      sorter(out.begin(), out.end(), comparator<T>{});
-    }
-
-    template <class T, class pS, class Sorter>
-    typename std::enable_if<std::tuple_size<pS>::value != 1, void>::type
-    _sort(types::ndarray<T, pS> &out, long axis, Sorter sorter)
-    {
-      constexpr auto N = std::tuple_size<pS>::value;
-      if (axis < 0)
-        axis += N;
-      long const flat_size = out.flat_size();
-      if (axis == N - 1) {
-        const long step = out.template shape<N - 1>();
-        for (T *out_iter = out.buffer, *end_iter = out.buffer + flat_size;
-             out_iter != end_iter; out_iter += step)
-          sorter(out_iter, out_iter + step, comparator<T>{});
-      } else {
-        auto out_shape = sutils::getshape(out);
-        const long step =
-            std::accumulate(out_shape.begin() + axis, out_shape.end(), 1L,
-                            std::multiplies<long>());
-        long const buffer_size = out_shape[axis];
-        const long stepper = step / out_shape[axis];
-        const long n = flat_size / out_shape[axis];
-        long ith = 0, nth = 0;
-        std::unique_ptr<T[]> buffer{new T[buffer_size]};
-        for (long i = 0; i < n; i++) {
-          for (long j = 0; j < buffer_size; ++j)
-            buffer[j] = out.buffer[ith + j * stepper];
-          sorter(buffer.get(), buffer.get() + buffer_size, comparator<T>{});
-          for (long j = 0; j < buffer_size; ++j)
-            out.buffer[ith + j * stepper] = buffer[j];
-
-          ith += step;
-          if (ith >= flat_size) {
-            ith = ++nth;
-          }
-        }
-      }
-    }
-  }
 
   template <class E>
   types::ndarray<typename E::dtype, types::array<long, E::value>>
   sort(E const &expr, long axis)
   {
     auto out = functor::array{}(expr);
-    _sort(out, axis, quicksorter());
+    ndarray::sort(out, axis);
     return out;
   }
 
@@ -128,7 +22,7 @@ namespace numpy
   sort(E const &expr, types::none_type)
   {
     auto out = functor::array{}(expr).flat();
-    _sort(out, 0, quicksorter());
+    ndarray::sort(out, types::none_type{});
     return out;
   }
 
@@ -137,18 +31,9 @@ namespace numpy
   sort(E const &expr, long axis, types::str const &kind)
   {
     auto out = functor::array{}(expr);
-    if (kind == "quicksort")
-      _sort(out, axis, quicksorter());
-    else if (kind == "mergesort")
-      _sort(out, axis, mergesorter());
-    else if (kind == "heapsort")
-      _sort(out, axis, heapsorter());
-    else if (kind == "stable")
-      _sort(out, axis, stablesorter());
+    ndarray::sort(out, axis, kind);
     return out;
   }
-
-  NUMPY_EXPR_TO_NDARRAY0_IMPL(sort);
 }
 PYTHONIC_NS_END
 

--- a/pythran/tables.py
+++ b/pythran/tables.py
@@ -757,6 +757,10 @@ CLASSES = {
         ),
         "size": AttributeIntr(signature=Fun[[NDArray[T0, :]], int],
                               return_range=interval.positive_values),
+        "sort": MethodIntr(
+            args=("self", "axis", "kind"),
+            defaults=(-1, None)
+        ),
         "strides": AttributeIntr(
             signature=Union[
                 # bool
@@ -4466,6 +4470,7 @@ MODULES = {
         ),
         "pop": MethodIntr(),
         "remove": MethodIntr(),
+        "sort": MethodIntr(),
         "update": MethodIntr(update_effects),
     },
 }
@@ -4575,6 +4580,7 @@ fill_constants_types((), MODULES)
 # a method name to module binding
 # {method_name : ((full module path), signature)}
 methods = {}
+duplicated_methods = {}
 
 
 def save_method(elements, module_path):
@@ -4587,6 +4593,10 @@ def save_method(elements, module_path):
         elif signature.ismethod():
             # in case of duplicates, there must be a __dispatch__ record
             # and it is the only recorded one
+            if elem in MODULES['__dispatch__'] and module_path[0] != '__dispatch__':
+                duplicated_methods.setdefault(elem, []).append((module_path,
+                                                                signature))
+
             if elem in methods and module_path[0] != '__dispatch__':
                 assert elem in MODULES['__dispatch__']
                 path = ('__dispatch__',)

--- a/pythran/tests/test_numpy_func0.py
+++ b/pythran/tests/test_numpy_func0.py
@@ -700,6 +700,9 @@ def np_rosen_der(x):
     def test_sort10(self):
         self.run_test("def np_sort10(a): from numpy import sort ; return sort(3*a, 0)", numpy.arange(2*3*4, 0, -1).reshape(2,3,4), np_sort10=[NDArray[int, :, :, :]])
 
+    def test_sort11(self):
+        self.run_test("def np_sort11(a): a.sort(kind='heapsort'); return a", numpy.arange(2*3*4, 0, -1).reshape(2,3,4), np_sort11=[NDArray[int, :, :, :]])
+
     def test_sort_complex0(self):
         self.run_test("def np_sort_complex0(a): from numpy import sort_complex ; return sort_complex(a)", numpy.array([[1,6],[7,5]]), np_sort_complex0=[NDArray[int,:,:]])
 


### PR DESCRIPTION
Basically, forward `a.sort(kind='heapsort')` to `numpy.ndarray.sort`
while forwarding `a.sort(key=l)` to `list.sort` base don their signature.

As a side effect, and tot test that change, support `numpy.ndarray.sort` and
dispatching `sort` method calls to `list`, `ndarray` or `__dispatch__` when no
keyword is available.

Fix #1791