### PR TITLE
Support scalar case of scipy.special.binom

### DIFF
--- a/pythran/pythonic/include/scipy/special/binom.hpp
+++ b/pythran/pythonic/include/scipy/special/binom.hpp
@@ -1,0 +1,28 @@
+#ifndef PYTHONIC_INCLUDE_SCIPY_SPECIAL_BINOM_HPP
+#define PYTHONIC_INCLUDE_SCIPY_SPECIAL_BINOM_HPP
+
+#include "pythonic/include/types/ndarray.hpp"
+#include "pythonic/include/utils/functor.hpp"
+#include "pythonic/include/utils/numpy_traits.hpp"
+
+PYTHONIC_NS_BEGIN
+
+namespace scipy
+{
+  namespace special
+  {
+
+    namespace details
+    {
+      template <class T0, class T1>
+      double binom(T0 n, T1 k);
+    }
+
+#define NUMPY_NARY_FUNC_NAME binom
+#define NUMPY_NARY_FUNC_SYM details::binom
+#include "pythonic/include/types/numpy_nary_expr.hpp"
+  }
+}
+PYTHONIC_NS_END
+
+#endif

--- a/pythran/pythonic/scipy/special/binom.hpp
+++ b/pythran/pythonic/scipy/special/binom.hpp
@@ -1,0 +1,40 @@
+#ifndef PYTHONIC_SCIPY_SPECIAL_BINOM_HPP
+#define PYTHONIC_SCIPY_SPECIAL_BINOM_HPP
+
+#include "pythonic/include/scipy/special/binom.hpp"
+
+#include "pythonic/types/ndarray.hpp"
+#include "pythonic/utils/functor.hpp"
+#include "pythonic/utils/numpy_traits.hpp"
+
+#define BOOST_MATH_THREAD_LOCAL thread_local
+#include <boost/math/special_functions/binomial.hpp>
+
+PYTHONIC_NS_BEGIN
+
+namespace scipy
+{
+  namespace special
+  {
+    namespace details
+    {
+      template <class T0, class T1>
+      double binom(T0 n, T1 k)
+      {
+        static_assert(std::is_integral<T0>::value &&
+                          std::is_integral<T1>::value,
+                      "only support integer case of scipy.special.binom");
+        using namespace boost::math::policies;
+        return boost::math::binomial_coefficient<double>(
+            n, k, make_policy(promote_double<true>()));
+      }
+    }
+
+#define NUMPY_NARY_FUNC_NAME binom
+#define NUMPY_NARY_FUNC_SYM details::binom
+#include "pythonic/types/numpy_nary_expr.hpp"
+  }
+}
+PYTHONIC_NS_END
+
+#endif

--- a/pythran/tables.py
+++ b/pythran/tables.py
@@ -2815,6 +2815,9 @@ MODULES = {
     },
     "scipy": {
         "special": {
+            "binom": ConstFunctionIntr(
+                signature=_numpy_binary_op_float_signature
+            ),
             "gammaln": ConstFunctionIntr(
                 signature=_numpy_unary_op_float_signature
             ),

--- a/pythran/tests/test_scipy.py
+++ b/pythran/tests/test_scipy.py
@@ -127,3 +127,20 @@ class TestScipySpecial(TestEnv):
             return spherical_jn(v, x)""",
                       5, np.array([[1.0, 2.0], [3.0, 4.0]]),
                       spherical_bessel_j_2d=[int, NDArray[float,:,:]])
+
+    def test_binom_scalar(self):
+        self.run_test("""
+        from scipy.special import binom
+        def binom_scalar(v, x):
+            return binom(v, x)""",
+                      5, 4,
+                      binom_scalar=[int, int])
+
+    def test_binom_arg1d(self):
+        self.run_test("""
+        from scipy.special import binom
+        def binom_1d(v, x):
+            return binom(v, x)""",
+                      5, np.array([1, 2, 3]),
+                      binom_1d=[int, NDArray[int,:]])
+

--- a/third_party/boost/math/special_functions/beta.hpp
+++ b/third_party/boost/math/special_functions/beta.hpp
@@ -1,0 +1,1595 @@
+//  (C) Copyright John Maddock 2006.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_MATH_SPECIAL_BETA_HPP
+#define BOOST_MATH_SPECIAL_BETA_HPP
+
+#ifdef _MSC_VER
+#pragma once
+#endif
+
+#include <boost/math/special_functions/math_fwd.hpp>
+#include <boost/math/tools/config.hpp>
+#include <boost/math/special_functions/gamma.hpp>
+#include <boost/math/special_functions/binomial.hpp>
+#include <boost/math/special_functions/factorials.hpp>
+#include <boost/math/special_functions/erf.hpp>
+#include <boost/math/special_functions/log1p.hpp>
+#include <boost/math/special_functions/expm1.hpp>
+#include <boost/math/special_functions/trunc.hpp>
+#include <boost/math/tools/roots.hpp>
+#include <boost/static_assert.hpp>
+#include <boost/config/no_tr1/cmath.hpp>
+
+namespace boost{ namespace math{
+
+namespace detail{
+
+//
+// Implementation of Beta(a,b) using the Lanczos approximation:
+//
+template <class T, class Lanczos, class Policy>
+T beta_imp(T a, T b, const Lanczos&, const Policy& pol)
+{
+   BOOST_MATH_STD_USING  // for ADL of std names
+
+   if(a <= 0)
+      return policies::raise_domain_error<T>("boost::math::beta<%1%>(%1%,%1%)", "The arguments to the beta function must be greater than zero (got a=%1%).", a, pol);
+   if(b <= 0)
+      return policies::raise_domain_error<T>("boost::math::beta<%1%>(%1%,%1%)", "The arguments to the beta function must be greater than zero (got b=%1%).", b, pol);
+
+   T result;
+
+   T prefix = 1;
+   T c = a + b;
+
+   // Special cases:
+   if((c == a) && (b < tools::epsilon<T>()))
+      return 1 / b;
+   else if((c == b) && (a < tools::epsilon<T>()))
+      return 1 / a;
+   if(b == 1)
+      return 1/a;
+   else if(a == 1)
+      return 1/b;
+   else if(c < tools::epsilon<T>())
+   {
+      result = c / a;
+      result /= b;
+      return result;
+   }
+
+   /*
+   //
+   // This code appears to be no longer necessary: it was
+   // used to offset errors introduced from the Lanczos
+   // approximation, but the current Lanczos approximations
+   // are sufficiently accurate for all z that we can ditch
+   // this.  It remains in the file for future reference...
+   //
+   // If a or b are less than 1, shift to greater than 1:
+   if(a < 1)
+   {
+      prefix *= c / a;
+      c += 1;
+      a += 1;
+   }
+   if(b < 1)
+   {
+      prefix *= c / b;
+      c += 1;
+      b += 1;
+   }
+   */
+
+   if(a < b)
+      std::swap(a, b);
+
+   // Lanczos calculation:
+   T agh = static_cast<T>(a + Lanczos::g() - 0.5f);
+   T bgh = static_cast<T>(b + Lanczos::g() - 0.5f);
+   T cgh = static_cast<T>(c + Lanczos::g() - 0.5f);
+   result = Lanczos::lanczos_sum_expG_scaled(a) * (Lanczos::lanczos_sum_expG_scaled(b) / Lanczos::lanczos_sum_expG_scaled(c));
+   T ambh = a - 0.5f - b;
+   if((fabs(b * ambh) < (cgh * 100)) && (a > 100))
+   {
+      // Special case where the base of the power term is close to 1
+      // compute (1+x)^y instead:
+      result *= exp(ambh * boost::math::log1p(-b / cgh, pol));
+   }
+   else
+   {
+      result *= pow(agh / cgh, a - T(0.5) - b);
+   }
+   if(cgh > 1e10f)
+      // this avoids possible overflow, but appears to be marginally less accurate:
+      result *= pow((agh / cgh) * (bgh / cgh), b);
+   else
+      result *= pow((agh * bgh) / (cgh * cgh), b);
+   result *= sqrt(boost::math::constants::e<T>() / bgh);
+
+   // If a and b were originally less than 1 we need to scale the result:
+   result *= prefix;
+
+   return result;
+} // template <class T, class Lanczos> beta_imp(T a, T b, const Lanczos&)
+
+//
+// Generic implementation of Beta(a,b) without Lanczos approximation support
+// (Caution this is slow!!!):
+//
+template <class T, class Policy>
+T beta_imp(T a, T b, const lanczos::undefined_lanczos& l, const Policy& pol)
+{
+   BOOST_MATH_STD_USING
+
+   if(a <= 0)
+      return policies::raise_domain_error<T>("boost::math::beta<%1%>(%1%,%1%)", "The arguments to the beta function must be greater than zero (got a=%1%).", a, pol);
+   if(b <= 0)
+      return policies::raise_domain_error<T>("boost::math::beta<%1%>(%1%,%1%)", "The arguments to the beta function must be greater than zero (got b=%1%).", b, pol);
+
+   const T c = a + b;
+
+   // Special cases:
+   if ((c == a) && (b < tools::epsilon<T>()))
+      return 1 / b;
+   else if ((c == b) && (a < tools::epsilon<T>()))
+      return 1 / a;
+   if (b == 1)
+      return 1 / a;
+   else if (a == 1)
+      return 1 / b;
+   else if (c < tools::epsilon<T>())
+   {
+      T result = c / a;
+      result /= b;
+      return result;
+   }
+
+   // Regular cases start here:
+   const T min_sterling = minimum_argument_for_bernoulli_recursion<T>();
+
+   long shift_a = 0;
+   long shift_b = 0;
+
+   if(a < min_sterling)
+      shift_a = 1 + ltrunc(min_sterling - a);
+   if(b < min_sterling)
+      shift_b = 1 + ltrunc(min_sterling - b);
+   long shift_c = shift_a + shift_b;
+
+   if ((shift_a == 0) && (shift_b == 0))
+   {
+      return pow(a / c, a) * pow(b / c, b) * scaled_tgamma_no_lanczos(a, pol) * scaled_tgamma_no_lanczos(b, pol) / scaled_tgamma_no_lanczos(c, pol);
+   }
+   else if ((a < 1) && (b < 1))
+   {
+      return boost::math::tgamma(a, pol) * (boost::math::tgamma(b, pol) / boost::math::tgamma(c));
+   }
+   else if(a < 1)
+      return boost::math::tgamma(a, pol) * boost::math::tgamma_delta_ratio(b, a, pol);
+   else if(b < 1)
+      return boost::math::tgamma(b, pol) * boost::math::tgamma_delta_ratio(a, b, pol);
+   else
+   {
+      T result = beta_imp(T(a + shift_a), T(b + shift_b), l, pol);
+      //
+      // Recursion:
+      //
+      for (long i = 0; i < shift_c; ++i)
+      {
+         result *= c + i;
+         if (i < shift_a)
+            result /= a + i;
+         if (i < shift_b)
+            result /= b + i;
+      }
+      return result;
+   }
+
+} // template <class T>T beta_imp(T a, T b, const lanczos::undefined_lanczos& l)
+
+
+//
+// Compute the leading power terms in the incomplete Beta:
+//
+// (x^a)(y^b)/Beta(a,b) when normalised, and
+// (x^a)(y^b) otherwise.
+//
+// Almost all of the error in the incomplete beta comes from this
+// function: particularly when a and b are large. Computing large
+// powers are *hard* though, and using logarithms just leads to
+// horrendous cancellation errors.
+//
+template <class T, class Lanczos, class Policy>
+T ibeta_power_terms(T a,
+                        T b,
+                        T x,
+                        T y,
+                        const Lanczos&,
+                        bool normalised,
+                        const Policy& pol,
+                        T prefix = 1,
+                        const char* function = "boost::math::ibeta<%1%>(%1%, %1%, %1%)")
+{
+   BOOST_MATH_STD_USING
+
+   if(!normalised)
+   {
+      // can we do better here?
+      return pow(x, a) * pow(y, b);
+   }
+
+   T result;
+
+   T c = a + b;
+
+   // combine power terms with Lanczos approximation:
+   T agh = static_cast<T>(a + Lanczos::g() - 0.5f);
+   T bgh = static_cast<T>(b + Lanczos::g() - 0.5f);
+   T cgh = static_cast<T>(c + Lanczos::g() - 0.5f);
+   result = Lanczos::lanczos_sum_expG_scaled(c) / (Lanczos::lanczos_sum_expG_scaled(a) * Lanczos::lanczos_sum_expG_scaled(b));
+   result *= prefix;
+   // combine with the leftover terms from the Lanczos approximation:
+   result *= sqrt(bgh / boost::math::constants::e<T>());
+   result *= sqrt(agh / cgh);
+
+   // l1 and l2 are the base of the exponents minus one:
+   T l1 = (x * b - y * agh) / agh;
+   T l2 = (y * a - x * bgh) / bgh;
+   if(((std::min)(fabs(l1), fabs(l2)) < 0.2))
+   {
+      // when the base of the exponent is very near 1 we get really
+      // gross errors unless extra care is taken:
+      if((l1 * l2 > 0) || ((std::min)(a, b) < 1))
+      {
+         //
+         // This first branch handles the simple cases where either:
+         //
+         // * The two power terms both go in the same direction
+         // (towards zero or towards infinity).  In this case if either
+         // term overflows or underflows, then the product of the two must
+         // do so also.
+         // *Alternatively if one exponent is less than one, then we
+         // can't productively use it to eliminate overflow or underflow
+         // from the other term.  Problems with spurious overflow/underflow
+         // can't be ruled out in this case, but it is *very* unlikely
+         // since one of the power terms will evaluate to a number close to 1.
+         //
+         if(fabs(l1) < 0.1)
+         {
+            result *= exp(a * boost::math::log1p(l1, pol));
+            BOOST_MATH_INSTRUMENT_VARIABLE(result);
+         }
+         else
+         {
+            result *= pow((x * cgh) / agh, a);
+            BOOST_MATH_INSTRUMENT_VARIABLE(result);
+         }
+         if(fabs(l2) < 0.1)
+         {
+            result *= exp(b * boost::math::log1p(l2, pol));
+            BOOST_MATH_INSTRUMENT_VARIABLE(result);
+         }
+         else
+         {
+            result *= pow((y * cgh) / bgh, b);
+            BOOST_MATH_INSTRUMENT_VARIABLE(result);
+         }
+      }
+      else if((std::max)(fabs(l1), fabs(l2)) < 0.5)
+      {
+         //
+         // Both exponents are near one and both the exponents are
+         // greater than one and further these two
+         // power terms tend in opposite directions (one towards zero,
+         // the other towards infinity), so we have to combine the terms
+         // to avoid any risk of overflow or underflow.
+         //
+         // We do this by moving one power term inside the other, we have:
+         //
+         //    (1 + l1)^a * (1 + l2)^b
+         //  = ((1 + l1)*(1 + l2)^(b/a))^a
+         //  = (1 + l1 + l3 + l1*l3)^a   ;  l3 = (1 + l2)^(b/a) - 1
+         //                                    = exp((b/a) * log(1 + l2)) - 1
+         //
+         // The tricky bit is deciding which term to move inside :-)
+         // By preference we move the larger term inside, so that the
+         // size of the largest exponent is reduced.  However, that can
+         // only be done as long as l3 (see above) is also small.
+         //
+         bool small_a = a < b;
+         T ratio = b / a;
+         if((small_a && (ratio * l2 < 0.1)) || (!small_a && (l1 / ratio > 0.1)))
+         {
+            T l3 = boost::math::expm1(ratio * boost::math::log1p(l2, pol), pol);
+            l3 = l1 + l3 + l3 * l1;
+            l3 = a * boost::math::log1p(l3, pol);
+            result *= exp(l3);
+            BOOST_MATH_INSTRUMENT_VARIABLE(result);
+         }
+         else
+         {
+            T l3 = boost::math::expm1(boost::math::log1p(l1, pol) / ratio, pol);
+            l3 = l2 + l3 + l3 * l2;
+            l3 = b * boost::math::log1p(l3, pol);
+            result *= exp(l3);
+            BOOST_MATH_INSTRUMENT_VARIABLE(result);
+         }
+      }
+      else if(fabs(l1) < fabs(l2))
+      {
+         // First base near 1 only:
+         T l = a * boost::math::log1p(l1, pol)
+            + b * log((y * cgh) / bgh);
+         if((l <= tools::log_min_value<T>()) || (l >= tools::log_max_value<T>()))
+         {
+            l += log(result);
+            if(l >= tools::log_max_value<T>())
+               return policies::raise_overflow_error<T>(function, 0, pol);
+            result = exp(l);
+         }
+         else
+            result *= exp(l);
+         BOOST_MATH_INSTRUMENT_VARIABLE(result);
+      }
+      else
+      {
+         // Second base near 1 only:
+         T l = b * boost::math::log1p(l2, pol)
+            + a * log((x * cgh) / agh);
+         if((l <= tools::log_min_value<T>()) || (l >= tools::log_max_value<T>()))
+         {
+            l += log(result);
+            if(l >= tools::log_max_value<T>())
+               return policies::raise_overflow_error<T>(function, 0, pol);
+            result = exp(l);
+         }
+         else
+            result *= exp(l);
+         BOOST_MATH_INSTRUMENT_VARIABLE(result);
+      }
+   }
+   else
+   {
+      // general case:
+      T b1 = (x * cgh) / agh;
+      T b2 = (y * cgh) / bgh;
+      l1 = a * log(b1);
+      l2 = b * log(b2);
+      BOOST_MATH_INSTRUMENT_VARIABLE(b1);
+      BOOST_MATH_INSTRUMENT_VARIABLE(b2);
+      BOOST_MATH_INSTRUMENT_VARIABLE(l1);
+      BOOST_MATH_INSTRUMENT_VARIABLE(l2);
+      if((l1 >= tools::log_max_value<T>())
+         || (l1 <= tools::log_min_value<T>())
+         || (l2 >= tools::log_max_value<T>())
+         || (l2 <= tools::log_min_value<T>())
+         )
+      {
+         // Oops, under/overflow, sidestep if we can:
+         if(a < b)
+         {
+            T p1 = pow(b2, b / a);
+            T l3 = a * (log(b1) + log(p1));
+            if((l3 < tools::log_max_value<T>())
+               && (l3 > tools::log_min_value<T>()))
+            {
+               result *= pow(p1 * b1, a);
+            }
+            else
+            {
+               l2 += l1 + log(result);
+               if(l2 >= tools::log_max_value<T>())
+                  return policies::raise_overflow_error<T>(function, 0, pol);
+               result = exp(l2);
+            }
+         }
+         else
+         {
+            T p1 = pow(b1, a / b);
+            T l3 = (log(p1) + log(b2)) * b;
+            if((l3 < tools::log_max_value<T>())
+               && (l3 > tools::log_min_value<T>()))
+            {
+               result *= pow(p1 * b2, b);
+            }
+            else
+            {
+               l2 += l1 + log(result);
+               if(l2 >= tools::log_max_value<T>())
+                  return policies::raise_overflow_error<T>(function, 0, pol);
+               result = exp(l2);
+            }
+         }
+         BOOST_MATH_INSTRUMENT_VARIABLE(result);
+      }
+      else
+      {
+         // finally the normal case:
+         result *= pow(b1, a) * pow(b2, b);
+         BOOST_MATH_INSTRUMENT_VARIABLE(result);
+      }
+   }
+
+   BOOST_MATH_INSTRUMENT_VARIABLE(result);
+
+   return result;
+}
+//
+// Compute the leading power terms in the incomplete Beta:
+//
+// (x^a)(y^b)/Beta(a,b) when normalised, and
+// (x^a)(y^b) otherwise.
+//
+// Almost all of the error in the incomplete beta comes from this
+// function: particularly when a and b are large. Computing large
+// powers are *hard* though, and using logarithms just leads to
+// horrendous cancellation errors.
+//
+// This version is generic, slow, and does not use the Lanczos approximation.
+//
+template <class T, class Policy>
+T ibeta_power_terms(T a,
+                        T b,
+                        T x,
+                        T y,
+                        const boost::math::lanczos::undefined_lanczos& l,
+                        bool normalised,
+                        const Policy& pol,
+                        T prefix = 1,
+                        const char* = "boost::math::ibeta<%1%>(%1%, %1%, %1%)")
+{
+   BOOST_MATH_STD_USING
+
+   if(!normalised)
+   {
+      return prefix * pow(x, a) * pow(y, b);
+   }
+
+   T c = a + b;
+
+   const T min_sterling = minimum_argument_for_bernoulli_recursion<T>();
+
+   long shift_a = 0;
+   long shift_b = 0;
+
+   if (a < min_sterling)
+      shift_a = 1 + ltrunc(min_sterling - a);
+   if (b < min_sterling)
+      shift_b = 1 + ltrunc(min_sterling - b);
+
+   if ((shift_a == 0) && (shift_b == 0))
+   {
+      T power1, power2;
+      if (a < b)
+      {
+         power1 = pow((x * y * c * c) / (a * b), a);
+         power2 = pow((y * c) / b, b - a);
+      }
+      else
+      {
+         power1 = pow((x * y * c * c) / (a * b), b);
+         power2 = pow((x * c) / a, a - b);
+      }
+      if (!(boost::math::isnormal)(power1) || !(boost::math::isnormal)(power2))
+      {
+         // We have to use logs :(
+         return prefix * exp(a * log(x * c / a) + b * log(y * c / b)) * scaled_tgamma_no_lanczos(c, pol) / (scaled_tgamma_no_lanczos(a, pol) * scaled_tgamma_no_lanczos(b, pol));
+      }
+      return prefix * power1 * power2 * scaled_tgamma_no_lanczos(c, pol) / (scaled_tgamma_no_lanczos(a, pol) * scaled_tgamma_no_lanczos(b, pol));
+   }
+
+   T power1 = pow(x, a);
+   T power2 = pow(y, b);
+   T bet = beta_imp(a, b, l, pol);
+
+   if(!(boost::math::isnormal)(power1) || !(boost::math::isnormal)(power2) || !(boost::math::isnormal)(bet))
+   {
+      int shift_c = shift_a + shift_b;
+      T result = ibeta_power_terms(T(a + shift_a), T(b + shift_b), x, y, l, normalised, pol, prefix);
+      if ((boost::math::isnormal)(result))
+      {
+         for (int i = 0; i < shift_c; ++i)
+         {
+            result /= c + i;
+               if (i < shift_a)
+               {
+                  result *= a + i;
+                     result /= x;
+               }
+            if (i < shift_b)
+            {
+               result *= b + i;
+               result /= y;
+            }
+         }
+         return prefix * result;
+      }
+      else
+      {
+         T log_result = log(x) * a + log(y) * b + log(prefix);
+         if ((boost::math::isnormal)(bet))
+            log_result -= log(bet);
+         else
+            log_result += boost::math::lgamma(c, pol) - boost::math::lgamma(a) - boost::math::lgamma(c, pol);
+         return exp(log_result);
+      }
+   }
+   return prefix * power1 * (power2 / bet);
+}
+//
+// Series approximation to the incomplete beta:
+//
+template <class T>
+struct ibeta_series_t
+{
+   typedef T result_type;
+   ibeta_series_t(T a_, T b_, T x_, T mult) : result(mult), x(x_), apn(a_), poch(1-b_), n(1) {}
+   T operator()()
+   {
+      T r = result / apn;
+      apn += 1;
+      result *= poch * x / n;
+      ++n;
+      poch += 1;
+      return r;
+   }
+private:
+   T result, x, apn, poch;
+   int n;
+};
+
+template <class T, class Lanczos, class Policy>
+T ibeta_series(T a, T b, T x, T s0, const Lanczos&, bool normalised, T* p_derivative, T y, const Policy& pol)
+{
+   BOOST_MATH_STD_USING
+
+   T result;
+
+   BOOST_ASSERT((p_derivative == 0) || normalised);
+
+   if(normalised)
+   {
+      T c = a + b;
+
+      // incomplete beta power term, combined with the Lanczos approximation:
+      T agh = static_cast<T>(a + Lanczos::g() - 0.5f);
+      T bgh = static_cast<T>(b + Lanczos::g() - 0.5f);
+      T cgh = static_cast<T>(c + Lanczos::g() - 0.5f);
+      result = Lanczos::lanczos_sum_expG_scaled(c) / (Lanczos::lanczos_sum_expG_scaled(a) * Lanczos::lanczos_sum_expG_scaled(b));
+
+      T l1 = log(cgh / bgh) * (b - 0.5f);
+      T l2 = log(x * cgh / agh) * a;
+      //
+      // Check for over/underflow in the power terms:
+      //
+      if((l1 > tools::log_min_value<T>())
+         && (l1 < tools::log_max_value<T>())
+         && (l2 > tools::log_min_value<T>())
+         && (l2 < tools::log_max_value<T>()))
+      {
+         if(a * b < bgh * 10)
+            result *= exp((b - 0.5f) * boost::math::log1p(a / bgh, pol));
+         else
+            result *= pow(cgh / bgh, b - 0.5f);
+         result *= pow(x * cgh / agh, a);
+         result *= sqrt(agh / boost::math::constants::e<T>());
+
+         if(p_derivative)
+         {
+            *p_derivative = result * pow(y, b);
+            BOOST_ASSERT(*p_derivative >= 0);
+         }
+      }
+      else
+      {
+         //
+         // Oh dear, we need logs, and this *will* cancel:
+         //
+         result = log(result) + l1 + l2 + (log(agh) - 1) / 2;
+         if(p_derivative)
+            *p_derivative = exp(result + b * log(y));
+         result = exp(result);
+      }
+   }
+   else
+   {
+      // Non-normalised, just compute the power:
+      result = pow(x, a);
+   }
+   if(result < tools::min_value<T>())
+      return s0; // Safeguard: series can't cope with denorms.
+   ibeta_series_t<T> s(a, b, x, result);
+   boost::uintmax_t max_iter = policies::get_max_series_iterations<Policy>();
+   result = boost::math::tools::sum_series(s, boost::math::policies::get_epsilon<T, Policy>(), max_iter, s0);
+   policies::check_series_iterations<T>("boost::math::ibeta<%1%>(%1%, %1%, %1%) in ibeta_series (with lanczos)", max_iter, pol);
+   return result;
+}
+//
+// Incomplete Beta series again, this time without Lanczos support:
+//
+template <class T, class Policy>
+T ibeta_series(T a, T b, T x, T s0, const boost::math::lanczos::undefined_lanczos& l, bool normalised, T* p_derivative, T y, const Policy& pol)
+{
+   BOOST_MATH_STD_USING
+
+   T result;
+   BOOST_ASSERT((p_derivative == 0) || normalised);
+
+   if(normalised)
+   {
+      const T min_sterling = minimum_argument_for_bernoulli_recursion<T>();
+
+      long shift_a = 0;
+      long shift_b = 0;
+
+      if (a < min_sterling)
+         shift_a = 1 + ltrunc(min_sterling - a);
+      if (b < min_sterling)
+         shift_b = 1 + ltrunc(min_sterling - b);
+
+      T c = a + b;
+
+      if ((shift_a == 0) && (shift_b == 0))
+      {
+         result = pow(x * c / a, a) * pow(c / b, b) * scaled_tgamma_no_lanczos(c, pol) / (scaled_tgamma_no_lanczos(a, pol) * scaled_tgamma_no_lanczos(b, pol));
+      }
+      else if ((a < 1) && (b > 1))
+         result = pow(x, a) / (boost::math::tgamma(a, pol) * boost::math::tgamma_delta_ratio(b, a, pol));
+      else
+      {
+         T power = pow(x, a);
+         T bet = beta_imp(a, b, l, pol);
+         if (!(boost::math::isnormal)(power) || !(boost::math::isnormal)(bet))
+         {
+            result = exp(a * log(x) + boost::math::lgamma(c, pol) - boost::math::lgamma(a, pol) - boost::math::lgamma(b, pol));
+         }
+         else
+            result = power / bet;
+      }
+      if(p_derivative)
+      {
+         *p_derivative = result * pow(y, b);
+         BOOST_ASSERT(*p_derivative >= 0);
+      }
+   }
+   else
+   {
+      // Non-normalised, just compute the power:
+      result = pow(x, a);
+   }
+   if(result < tools::min_value<T>())
+      return s0; // Safeguard: series can't cope with denorms.
+   ibeta_series_t<T> s(a, b, x, result);
+   boost::uintmax_t max_iter = policies::get_max_series_iterations<Policy>();
+   result = boost::math::tools::sum_series(s, boost::math::policies::get_epsilon<T, Policy>(), max_iter, s0);
+   policies::check_series_iterations<T>("boost::math::ibeta<%1%>(%1%, %1%, %1%) in ibeta_series (without lanczos)", max_iter, pol);
+   return result;
+}
+
+//
+// Continued fraction for the incomplete beta:
+//
+template <class T>
+struct ibeta_fraction2_t
+{
+   typedef std::pair<T, T> result_type;
+
+   ibeta_fraction2_t(T a_, T b_, T x_, T y_) : a(a_), b(b_), x(x_), y(y_), m(0) {}
+
+   result_type operator()()
+   {
+      T aN = (a + m - 1) * (a + b + m - 1) * m * (b - m) * x * x;
+      T denom = (a + 2 * m - 1);
+      aN /= denom * denom;
+
+      T bN = static_cast<T>(m);
+      bN += (m * (b - m) * x) / (a + 2*m - 1);
+      bN += ((a + m) * (a * y - b * x + 1 + m *(2 - x))) / (a + 2*m + 1);
+
+      ++m;
+
+      return std::make_pair(aN, bN);
+   }
+
+private:
+   T a, b, x, y;
+   int m;
+};
+//
+// Evaluate the incomplete beta via the continued fraction representation:
+//
+template <class T, class Policy>
+inline T ibeta_fraction2(T a, T b, T x, T y, const Policy& pol, bool normalised, T* p_derivative)
+{
+   typedef typename lanczos::lanczos<T, Policy>::type lanczos_type;
+   BOOST_MATH_STD_USING
+   T result = ibeta_power_terms(a, b, x, y, lanczos_type(), normalised, pol);
+   if(p_derivative)
+   {
+      *p_derivative = result;
+      BOOST_ASSERT(*p_derivative >= 0);
+   }
+   if(result == 0)
+      return result;
+
+   ibeta_fraction2_t<T> f(a, b, x, y);
+   T fract = boost::math::tools::continued_fraction_b(f, boost::math::policies::get_epsilon<T, Policy>());
+   BOOST_MATH_INSTRUMENT_VARIABLE(fract);
+   BOOST_MATH_INSTRUMENT_VARIABLE(result);
+   return result / fract;
+}
+//
+// Computes the difference between ibeta(a,b,x) and ibeta(a+k,b,x):
+//
+template <class T, class Policy>
+T ibeta_a_step(T a, T b, T x, T y, int k, const Policy& pol, bool normalised, T* p_derivative)
+{
+   typedef typename lanczos::lanczos<T, Policy>::type lanczos_type;
+
+   BOOST_MATH_INSTRUMENT_VARIABLE(k);
+
+   T prefix = ibeta_power_terms(a, b, x, y, lanczos_type(), normalised, pol);
+   if(p_derivative)
+   {
+      *p_derivative = prefix;
+      BOOST_ASSERT(*p_derivative >= 0);
+   }
+   prefix /= a;
+   if(prefix == 0)
+      return prefix;
+   T sum = 1;
+   T term = 1;
+   // series summation from 0 to k-1:
+   for(int i = 0; i < k-1; ++i)
+   {
+      term *= (a+b+i) * x / (a+i+1);
+      sum += term;
+   }
+   prefix *= sum;
+
+   return prefix;
+}
+//
+// This function is only needed for the non-regular incomplete beta,
+// it computes the delta in:
+// beta(a,b,x) = prefix + delta * beta(a+k,b,x)
+// it is currently only called for small k.
+//
+template <class T>
+inline T rising_factorial_ratio(T a, T b, int k)
+{
+   // calculate:
+   // (a)(a+1)(a+2)...(a+k-1)
+   // _______________________
+   // (b)(b+1)(b+2)...(b+k-1)
+
+   // This is only called with small k, for large k
+   // it is grossly inefficient, do not use outside it's
+   // intended purpose!!!
+   BOOST_MATH_INSTRUMENT_VARIABLE(k);
+   if(k == 0)
+      return 1;
+   T result = 1;
+   for(int i = 0; i < k; ++i)
+      result *= (a+i) / (b+i);
+   return result;
+}
+//
+// Routine for a > 15, b < 1
+//
+// Begin by figuring out how large our table of Pn's should be,
+// quoted accuracies are "guestimates" based on empiracal observation.
+// Note that the table size should never exceed the size of our
+// tables of factorials.
+//
+template <class T>
+struct Pn_size
+{
+   // This is likely to be enough for ~35-50 digit accuracy
+   // but it's hard to quantify exactly:
+   BOOST_STATIC_CONSTANT(unsigned, value =
+      ::boost::math::max_factorial<T>::value >= 100 ? 50
+   : ::boost::math::max_factorial<T>::value >= ::boost::math::max_factorial<double>::value ? 30
+   : ::boost::math::max_factorial<T>::value >= ::boost::math::max_factorial<float>::value ? 15 : 1);
+   BOOST_STATIC_ASSERT(::boost::math::max_factorial<T>::value >= ::boost::math::max_factorial<float>::value);
+};
+template <>
+struct Pn_size<float>
+{
+   BOOST_STATIC_CONSTANT(unsigned, value = 15); // ~8-15 digit accuracy
+   BOOST_STATIC_ASSERT(::boost::math::max_factorial<float>::value >= 30);
+};
+template <>
+struct Pn_size<double>
+{
+   BOOST_STATIC_CONSTANT(unsigned, value = 30); // 16-20 digit accuracy
+   BOOST_STATIC_ASSERT(::boost::math::max_factorial<double>::value >= 60);
+};
+template <>
+struct Pn_size<long double>
+{
+   BOOST_STATIC_CONSTANT(unsigned, value = 50); // ~35-50 digit accuracy
+   BOOST_STATIC_ASSERT(::boost::math::max_factorial<long double>::value >= 100);
+};
+
+template <class T, class Policy>
+T beta_small_b_large_a_series(T a, T b, T x, T y, T s0, T mult, const Policy& pol, bool normalised)
+{
+   typedef typename lanczos::lanczos<T, Policy>::type lanczos_type;
+   BOOST_MATH_STD_USING
+   //
+   // This is DiDonato and Morris's BGRAT routine, see Eq's 9 through 9.6.
+   //
+   // Some values we'll need later, these are Eq 9.1:
+   //
+   T bm1 = b - 1;
+   T t = a + bm1 / 2;
+   T lx, u;
+   if(y < 0.35)
+      lx = boost::math::log1p(-y, pol);
+   else
+      lx = log(x);
+   u = -t * lx;
+   // and from from 9.2:
+   T prefix;
+   T h = regularised_gamma_prefix(b, u, pol, lanczos_type());
+   if(h <= tools::min_value<T>())
+      return s0;
+   if(normalised)
+   {
+      prefix = h / boost::math::tgamma_delta_ratio(a, b, pol);
+      prefix /= pow(t, b);
+   }
+   else
+   {
+      prefix = full_igamma_prefix(b, u, pol) / pow(t, b);
+   }
+   prefix *= mult;
+   //
+   // now we need the quantity Pn, unfortunatately this is computed
+   // recursively, and requires a full history of all the previous values
+   // so no choice but to declare a big table and hope it's big enough...
+   //
+   T p[ ::boost::math::detail::Pn_size<T>::value ] = { 1 };  // see 9.3.
+   //
+   // Now an initial value for J, see 9.6:
+   //
+   T j = boost::math::gamma_q(b, u, pol) / h;
+   //
+   // Now we can start to pull things together and evaluate the sum in Eq 9:
+   //
+   T sum = s0 + prefix * j;  // Value at N = 0
+   // some variables we'll need:
+   unsigned tnp1 = 1; // 2*N+1
+   T lx2 = lx / 2;
+   lx2 *= lx2;
+   T lxp = 1;
+   T t4 = 4 * t * t;
+   T b2n = b;
+
+   for(unsigned n = 1; n < sizeof(p)/sizeof(p[0]); ++n)
+   {
+      /*
+      // debugging code, enable this if you want to determine whether
+      // the table of Pn's is large enough...
+      //
+      static int max_count = 2;
+      if(n > max_count)
+      {
+         max_count = n;
+         std::cerr << "Max iterations in BGRAT was " << n << std::endl;
+      }
+      */
+      //
+      // begin by evaluating the next Pn from Eq 9.4:
+      //
+      tnp1 += 2;
+      p[n] = 0;
+      T mbn = b - n;
+      unsigned tmp1 = 3;
+      for(unsigned m = 1; m < n; ++m)
+      {
+         mbn = m * b - n;
+         p[n] += mbn * p[n-m] / boost::math::unchecked_factorial<T>(tmp1);
+         tmp1 += 2;
+      }
+      p[n] /= n;
+      p[n] += bm1 / boost::math::unchecked_factorial<T>(tnp1);
+      //
+      // Now we want Jn from Jn-1 using Eq 9.6:
+      //
+      j = (b2n * (b2n + 1) * j + (u + b2n + 1) * lxp) / t4;
+      lxp *= lx2;
+      b2n += 2;
+      //
+      // pull it together with Eq 9:
+      //
+      T r = prefix * p[n] * j;
+      sum += r;
+      if(r > 1)
+      {
+         if(fabs(r) < fabs(tools::epsilon<T>() * sum))
+            break;
+      }
+      else
+      {
+         if(fabs(r / tools::epsilon<T>()) < fabs(sum))
+            break;
+      }
+   }
+   return sum;
+} // template <class T, class Lanczos>T beta_small_b_large_a_series(T a, T b, T x, T y, T s0, T mult, const Lanczos& l, bool normalised)
+
+//
+// For integer arguments we can relate the incomplete beta to the
+// complement of the binomial distribution cdf and use this finite sum.
+//
+template <class T>
+T binomial_ccdf(T n, T k, T x, T y)
+{
+   BOOST_MATH_STD_USING // ADL of std names
+
+   T result = pow(x, n);
+
+   if(result > tools::min_value<T>())
+   {
+      T term = result;
+      for(unsigned i = itrunc(T(n - 1)); i > k; --i)
+      {
+         term *= ((i + 1) * y) / ((n - i) * x);
+         result += term;
+      }
+   }
+   else
+   {
+      // First term underflows so we need to start at the mode of the
+      // distribution and work outwards:
+      int start = itrunc(n * x);
+      if(start <= k + 1)
+         start = itrunc(k + 2);
+      result = pow(x, start) * pow(y, n - start) * boost::math::binomial_coefficient<T>(itrunc(n), itrunc(start));
+      if(result == 0)
+      {
+         // OK, starting slightly above the mode didn't work,
+         // we'll have to sum the terms the old fashioned way:
+         for(unsigned i = start - 1; i > k; --i)
+         {
+            result += pow(x, (int)i) * pow(y, n - i) * boost::math::binomial_coefficient<T>(itrunc(n), itrunc(i));
+         }
+      }
+      else
+      {
+         T term = result;
+         T start_term = result;
+         for(unsigned i = start - 1; i > k; --i)
+         {
+            term *= ((i + 1) * y) / ((n - i) * x);
+            result += term;
+         }
+         term = start_term;
+         for(unsigned i = start + 1; i <= n; ++i)
+         {
+            term *= (n - i + 1) * x / (i * y);
+            result += term;
+         }
+      }
+   }
+
+   return result;
+}
+
+
+//
+// The incomplete beta function implementation:
+// This is just a big bunch of spagetti code to divide up the
+// input range and select the right implementation method for
+// each domain:
+//
+template <class T, class Policy>
+T ibeta_imp(T a, T b, T x, const Policy& pol, bool inv, bool normalised, T* p_derivative)
+{
+   static const char* function = "boost::math::ibeta<%1%>(%1%, %1%, %1%)";
+   typedef typename lanczos::lanczos<T, Policy>::type lanczos_type;
+   BOOST_MATH_STD_USING // for ADL of std math functions.
+
+   BOOST_MATH_INSTRUMENT_VARIABLE(a);
+   BOOST_MATH_INSTRUMENT_VARIABLE(b);
+   BOOST_MATH_INSTRUMENT_VARIABLE(x);
+   BOOST_MATH_INSTRUMENT_VARIABLE(inv);
+   BOOST_MATH_INSTRUMENT_VARIABLE(normalised);
+
+   bool invert = inv;
+   T fract;
+   T y = 1 - x;
+
+   BOOST_ASSERT((p_derivative == 0) || normalised);
+
+   if(p_derivative)
+      *p_derivative = -1; // value not set.
+
+   if((x < 0) || (x > 1))
+      return policies::raise_domain_error<T>(function, "Parameter x outside the range [0,1] in the incomplete beta function (got x=%1%).", x, pol);
+
+   if(normalised)
+   {
+      if(a < 0)
+         return policies::raise_domain_error<T>(function, "The argument a to the incomplete beta function must be >= zero (got a=%1%).", a, pol);
+      if(b < 0)
+         return policies::raise_domain_error<T>(function, "The argument b to the incomplete beta function must be >= zero (got b=%1%).", b, pol);
+      // extend to a few very special cases:
+      if(a == 0)
+      {
+         if(b == 0)
+            return policies::raise_domain_error<T>(function, "The arguments a and b to the incomplete beta function cannot both be zero, with x=%1%.", x, pol);
+         if(b > 0)
+            return static_cast<T>(inv ? 0 : 1);
+      }
+      else if(b == 0)
+      {
+         if(a > 0)
+            return static_cast<T>(inv ? 1 : 0);
+      }
+   }
+   else
+   {
+      if(a <= 0)
+         return policies::raise_domain_error<T>(function, "The argument a to the incomplete beta function must be greater than zero (got a=%1%).", a, pol);
+      if(b <= 0)
+         return policies::raise_domain_error<T>(function, "The argument b to the incomplete beta function must be greater than zero (got b=%1%).", b, pol);
+   }
+
+   if(x == 0)
+   {
+      if(p_derivative)
+      {
+         *p_derivative = (a == 1) ? (T)1 : (a < 1) ? T(tools::max_value<T>() / 2) : T(tools::min_value<T>() * 2);
+      }
+      return (invert ? (normalised ? T(1) : boost::math::beta(a, b, pol)) : T(0));
+   }
+   if(x == 1)
+   {
+      if(p_derivative)
+      {
+         *p_derivative = (b == 1) ? T(1) : (b < 1) ? T(tools::max_value<T>() / 2) : T(tools::min_value<T>() * 2);
+      }
+      return (invert == 0 ? (normalised ? 1 : boost::math::beta(a, b, pol)) : 0);
+   }
+   if((a == 0.5f) && (b == 0.5f))
+   {
+      // We have an arcsine distribution:
+      if(p_derivative)
+      {
+         *p_derivative = 1 / constants::pi<T>() * sqrt(y * x);
+      }
+      T p = invert ? asin(sqrt(y)) / constants::half_pi<T>() : asin(sqrt(x)) / constants::half_pi<T>();
+      if(!normalised)
+         p *= constants::pi<T>();
+      return p;
+   }
+   if(a == 1)
+   {
+      std::swap(a, b);
+      std::swap(x, y);
+      invert = !invert;
+   }
+   if(b == 1)
+   {
+      //
+      // Special case see: http://functions.wolfram.com/GammaBetaErf/BetaRegularized/03/01/01/
+      //
+      if(a == 1)
+      {
+         if(p_derivative)
+            *p_derivative = 1;
+         return invert ? y : x;
+      }
+
+      if(p_derivative)
+      {
+         *p_derivative = a * pow(x, a - 1);
+      }
+      T p;
+      if(y < 0.5)
+         p = invert ? T(-boost::math::expm1(a * boost::math::log1p(-y, pol), pol)) : T(exp(a * boost::math::log1p(-y, pol)));
+      else
+         p = invert ? T(-boost::math::powm1(x, a, pol)) : T(pow(x, a));
+      if(!normalised)
+         p /= a;
+      return p;
+   }
+
+   if((std::min)(a, b) <= 1)
+   {
+      if(x > 0.5)
+      {
+         std::swap(a, b);
+         std::swap(x, y);
+         invert = !invert;
+         BOOST_MATH_INSTRUMENT_VARIABLE(invert);
+      }
+      if((std::max)(a, b) <= 1)
+      {
+         // Both a,b < 1:
+         if((a >= (std::min)(T(0.2), b)) || (pow(x, a) <= 0.9))
+         {
+            if(!invert)
+            {
+               fract = ibeta_series(a, b, x, T(0), lanczos_type(), normalised, p_derivative, y, pol);
+               BOOST_MATH_INSTRUMENT_VARIABLE(fract);
+            }
+            else
+            {
+               fract = -(normalised ? 1 : boost::math::beta(a, b, pol));
+               invert = false;
+               fract = -ibeta_series(a, b, x, fract, lanczos_type(), normalised, p_derivative, y, pol);
+               BOOST_MATH_INSTRUMENT_VARIABLE(fract);
+            }
+         }
+         else
+         {
+            std::swap(a, b);
+            std::swap(x, y);
+            invert = !invert;
+            if(y >= 0.3)
+            {
+               if(!invert)
+               {
+                  fract = ibeta_series(a, b, x, T(0), lanczos_type(), normalised, p_derivative, y, pol);
+                  BOOST_MATH_INSTRUMENT_VARIABLE(fract);
+               }
+               else
+               {
+                  fract = -(normalised ? 1 : boost::math::beta(a, b, pol));
+                  invert = false;
+                  fract = -ibeta_series(a, b, x, fract, lanczos_type(), normalised, p_derivative, y, pol);
+                  BOOST_MATH_INSTRUMENT_VARIABLE(fract);
+               }
+            }
+            else
+            {
+               // Sidestep on a, and then use the series representation:
+               T prefix;
+               if(!normalised)
+               {
+                  prefix = rising_factorial_ratio(T(a+b), a, 20);
+               }
+               else
+               {
+                  prefix = 1;
+               }
+               fract = ibeta_a_step(a, b, x, y, 20, pol, normalised, p_derivative);
+               if(!invert)
+               {
+                  fract = beta_small_b_large_a_series(T(a + 20), b, x, y, fract, prefix, pol, normalised);
+                  BOOST_MATH_INSTRUMENT_VARIABLE(fract);
+               }
+               else
+               {
+                  fract -= (normalised ? 1 : boost::math::beta(a, b, pol));
+                  invert = false;
+                  fract = -beta_small_b_large_a_series(T(a + 20), b, x, y, fract, prefix, pol, normalised);
+                  BOOST_MATH_INSTRUMENT_VARIABLE(fract);
+               }
+            }
+         }
+      }
+      else
+      {
+         // One of a, b < 1 only:
+         if((b <= 1) || ((x < 0.1) && (pow(b * x, a) <= 0.7)))
+         {
+            if(!invert)
+            {
+               fract = ibeta_series(a, b, x, T(0), lanczos_type(), normalised, p_derivative, y, pol);
+               BOOST_MATH_INSTRUMENT_VARIABLE(fract);
+            }
+            else
+            {
+               fract = -(normalised ? 1 : boost::math::beta(a, b, pol));
+               invert = false;
+               fract = -ibeta_series(a, b, x, fract, lanczos_type(), normalised, p_derivative, y, pol);
+               BOOST_MATH_INSTRUMENT_VARIABLE(fract);
+            }
+         }
+         else
+         {
+            std::swap(a, b);
+            std::swap(x, y);
+            invert = !invert;
+
+            if(y >= 0.3)
+            {
+               if(!invert)
+               {
+                  fract = ibeta_series(a, b, x, T(0), lanczos_type(), normalised, p_derivative, y, pol);
+                  BOOST_MATH_INSTRUMENT_VARIABLE(fract);
+               }
+               else
+               {
+                  fract = -(normalised ? 1 : boost::math::beta(a, b, pol));
+                  invert = false;
+                  fract = -ibeta_series(a, b, x, fract, lanczos_type(), normalised, p_derivative, y, pol);
+                  BOOST_MATH_INSTRUMENT_VARIABLE(fract);
+               }
+            }
+            else if(a >= 15)
+            {
+               if(!invert)
+               {
+                  fract = beta_small_b_large_a_series(a, b, x, y, T(0), T(1), pol, normalised);
+                  BOOST_MATH_INSTRUMENT_VARIABLE(fract);
+               }
+               else
+               {
+                  fract = -(normalised ? 1 : boost::math::beta(a, b, pol));
+                  invert = false;
+                  fract = -beta_small_b_large_a_series(a, b, x, y, fract, T(1), pol, normalised);
+                  BOOST_MATH_INSTRUMENT_VARIABLE(fract);
+               }
+            }
+            else
+            {
+               // Sidestep to improve errors:
+               T prefix;
+               if(!normalised)
+               {
+                  prefix = rising_factorial_ratio(T(a+b), a, 20);
+               }
+               else
+               {
+                  prefix = 1;
+               }
+               fract = ibeta_a_step(a, b, x, y, 20, pol, normalised, p_derivative);
+               BOOST_MATH_INSTRUMENT_VARIABLE(fract);
+               if(!invert)
+               {
+                  fract = beta_small_b_large_a_series(T(a + 20), b, x, y, fract, prefix, pol, normalised);
+                  BOOST_MATH_INSTRUMENT_VARIABLE(fract);
+               }
+               else
+               {
+                  fract -= (normalised ? 1 : boost::math::beta(a, b, pol));
+                  invert = false;
+                  fract = -beta_small_b_large_a_series(T(a + 20), b, x, y, fract, prefix, pol, normalised);
+                  BOOST_MATH_INSTRUMENT_VARIABLE(fract);
+               }
+            }
+         }
+      }
+   }
+   else
+   {
+      // Both a,b >= 1:
+      T lambda;
+      if(a < b)
+      {
+         lambda = a - (a + b) * x;
+      }
+      else
+      {
+         lambda = (a + b) * y - b;
+      }
+      if(lambda < 0)
+      {
+         std::swap(a, b);
+         std::swap(x, y);
+         invert = !invert;
+         BOOST_MATH_INSTRUMENT_VARIABLE(invert);
+      }
+
+      if(b < 40)
+      {
+         if((floor(a) == a) && (floor(b) == b) && (a < (std::numeric_limits<int>::max)() - 100) && (y != 1))
+         {
+            // relate to the binomial distribution and use a finite sum:
+            T k = a - 1;
+            T n = b + k;
+            fract = binomial_ccdf(n, k, x, y);
+            if(!normalised)
+               fract *= boost::math::beta(a, b, pol);
+            BOOST_MATH_INSTRUMENT_VARIABLE(fract);
+         }
+         else if(b * x <= 0.7)
+         {
+            if(!invert)
+            {
+               fract = ibeta_series(a, b, x, T(0), lanczos_type(), normalised, p_derivative, y, pol);
+               BOOST_MATH_INSTRUMENT_VARIABLE(fract);
+            }
+            else
+            {
+               fract = -(normalised ? 1 : boost::math::beta(a, b, pol));
+               invert = false;
+               fract = -ibeta_series(a, b, x, fract, lanczos_type(), normalised, p_derivative, y, pol);
+               BOOST_MATH_INSTRUMENT_VARIABLE(fract);
+            }
+         }
+         else if(a > 15)
+         {
+            // sidestep so we can use the series representation:
+            int n = itrunc(T(floor(b)), pol);
+            if(n == b)
+               --n;
+            T bbar = b - n;
+            T prefix;
+            if(!normalised)
+            {
+               prefix = rising_factorial_ratio(T(a+bbar), bbar, n);
+            }
+            else
+            {
+               prefix = 1;
+            }
+            fract = ibeta_a_step(bbar, a, y, x, n, pol, normalised, static_cast<T*>(0));
+            fract = beta_small_b_large_a_series(a,  bbar, x, y, fract, T(1), pol, normalised);
+            fract /= prefix;
+            BOOST_MATH_INSTRUMENT_VARIABLE(fract);
+         }
+         else if(normalised)
+         {
+            // The formula here for the non-normalised case is tricky to figure
+            // out (for me!!), and requires two pochhammer calculations rather
+            // than one, so leave it for now and only use this in the normalized case....
+            int n = itrunc(T(floor(b)), pol);
+            T bbar = b - n;
+            if(bbar <= 0)
+            {
+               --n;
+               bbar += 1;
+            }
+            fract = ibeta_a_step(bbar, a, y, x, n, pol, normalised, static_cast<T*>(0));
+            fract += ibeta_a_step(a, bbar, x, y, 20, pol, normalised, static_cast<T*>(0));
+            if(invert)
+               fract -= 1;  // Note this line would need changing if we ever enable this branch in non-normalized case
+            fract = beta_small_b_large_a_series(T(a+20),  bbar, x, y, fract, T(1), pol, normalised);
+            if(invert)
+            {
+               fract = -fract;
+               invert = false;
+            }
+            BOOST_MATH_INSTRUMENT_VARIABLE(fract);
+         }
+         else
+         {
+            fract = ibeta_fraction2(a, b, x, y, pol, normalised, p_derivative);
+            BOOST_MATH_INSTRUMENT_VARIABLE(fract);
+         }
+      }
+      else
+      {
+         fract = ibeta_fraction2(a, b, x, y, pol, normalised, p_derivative);
+         BOOST_MATH_INSTRUMENT_VARIABLE(fract);
+      }
+   }
+   if(p_derivative)
+   {
+      if(*p_derivative < 0)
+      {
+         *p_derivative = ibeta_power_terms(a, b, x, y, lanczos_type(), true, pol);
+      }
+      T div = y * x;
+
+      if(*p_derivative != 0)
+      {
+         if((tools::max_value<T>() * div < *p_derivative))
+         {
+            // overflow, return an arbitarily large value:
+            *p_derivative = tools::max_value<T>() / 2;
+         }
+         else
+         {
+            *p_derivative /= div;
+         }
+      }
+   }
+   return invert ? (normalised ? 1 : boost::math::beta(a, b, pol)) - fract : fract;
+} // template <class T, class Lanczos>T ibeta_imp(T a, T b, T x, const Lanczos& l, bool inv, bool normalised)
+
+template <class T, class Policy>
+inline T ibeta_imp(T a, T b, T x, const Policy& pol, bool inv, bool normalised)
+{
+   return ibeta_imp(a, b, x, pol, inv, normalised, static_cast<T*>(0));
+}
+
+template <class T, class Policy>
+T ibeta_derivative_imp(T a, T b, T x, const Policy& pol)
+{
+   static const char* function = "ibeta_derivative<%1%>(%1%,%1%,%1%)";
+   //
+   // start with the usual error checks:
+   //
+   if(a <= 0)
+      return policies::raise_domain_error<T>(function, "The argument a to the incomplete beta function must be greater than zero (got a=%1%).", a, pol);
+   if(b <= 0)
+      return policies::raise_domain_error<T>(function, "The argument b to the incomplete beta function must be greater than zero (got b=%1%).", b, pol);
+   if((x < 0) || (x > 1))
+      return policies::raise_domain_error<T>(function, "Parameter x outside the range [0,1] in the incomplete beta function (got x=%1%).", x, pol);
+   //
+   // Now the corner cases:
+   //
+   if(x == 0)
+   {
+      return (a > 1) ? 0 :
+         (a == 1) ? 1 / boost::math::beta(a, b, pol) : policies::raise_overflow_error<T>(function, 0, pol);
+   }
+   else if(x == 1)
+   {
+      return (b > 1) ? 0 :
+         (b == 1) ? 1 / boost::math::beta(a, b, pol) : policies::raise_overflow_error<T>(function, 0, pol);
+   }
+   //
+   // Now the regular cases:
+   //
+   typedef typename lanczos::lanczos<T, Policy>::type lanczos_type;
+   T y = (1 - x) * x;
+   T f1 = ibeta_power_terms<T>(a, b, x, 1 - x, lanczos_type(), true, pol, 1 / y, function);
+   return f1;
+}
+//
+// Some forwarding functions that dis-ambiguate the third argument type:
+//
+template <class RT1, class RT2, class Policy>
+inline typename tools::promote_args<RT1, RT2>::type
+   beta(RT1 a, RT2 b, const Policy&, const mpl::true_*)
+{
+   BOOST_FPU_EXCEPTION_GUARD
+   typedef typename tools::promote_args<RT1, RT2>::type result_type;
+   typedef typename policies::evaluation<result_type, Policy>::type value_type;
+   typedef typename lanczos::lanczos<value_type, Policy>::type evaluation_type;
+   typedef typename policies::normalise<
+      Policy,
+      policies::promote_float<false>,
+      policies::promote_double<false>,
+      policies::discrete_quantile<>,
+      policies::assert_undefined<> >::type forwarding_policy;
+
+   return policies::checked_narrowing_cast<result_type, forwarding_policy>(detail::beta_imp(static_cast<value_type>(a), static_cast<value_type>(b), evaluation_type(), forwarding_policy()), "boost::math::beta<%1%>(%1%,%1%)");
+}
+template <class RT1, class RT2, class RT3>
+inline typename tools::promote_args<RT1, RT2, RT3>::type
+   beta(RT1 a, RT2 b, RT3 x, const mpl::false_*)
+{
+   return boost::math::beta(a, b, x, policies::policy<>());
+}
+} // namespace detail
+
+//
+// The actual function entry-points now follow, these just figure out
+// which Lanczos approximation to use
+// and forward to the implementation functions:
+//
+template <class RT1, class RT2, class A>
+inline typename tools::promote_args<RT1, RT2, A>::type
+   beta(RT1 a, RT2 b, A arg)
+{
+   typedef typename policies::is_policy<A>::type tag;
+   return boost::math::detail::beta(a, b, arg, static_cast<tag*>(0));
+}
+
+template <class RT1, class RT2>
+inline typename tools::promote_args<RT1, RT2>::type
+   beta(RT1 a, RT2 b)
+{
+   return boost::math::beta(a, b, policies::policy<>());
+}
+
+template <class RT1, class RT2, class RT3, class Policy>
+inline typename tools::promote_args<RT1, RT2, RT3>::type
+   beta(RT1 a, RT2 b, RT3 x, const Policy&)
+{
+   BOOST_FPU_EXCEPTION_GUARD
+   typedef typename tools::promote_args<RT1, RT2, RT3>::type result_type;
+   typedef typename policies::evaluation<result_type, Policy>::type value_type;
+   typedef typename policies::normalise<
+      Policy,
+      policies::promote_float<false>,
+      policies::promote_double<false>,
+      policies::discrete_quantile<>,
+      policies::assert_undefined<> >::type forwarding_policy;
+
+   return policies::checked_narrowing_cast<result_type, forwarding_policy>(detail::ibeta_imp(static_cast<value_type>(a), static_cast<value_type>(b), static_cast<value_type>(x), forwarding_policy(), false, false), "boost::math::beta<%1%>(%1%,%1%,%1%)");
+}
+
+template <class RT1, class RT2, class RT3, class Policy>
+inline typename tools::promote_args<RT1, RT2, RT3>::type
+   betac(RT1 a, RT2 b, RT3 x, const Policy&)
+{
+   BOOST_FPU_EXCEPTION_GUARD
+   typedef typename tools::promote_args<RT1, RT2, RT3>::type result_type;
+   typedef typename policies::evaluation<result_type, Policy>::type value_type;
+   typedef typename policies::normalise<
+      Policy,
+      policies::promote_float<false>,
+      policies::promote_double<false>,
+      policies::discrete_quantile<>,
+      policies::assert_undefined<> >::type forwarding_policy;
+
+   return policies::checked_narrowing_cast<result_type, forwarding_policy>(detail::ibeta_imp(static_cast<value_type>(a), static_cast<value_type>(b), static_cast<value_type>(x), forwarding_policy(), true, false), "boost::math::betac<%1%>(%1%,%1%,%1%)");
+}
+template <class RT1, class RT2, class RT3>
+inline typename tools::promote_args<RT1, RT2, RT3>::type
+   betac(RT1 a, RT2 b, RT3 x)
+{
+   return boost::math::betac(a, b, x, policies::policy<>());
+}
+
+template <class RT1, class RT2, class RT3, class Policy>
+inline typename tools::promote_args<RT1, RT2, RT3>::type
+   ibeta(RT1 a, RT2 b, RT3 x, const Policy&)
+{
+   BOOST_FPU_EXCEPTION_GUARD
+   typedef typename tools::promote_args<RT1, RT2, RT3>::type result_type;
+   typedef typename policies::evaluation<result_type, Policy>::type value_type;
+   typedef typename policies::normalise<
+      Policy,
+      policies::promote_float<false>,
+      policies::promote_double<false>,
+      policies::discrete_quantile<>,
+      policies::assert_undefined<> >::type forwarding_policy;
+
+   return policies::checked_narrowing_cast<result_type, forwarding_policy>(detail::ibeta_imp(static_cast<value_type>(a), static_cast<value_type>(b), static_cast<value_type>(x), forwarding_policy(), false, true), "boost::math::ibeta<%1%>(%1%,%1%,%1%)");
+}
+template <class RT1, class RT2, class RT3>
+inline typename tools::promote_args<RT1, RT2, RT3>::type
+   ibeta(RT1 a, RT2 b, RT3 x)
+{
+   return boost::math::ibeta(a, b, x, policies::policy<>());
+}
+
+template <class RT1, class RT2, class RT3, class Policy>
+inline typename tools::promote_args<RT1, RT2, RT3>::type
+   ibetac(RT1 a, RT2 b, RT3 x, const Policy&)
+{
+   BOOST_FPU_EXCEPTION_GUARD
+   typedef typename tools::promote_args<RT1, RT2, RT3>::type result_type;
+   typedef typename policies::evaluation<result_type, Policy>::type value_type;
+   typedef typename policies::normalise<
+      Policy,
+      policies::promote_float<false>,
+      policies::promote_double<false>,
+      policies::discrete_quantile<>,
+      policies::assert_undefined<> >::type forwarding_policy;
+
+   return policies::checked_narrowing_cast<result_type, forwarding_policy>(detail::ibeta_imp(static_cast<value_type>(a), static_cast<value_type>(b), static_cast<value_type>(x), forwarding_policy(), true, true), "boost::math::ibetac<%1%>(%1%,%1%,%1%)");
+}
+template <class RT1, class RT2, class RT3>
+inline typename tools::promote_args<RT1, RT2, RT3>::type
+   ibetac(RT1 a, RT2 b, RT3 x)
+{
+   return boost::math::ibetac(a, b, x, policies::policy<>());
+}
+
+template <class RT1, class RT2, class RT3, class Policy>
+inline typename tools::promote_args<RT1, RT2, RT3>::type
+   ibeta_derivative(RT1 a, RT2 b, RT3 x, const Policy&)
+{
+   BOOST_FPU_EXCEPTION_GUARD
+   typedef typename tools::promote_args<RT1, RT2, RT3>::type result_type;
+   typedef typename policies::evaluation<result_type, Policy>::type value_type;
+   typedef typename policies::normalise<
+      Policy,
+      policies::promote_float<false>,
+      policies::promote_double<false>,
+      policies::discrete_quantile<>,
+      policies::assert_undefined<> >::type forwarding_policy;
+
+   return policies::checked_narrowing_cast<result_type, forwarding_policy>(detail::ibeta_derivative_imp(static_cast<value_type>(a), static_cast<value_type>(b), static_cast<value_type>(x), forwarding_policy()), "boost::math::ibeta_derivative<%1%>(%1%,%1%,%1%)");
+}
+template <class RT1, class RT2, class RT3>
+inline typename tools::promote_args<RT1, RT2, RT3>::type
+   ibeta_derivative(RT1 a, RT2 b, RT3 x)
+{
+   return boost::math::ibeta_derivative(a, b, x, policies::policy<>());
+}
+
+} // namespace math
+} // namespace boost
+
+#include <boost/math/special_functions/detail/ibeta_inverse.hpp>
+#include <boost/math/special_functions/detail/ibeta_inv_ab.hpp>
+
+#endif // BOOST_MATH_SPECIAL_BETA_HPP

--- a/third_party/boost/math/special_functions/binomial.hpp
+++ b/third_party/boost/math/special_functions/binomial.hpp
@@ -1,0 +1,82 @@
+//  Copyright John Maddock 2006.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_MATH_SF_BINOMIAL_HPP
+#define BOOST_MATH_SF_BINOMIAL_HPP
+
+#ifdef _MSC_VER
+#pragma once
+#endif
+
+#include <boost/math/special_functions/math_fwd.hpp>
+#include <boost/math/special_functions/factorials.hpp>
+#include <boost/math/special_functions/beta.hpp>
+#include <boost/math/policies/error_handling.hpp>
+
+namespace boost{ namespace math{
+
+template <class T, class Policy>
+T binomial_coefficient(unsigned n, unsigned k, const Policy& pol)
+{
+   BOOST_STATIC_ASSERT(!boost::is_integral<T>::value);
+   BOOST_MATH_STD_USING
+   static const char* function = "boost::math::binomial_coefficient<%1%>(unsigned, unsigned)";
+   if(k > n)
+      return policies::raise_domain_error<T>(
+         function, 
+         "The binomial coefficient is undefined for k > n, but got k = %1%.",
+         static_cast<T>(k), pol);
+   T result;
+   if((k == 0) || (k == n))
+      return static_cast<T>(1);
+   if((k == 1) || (k == n-1))
+      return static_cast<T>(n);
+
+   if(n <= max_factorial<T>::value)
+   {
+      // Use fast table lookup:
+      result = unchecked_factorial<T>(n);
+      result /= unchecked_factorial<T>(n-k);
+      result /= unchecked_factorial<T>(k);
+   }
+   else
+   {
+      // Use the beta function:
+      if(k < n - k)
+         result = k * beta(static_cast<T>(k), static_cast<T>(n-k+1), pol);
+      else
+         result = (n - k) * beta(static_cast<T>(k+1), static_cast<T>(n-k), pol);
+      if(result == 0)
+         return policies::raise_overflow_error<T>(function, 0, pol);
+      result = 1 / result;
+   }
+   // convert to nearest integer:
+   return ceil(result - 0.5f);
+}
+//
+// Type float can only store the first 35 factorials, in order to
+// increase the chance that we can use a table driven implementation
+// we'll promote to double:
+//
+template <>
+inline float binomial_coefficient<float, policies::policy<> >(unsigned n, unsigned k, const policies::policy<>& pol)
+{
+   return policies::checked_narrowing_cast<float, policies::policy<> >(binomial_coefficient<double>(n, k, pol), "boost::math::binomial_coefficient<%1%>(unsigned,unsigned)");
+}
+
+template <class T>
+inline T binomial_coefficient(unsigned n, unsigned k)
+{
+   return binomial_coefficient<T>(n, k, policies::policy<>());
+}
+
+} // namespace math
+} // namespace boost
+
+
+#endif // BOOST_MATH_SF_BINOMIAL_HPP
+
+
+

--- a/third_party/boost/math/special_functions/detail/ibeta_inv_ab.hpp
+++ b/third_party/boost/math/special_functions/detail/ibeta_inv_ab.hpp
@@ -1,0 +1,328 @@
+//  (C) Copyright John Maddock 2006.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+//
+// This is not a complete header file, it is included by beta.hpp
+// after it has defined it's definitions.  This inverts the incomplete
+// beta functions ibeta and ibetac on the first parameters "a"
+// and "b" using a generic root finding algorithm (TOMS Algorithm 748).
+//
+
+#ifndef BOOST_MATH_SP_DETAIL_BETA_INV_AB
+#define BOOST_MATH_SP_DETAIL_BETA_INV_AB
+
+#ifdef _MSC_VER
+#pragma once
+#endif
+
+#include <boost/math/tools/toms748_solve.hpp>
+#include <boost/cstdint.hpp>
+
+namespace boost{ namespace math{ namespace detail{
+
+template <class T, class Policy>
+struct beta_inv_ab_t
+{
+   beta_inv_ab_t(T b_, T z_, T p_, bool invert_, bool swap_ab_) : b(b_), z(z_), p(p_), invert(invert_), swap_ab(swap_ab_) {}
+   T operator()(T a)
+   {
+      return invert ? 
+         p - boost::math::ibetac(swap_ab ? b : a, swap_ab ? a : b, z, Policy()) 
+         : boost::math::ibeta(swap_ab ? b : a, swap_ab ? a : b, z, Policy()) - p;
+   }
+private:
+   T b, z, p;
+   bool invert, swap_ab;
+};
+
+template <class T, class Policy>
+T inverse_negative_binomial_cornish_fisher(T n, T sf, T sfc, T p, T q, const Policy& pol)
+{
+   BOOST_MATH_STD_USING
+   // mean:
+   T m = n * (sfc) / sf;
+   T t = sqrt(n * (sfc));
+   // standard deviation:
+   T sigma = t / sf;
+   // skewness
+   T sk = (1 + sfc) / t;
+   // kurtosis:
+   T k = (6 - sf * (5+sfc)) / (n * (sfc));
+   // Get the inverse of a std normal distribution:
+   T x = boost::math::erfc_inv(p > q ? 2 * q : 2 * p, pol) * constants::root_two<T>();
+   // Set the sign:
+   if(p < 0.5)
+      x = -x;
+   T x2 = x * x;
+   // w is correction term due to skewness
+   T w = x + sk * (x2 - 1) / 6;
+   //
+   // Add on correction due to kurtosis.
+   //
+   if(n >= 10)
+      w += k * x * (x2 - 3) / 24 + sk * sk * x * (2 * x2 - 5) / -36;
+
+   w = m + sigma * w;
+   if(w < tools::min_value<T>())
+      return tools::min_value<T>();
+   return w;
+}
+
+template <class T, class Policy>
+T ibeta_inv_ab_imp(const T& b, const T& z, const T& p, const T& q, bool swap_ab, const Policy& pol)
+{
+   BOOST_MATH_STD_USING  // for ADL of std lib math functions
+   //
+   // Special cases first:
+   //
+   BOOST_MATH_INSTRUMENT_CODE("b = " << b << " z = " << z << " p = " << p << " q = " << " swap = " << swap_ab);
+   if(p == 0)
+   {
+      return swap_ab ? tools::min_value<T>() : tools::max_value<T>();
+   }
+   if(q == 0)
+   {
+      return swap_ab ? tools::max_value<T>() : tools::min_value<T>();
+   }
+   //
+   // Function object, this is the functor whose root
+   // we have to solve:
+   //
+   beta_inv_ab_t<T, Policy> f(b, z, (p < q) ? p : q, (p < q) ? false : true, swap_ab);
+   //
+   // Tolerance: full precision.
+   //
+   tools::eps_tolerance<T> tol(policies::digits<T, Policy>());
+   //
+   // Now figure out a starting guess for what a may be, 
+   // we'll start out with a value that'll put p or q
+   // right bang in the middle of their range, the functions
+   // are quite sensitive so we should need too many steps
+   // to bracket the root from there:
+   //
+   T guess = 0;
+   T factor = 5;
+   //
+   // Convert variables to parameters of a negative binomial distribution:
+   //
+   T n = b;
+   T sf = swap_ab ? z : 1-z;
+   T sfc = swap_ab ? 1-z : z;
+   T u = swap_ab ? p : q;
+   T v = swap_ab ? q : p;
+   if(u <= pow(sf, n))
+   {
+      //
+      // Result is less than 1, negative binomial approximation
+      // is useless....
+      //
+      if((p < q) != swap_ab)
+      {
+         guess = (std::min)(T(b * 2), T(1));
+      }
+      else
+      {
+         guess = (std::min)(T(b / 2), T(1));
+      }
+   }
+   if(n * n * n * u * sf > 0.005)
+      guess = 1 + inverse_negative_binomial_cornish_fisher(n, sf, sfc, u, v, pol);
+
+   if(guess < 10)
+   {
+      //
+      // Negative binomial approximation not accurate in this area:
+      //
+      if((p < q) != swap_ab)
+      {
+         guess = (std::min)(T(b * 2), T(10));
+      }
+      else
+      {
+         guess = (std::min)(T(b / 2), T(10));
+      }
+   }
+   else
+      factor = (v < sqrt(tools::epsilon<T>())) ? 2 : (guess < 20 ? 1.2f : 1.1f);
+   BOOST_MATH_INSTRUMENT_CODE("guess = " << guess);
+   //
+   // Max iterations permitted:
+   //
+   boost::uintmax_t max_iter = policies::get_max_root_iterations<Policy>();
+   std::pair<T, T> r = bracket_and_solve_root(f, guess, factor, swap_ab ? true : false, tol, max_iter, pol);
+   if(max_iter >= policies::get_max_root_iterations<Policy>())
+      return policies::raise_evaluation_error<T>("boost::math::ibeta_invab_imp<%1%>(%1%,%1%,%1%)", "Unable to locate the root within a reasonable number of iterations, closest approximation so far was %1%", r.first, pol);
+   return (r.first + r.second) / 2;
+}
+
+} // namespace detail
+
+template <class RT1, class RT2, class RT3, class Policy>
+typename tools::promote_args<RT1, RT2, RT3>::type 
+      ibeta_inva(RT1 b, RT2 x, RT3 p, const Policy& pol)
+{
+   typedef typename tools::promote_args<RT1, RT2, RT3>::type result_type;
+   typedef typename policies::evaluation<result_type, Policy>::type value_type;
+   typedef typename policies::normalise<
+      Policy, 
+      policies::promote_float<false>, 
+      policies::promote_double<false>, 
+      policies::discrete_quantile<>,
+      policies::assert_undefined<> >::type forwarding_policy;
+
+   static const char* function = "boost::math::ibeta_inva<%1%>(%1%,%1%,%1%)";
+   if(p == 0)
+   {
+      return policies::raise_overflow_error<result_type>(function, 0, Policy());
+   }
+   if(p == 1)
+   {
+      return tools::min_value<result_type>();
+   }
+
+   return policies::checked_narrowing_cast<result_type, forwarding_policy>(
+      detail::ibeta_inv_ab_imp(
+         static_cast<value_type>(b), 
+         static_cast<value_type>(x), 
+         static_cast<value_type>(p), 
+         static_cast<value_type>(1 - static_cast<value_type>(p)), 
+         false, pol), 
+      function);
+}
+
+template <class RT1, class RT2, class RT3, class Policy>
+typename tools::promote_args<RT1, RT2, RT3>::type 
+      ibetac_inva(RT1 b, RT2 x, RT3 q, const Policy& pol)
+{
+   typedef typename tools::promote_args<RT1, RT2, RT3>::type result_type;
+   typedef typename policies::evaluation<result_type, Policy>::type value_type;
+   typedef typename policies::normalise<
+      Policy, 
+      policies::promote_float<false>, 
+      policies::promote_double<false>, 
+      policies::discrete_quantile<>,
+      policies::assert_undefined<> >::type forwarding_policy;
+
+   static const char* function = "boost::math::ibetac_inva<%1%>(%1%,%1%,%1%)";
+   if(q == 1)
+   {
+      return policies::raise_overflow_error<result_type>(function, 0, Policy());
+   }
+   if(q == 0)
+   {
+      return tools::min_value<result_type>();
+   }
+
+   return policies::checked_narrowing_cast<result_type, forwarding_policy>(
+      detail::ibeta_inv_ab_imp(
+         static_cast<value_type>(b), 
+         static_cast<value_type>(x), 
+         static_cast<value_type>(1 - static_cast<value_type>(q)), 
+         static_cast<value_type>(q), 
+         false, pol),
+      function);
+}
+
+template <class RT1, class RT2, class RT3, class Policy>
+typename tools::promote_args<RT1, RT2, RT3>::type 
+      ibeta_invb(RT1 a, RT2 x, RT3 p, const Policy& pol)
+{
+   typedef typename tools::promote_args<RT1, RT2, RT3>::type result_type;
+   typedef typename policies::evaluation<result_type, Policy>::type value_type;
+   typedef typename policies::normalise<
+      Policy, 
+      policies::promote_float<false>, 
+      policies::promote_double<false>, 
+      policies::discrete_quantile<>,
+      policies::assert_undefined<> >::type forwarding_policy;
+
+   static const char* function = "boost::math::ibeta_invb<%1%>(%1%,%1%,%1%)";
+   if(p == 0)
+   {
+      return tools::min_value<result_type>();
+   }
+   if(p == 1)
+   {
+      return policies::raise_overflow_error<result_type>(function, 0, Policy());
+   }
+
+   return policies::checked_narrowing_cast<result_type, forwarding_policy>(
+      detail::ibeta_inv_ab_imp(
+         static_cast<value_type>(a), 
+         static_cast<value_type>(x), 
+         static_cast<value_type>(p), 
+         static_cast<value_type>(1 - static_cast<value_type>(p)), 
+         true, pol),
+      function);
+}
+
+template <class RT1, class RT2, class RT3, class Policy>
+typename tools::promote_args<RT1, RT2, RT3>::type 
+      ibetac_invb(RT1 a, RT2 x, RT3 q, const Policy& pol)
+{
+   static const char* function = "boost::math::ibeta_invb<%1%>(%1%, %1%, %1%)";
+   typedef typename tools::promote_args<RT1, RT2, RT3>::type result_type;
+   typedef typename policies::evaluation<result_type, Policy>::type value_type;
+   typedef typename policies::normalise<
+      Policy, 
+      policies::promote_float<false>, 
+      policies::promote_double<false>, 
+      policies::discrete_quantile<>,
+      policies::assert_undefined<> >::type forwarding_policy;
+
+   if(q == 1)
+   {
+      return tools::min_value<result_type>();
+   }
+   if(q == 0)
+   {
+      return policies::raise_overflow_error<result_type>(function, 0, Policy());
+   }
+
+   return policies::checked_narrowing_cast<result_type, forwarding_policy>(
+      detail::ibeta_inv_ab_imp(
+         static_cast<value_type>(a), 
+         static_cast<value_type>(x), 
+         static_cast<value_type>(1 - static_cast<value_type>(q)), 
+         static_cast<value_type>(q),
+         true, pol),
+         function);
+}
+
+template <class RT1, class RT2, class RT3>
+inline typename tools::promote_args<RT1, RT2, RT3>::type 
+         ibeta_inva(RT1 b, RT2 x, RT3 p)
+{
+   return boost::math::ibeta_inva(b, x, p, policies::policy<>());
+}
+
+template <class RT1, class RT2, class RT3>
+inline typename tools::promote_args<RT1, RT2, RT3>::type 
+         ibetac_inva(RT1 b, RT2 x, RT3 q)
+{
+   return boost::math::ibetac_inva(b, x, q, policies::policy<>());
+}
+
+template <class RT1, class RT2, class RT3>
+inline typename tools::promote_args<RT1, RT2, RT3>::type 
+         ibeta_invb(RT1 a, RT2 x, RT3 p)
+{
+   return boost::math::ibeta_invb(a, x, p, policies::policy<>());
+}
+
+template <class RT1, class RT2, class RT3>
+inline typename tools::promote_args<RT1, RT2, RT3>::type 
+         ibetac_invb(RT1 a, RT2 x, RT3 q)
+{
+   return boost::math::ibetac_invb(a, x, q, policies::policy<>());
+}
+
+} // namespace math
+} // namespace boost
+
+#endif // BOOST_MATH_SP_DETAIL_BETA_INV_AB
+
+
+

--- a/third_party/boost/math/special_functions/detail/ibeta_inverse.hpp
+++ b/third_party/boost/math/special_functions/detail/ibeta_inverse.hpp
@@ -1,0 +1,993 @@
+//  Copyright John Maddock 2006.
+//  Copyright Paul A. Bristow 2007
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_MATH_SPECIAL_FUNCTIONS_IBETA_INVERSE_HPP
+#define BOOST_MATH_SPECIAL_FUNCTIONS_IBETA_INVERSE_HPP
+
+#ifdef _MSC_VER
+#pragma once
+#endif
+
+#include <boost/math/special_functions/beta.hpp>
+#include <boost/math/special_functions/erf.hpp>
+#include <boost/math/tools/roots.hpp>
+#include <boost/math/special_functions/detail/t_distribution_inv.hpp>
+
+namespace boost{ namespace math{ namespace detail{
+
+//
+// Helper object used by root finding
+// code to convert eta to x.
+//
+template <class T>
+struct temme_root_finder
+{
+   temme_root_finder(const T t_, const T a_) : t(t_), a(a_) {}
+
+   boost::math::tuple<T, T> operator()(T x)
+   {
+      BOOST_MATH_STD_USING // ADL of std names
+
+      T y = 1 - x;
+      if(y == 0)
+      {
+         T big = tools::max_value<T>() / 4;
+         return boost::math::make_tuple(static_cast<T>(-big), static_cast<T>(-big));
+      }
+      if(x == 0)
+      {
+         T big = tools::max_value<T>() / 4;
+         return boost::math::make_tuple(static_cast<T>(-big), big);
+      }
+      T f = log(x) + a * log(y) + t;
+      T f1 = (1 / x) - (a / (y));
+      return boost::math::make_tuple(f, f1);
+   }
+private:
+   T t, a;
+};
+//
+// See:
+// "Asymptotic Inversion of the Incomplete Beta Function"
+// N.M. Temme
+// Journal of Computation and Applied Mathematics 41 (1992) 145-157.
+// Section 2.
+//
+template <class T, class Policy>
+T temme_method_1_ibeta_inverse(T a, T b, T z, const Policy& pol)
+{
+   BOOST_MATH_STD_USING // ADL of std names
+
+   const T r2 = sqrt(T(2));
+   //
+   // get the first approximation for eta from the inverse
+   // error function (Eq: 2.9 and 2.10).
+   //
+   T eta0 = boost::math::erfc_inv(2 * z, pol);
+   eta0 /= -sqrt(a / 2);
+
+   T terms[4] = { eta0 };
+   T workspace[7];
+   //
+   // calculate powers:
+   //
+   T B = b - a;
+   T B_2 = B * B;
+   T B_3 = B_2 * B;
+   //
+   // Calculate correction terms:
+   //
+
+   // See eq following 2.15:
+   workspace[0] = -B * r2 / 2;
+   workspace[1] = (1 - 2 * B) / 8;
+   workspace[2] = -(B * r2 / 48);
+   workspace[3] = T(-1) / 192;
+   workspace[4] = -B * r2 / 3840;
+   terms[1] = tools::evaluate_polynomial(workspace, eta0, 5);
+   // Eq Following 2.17:
+   workspace[0] = B * r2 * (3 * B - 2) / 12;
+   workspace[1] = (20 * B_2 - 12 * B + 1) / 128;
+   workspace[2] = B * r2 * (20 * B - 1) / 960;
+   workspace[3] = (16 * B_2 + 30 * B - 15) / 4608;
+   workspace[4] = B * r2 * (21 * B + 32) / 53760;
+   workspace[5] = (-32 * B_2 + 63) / 368640;
+   workspace[6] = -B * r2 * (120 * B + 17) / 25804480;
+   terms[2] = tools::evaluate_polynomial(workspace, eta0, 7);
+   // Eq Following 2.17:
+   workspace[0] = B * r2 * (-75 * B_2 + 80 * B - 16) / 480;
+   workspace[1] = (-1080 * B_3 + 868 * B_2 - 90 * B - 45) / 9216;
+   workspace[2] = B * r2 * (-1190 * B_2 + 84 * B + 373) / 53760;
+   workspace[3] = (-2240 * B_3 - 2508 * B_2 + 2100 * B - 165) / 368640;
+   terms[3] = tools::evaluate_polynomial(workspace, eta0, 4);
+   //
+   // Bring them together to get a final estimate for eta:
+   //
+   T eta = tools::evaluate_polynomial(terms, T(1/a), 4);
+   //
+   // now we need to convert eta to x, by solving the appropriate
+   // quadratic equation:
+   //
+   T eta_2 = eta * eta;
+   T c = -exp(-eta_2 / 2);
+   T x;
+   if(eta_2 == 0)
+      x = 0.5;
+   else
+      x = (1 + eta * sqrt((1 + c) / eta_2)) / 2;
+
+   BOOST_ASSERT(x >= 0);
+   BOOST_ASSERT(x <= 1);
+   BOOST_ASSERT(eta * (x - 0.5) >= 0);
+#ifdef BOOST_INSTRUMENT
+   std::cout << "Estimating x with Temme method 1: " << x << std::endl;
+#endif
+   return x;
+}
+//
+// See:
+// "Asymptotic Inversion of the Incomplete Beta Function"
+// N.M. Temme
+// Journal of Computation and Applied Mathematics 41 (1992) 145-157.
+// Section 3.
+//
+template <class T, class Policy>
+T temme_method_2_ibeta_inverse(T /*a*/, T /*b*/, T z, T r, T theta, const Policy& pol)
+{
+   BOOST_MATH_STD_USING // ADL of std names
+
+   //
+   // Get first estimate for eta, see Eq 3.9 and 3.10,
+   // but note there is a typo in Eq 3.10:
+   //
+   T eta0 = boost::math::erfc_inv(2 * z, pol);
+   eta0 /= -sqrt(r / 2);
+
+   T s = sin(theta);
+   T c = cos(theta);
+   //
+   // Now we need to purturb eta0 to get eta, which we do by
+   // evaluating the polynomial in 1/r at the bottom of page 151,
+   // to do this we first need the error terms e1, e2 e3
+   // which we'll fill into the array "terms".  Since these
+   // terms are themselves polynomials, we'll need another
+   // array "workspace" to calculate those...
+   //
+   T terms[4] = { eta0 };
+   T workspace[6];
+   //
+   // some powers of sin(theta)cos(theta) that we'll need later:
+   //
+   T sc = s * c;
+   T sc_2 = sc * sc;
+   T sc_3 = sc_2 * sc;
+   T sc_4 = sc_2 * sc_2;
+   T sc_5 = sc_2 * sc_3;
+   T sc_6 = sc_3 * sc_3;
+   T sc_7 = sc_4 * sc_3;
+   //
+   // Calculate e1 and put it in terms[1], see the middle of page 151:
+   //
+   workspace[0] = (2 * s * s - 1) / (3 * s * c);
+   static const BOOST_MATH_INT_TABLE_TYPE(T, int) co1[] = { -1, -5, 5 };
+   workspace[1] = -tools::evaluate_even_polynomial(co1, s, 3) / (36 * sc_2);
+   static const BOOST_MATH_INT_TABLE_TYPE(T, int) co2[] = { 1, 21, -69, 46 };
+   workspace[2] = tools::evaluate_even_polynomial(co2, s, 4) / (1620 * sc_3);
+   static const BOOST_MATH_INT_TABLE_TYPE(T, int) co3[] = { 7, -2, 33, -62, 31 };
+   workspace[3] = -tools::evaluate_even_polynomial(co3, s, 5) / (6480 * sc_4);
+   static const BOOST_MATH_INT_TABLE_TYPE(T, int) co4[] = { 25, -52, -17, 88, -115, 46 };
+   workspace[4] = tools::evaluate_even_polynomial(co4, s, 6) / (90720 * sc_5);
+   terms[1] = tools::evaluate_polynomial(workspace, eta0, 5);
+   //
+   // Now evaluate e2 and put it in terms[2]:
+   //
+   static const BOOST_MATH_INT_TABLE_TYPE(T, int) co5[] = { 7, 12, -78, 52 };
+   workspace[0] = -tools::evaluate_even_polynomial(co5, s, 4) / (405 * sc_3);
+   static const BOOST_MATH_INT_TABLE_TYPE(T, int) co6[] = { -7, 2, 183, -370, 185 };
+   workspace[1] = tools::evaluate_even_polynomial(co6, s, 5) / (2592 * sc_4);
+   static const BOOST_MATH_INT_TABLE_TYPE(T, int) co7[] = { -533, 776, -1835, 10240, -13525, 5410 };
+   workspace[2] = -tools::evaluate_even_polynomial(co7, s, 6) / (204120 * sc_5);
+   static const BOOST_MATH_INT_TABLE_TYPE(T, int) co8[] = { -1579, 3747, -3372, -15821, 45588, -45213, 15071 };
+   workspace[3] = -tools::evaluate_even_polynomial(co8, s, 7) / (2099520 * sc_6);
+   terms[2] = tools::evaluate_polynomial(workspace, eta0, 4);
+   //
+   // And e3, and put it in terms[3]:
+   //
+   static const BOOST_MATH_INT_TABLE_TYPE(T, int) co9[] = {449, -1259, -769, 6686, -9260, 3704 };
+   workspace[0] = tools::evaluate_even_polynomial(co9, s, 6) / (102060 * sc_5);
+   static const BOOST_MATH_INT_TABLE_TYPE(T, int) co10[] = { 63149, -151557, 140052, -727469, 2239932, -2251437, 750479 };
+   workspace[1] = -tools::evaluate_even_polynomial(co10, s, 7) / (20995200 * sc_6);
+   static const BOOST_MATH_INT_TABLE_TYPE(T, int) co11[] = { 29233, -78755, 105222, 146879, -1602610, 3195183, -2554139, 729754 };
+   workspace[2] = tools::evaluate_even_polynomial(co11, s, 8) / (36741600 * sc_7);
+   terms[3] = tools::evaluate_polynomial(workspace, eta0, 3);
+   //
+   // Bring the correction terms together to evaluate eta,
+   // this is the last equation on page 151:
+   //
+   T eta = tools::evaluate_polynomial(terms, T(1/r), 4);
+   //
+   // Now that we have eta we need to back solve for x,
+   // we seek the value of x that gives eta in Eq 3.2.
+   // The two methods used are described in section 5.
+   //
+   // Begin by defining a few variables we'll need later:
+   //
+   T x;
+   T s_2 = s * s;
+   T c_2 = c * c;
+   T alpha = c / s;
+   alpha *= alpha;
+   T lu = (-(eta * eta) / (2 * s_2) + log(s_2) + c_2 * log(c_2) / s_2);
+   //
+   // Temme doesn't specify what value to switch on here,
+   // but this seems to work pretty well:
+   //
+   if(fabs(eta) < 0.7)
+   {
+      //
+      // Small eta use the expansion Temme gives in the second equation
+      // of section 5, it's a polynomial in eta:
+      //
+      workspace[0] = s * s;
+      workspace[1] = s * c;
+      workspace[2] = (1 - 2 * workspace[0]) / 3;
+      static const BOOST_MATH_INT_TABLE_TYPE(T, int) co12[] = { 1, -13, 13 };
+      workspace[3] = tools::evaluate_polynomial(co12, workspace[0], 3) / (36 * s * c);
+      static const BOOST_MATH_INT_TABLE_TYPE(T, int) co13[] = { 1, 21, -69, 46 };
+      workspace[4] = tools::evaluate_polynomial(co13, workspace[0], 4) / (270 * workspace[0] * c * c);
+      x = tools::evaluate_polynomial(workspace, eta, 5);
+#ifdef BOOST_INSTRUMENT
+      std::cout << "Estimating x with Temme method 2 (small eta): " << x << std::endl;
+#endif
+   }
+   else
+   {
+      //
+      // If eta is large we need to solve Eq 3.2 more directly,
+      // begin by getting an initial approximation for x from
+      // the last equation on page 155, this is a polynomial in u:
+      //
+      T u = exp(lu);
+      workspace[0] = u;
+      workspace[1] = alpha;
+      workspace[2] = 0;
+      workspace[3] = 3 * alpha * (3 * alpha + 1) / 6;
+      workspace[4] = 4 * alpha * (4 * alpha + 1) * (4 * alpha + 2) / 24;
+      workspace[5] = 5 * alpha * (5 * alpha + 1) * (5 * alpha + 2) * (5 * alpha + 3) / 120;
+      x = tools::evaluate_polynomial(workspace, u, 6);
+      //
+      // At this point we may or may not have the right answer, Eq-3.2 has
+      // two solutions for x for any given eta, however the mapping in 3.2
+      // is 1:1 with the sign of eta and x-sin^2(theta) being the same.
+      // So we can check if we have the right root of 3.2, and if not
+      // switch x for 1-x.  This transformation is motivated by the fact
+      // that the distribution is *almost* symetric so 1-x will be in the right
+      // ball park for the solution:
+      //
+      if((x - s_2) * eta < 0)
+         x = 1 - x;
+#ifdef BOOST_INSTRUMENT
+      std::cout << "Estimating x with Temme method 2 (large eta): " << x << std::endl;
+#endif
+   }
+   //
+   // The final step is a few Newton-Raphson iterations to
+   // clean up our approximation for x, this is pretty cheap
+   // in general, and very cheap compared to an incomplete beta
+   // evaluation.  The limits set on x come from the observation
+   // that the sign of eta and x-sin^2(theta) are the same.
+   //
+   T lower, upper;
+   if(eta < 0)
+   {
+      lower = 0;
+      upper = s_2;
+   }
+   else
+   {
+      lower = s_2;
+      upper = 1;
+   }
+   //
+   // If our initial approximation is out of bounds then bisect:
+   //
+   if((x < lower) || (x > upper))
+      x = (lower+upper) / 2;
+   //
+   // And iterate:
+   //
+   x = tools::newton_raphson_iterate(
+      temme_root_finder<T>(-lu, alpha), x, lower, upper, policies::digits<T, Policy>() / 2);
+
+   return x;
+}
+//
+// See:
+// "Asymptotic Inversion of the Incomplete Beta Function"
+// N.M. Temme
+// Journal of Computation and Applied Mathematics 41 (1992) 145-157.
+// Section 4.
+//
+template <class T, class Policy>
+T temme_method_3_ibeta_inverse(T a, T b, T p, T q, const Policy& pol)
+{
+   BOOST_MATH_STD_USING // ADL of std names
+
+   //
+   // Begin by getting an initial approximation for the quantity
+   // eta from the dominant part of the incomplete beta:
+   //
+   T eta0;
+   if(p < q)
+      eta0 = boost::math::gamma_q_inv(b, p, pol);
+   else
+      eta0 = boost::math::gamma_p_inv(b, q, pol);
+   eta0 /= a;
+   //
+   // Define the variables and powers we'll need later on:
+   //
+   T mu = b / a;
+   T w = sqrt(1 + mu);
+   T w_2 = w * w;
+   T w_3 = w_2 * w;
+   T w_4 = w_2 * w_2;
+   T w_5 = w_3 * w_2;
+   T w_6 = w_3 * w_3;
+   T w_7 = w_4 * w_3;
+   T w_8 = w_4 * w_4;
+   T w_9 = w_5 * w_4;
+   T w_10 = w_5 * w_5;
+   T d = eta0 - mu;
+   T d_2 = d * d;
+   T d_3 = d_2 * d;
+   T d_4 = d_2 * d_2;
+   T w1 = w + 1;
+   T w1_2 = w1 * w1;
+   T w1_3 = w1 * w1_2;
+   T w1_4 = w1_2 * w1_2;
+   //
+   // Now we need to compute the purturbation error terms that
+   // convert eta0 to eta, these are all polynomials of polynomials.
+   // Probably these should be re-written to use tabulated data
+   // (see examples above), but it's less of a win in this case as we
+   // need to calculate the individual powers for the denominator terms
+   // anyway, so we might as well use them for the numerator-polynomials
+   // as well....
+   //
+   // Refer to p154-p155 for the details of these expansions:
+   //
+   T e1 = (w + 2) * (w - 1) / (3 * w);
+   e1 += (w_3 + 9 * w_2 + 21 * w + 5) * d / (36 * w_2 * w1);
+   e1 -= (w_4 - 13 * w_3 + 69 * w_2 + 167 * w + 46) * d_2 / (1620 * w1_2 * w_3);
+   e1 -= (7 * w_5 + 21 * w_4 + 70 * w_3 + 26 * w_2 - 93 * w - 31) * d_3 / (6480 * w1_3 * w_4);
+   e1 -= (75 * w_6 + 202 * w_5 + 188 * w_4 - 888 * w_3 - 1345 * w_2 + 118 * w + 138) * d_4 / (272160 * w1_4 * w_5);
+
+   T e2 = (28 * w_4 + 131 * w_3 + 402 * w_2 + 581 * w + 208) * (w - 1) / (1620 * w1 * w_3);
+   e2 -= (35 * w_6 - 154 * w_5 - 623 * w_4 - 1636 * w_3 - 3983 * w_2 - 3514 * w - 925) * d / (12960 * w1_2 * w_4);
+   e2 -= (2132 * w_7 + 7915 * w_6 + 16821 * w_5 + 35066 * w_4 + 87490 * w_3 + 141183 * w_2 + 95993 * w + 21640) * d_2  / (816480 * w_5 * w1_3);
+   e2 -= (11053 * w_8 + 53308 * w_7 + 117010 * w_6 + 163924 * w_5 + 116188 * w_4 - 258428 * w_3 - 677042 * w_2 - 481940 * w - 105497) * d_3 / (14696640 * w1_4 * w_6);
+
+   T e3 = -((3592 * w_7 + 8375 * w_6 - 1323 * w_5 - 29198 * w_4 - 89578 * w_3 - 154413 * w_2 - 116063 * w - 29632) * (w - 1)) / (816480 * w_5 * w1_2);
+   e3 -= (442043 * w_9 + 2054169 * w_8 + 3803094 * w_7 + 3470754 * w_6 + 2141568 * w_5 - 2393568 * w_4 - 19904934 * w_3 - 34714674 * w_2 - 23128299 * w - 5253353) * d / (146966400 * w_6 * w1_3);
+   e3 -= (116932 * w_10 + 819281 * w_9 + 2378172 * w_8 + 4341330 * w_7 + 6806004 * w_6 + 10622748 * w_5 + 18739500 * w_4 + 30651894 * w_3 + 30869976 * w_2 + 15431867 * w + 2919016) * d_2 / (146966400 * w1_4 * w_7);
+   //
+   // Combine eta0 and the error terms to compute eta (Second eqaution p155):
+   //
+   T eta = eta0 + e1 / a + e2 / (a * a) + e3 / (a * a * a);
+   //
+   // Now we need to solve Eq 4.2 to obtain x.  For any given value of
+   // eta there are two solutions to this equation, and since the distribtion
+   // may be very skewed, these are not related by x ~ 1-x we used when
+   // implementing section 3 above.  However we know that:
+   //
+   //  cross < x <= 1       ; iff eta < mu
+   //          x == cross   ; iff eta == mu
+   //     0 <= x < cross    ; iff eta > mu
+   //
+   // Where cross == 1 / (1 + mu)
+   // Many thanks to Prof Temme for clarifying this point.
+   //
+   // Therefore we'll just jump straight into Newton iterations
+   // to solve Eq 4.2 using these bounds, and simple bisection
+   // as the first guess, in practice this converges pretty quickly
+   // and we only need a few digits correct anyway:
+   //
+   if(eta <= 0)
+      eta = tools::min_value<T>();
+   T u = eta - mu * log(eta) + (1 + mu) * log(1 + mu) - mu;
+   T cross = 1 / (1 + mu);
+   T lower = eta < mu ? cross : 0;
+   T upper = eta < mu ? 1 : cross;
+   T x = (lower + upper) / 2;
+   x = tools::newton_raphson_iterate(
+      temme_root_finder<T>(u, mu), x, lower, upper, policies::digits<T, Policy>() / 2);
+#ifdef BOOST_INSTRUMENT
+   std::cout << "Estimating x with Temme method 3: " << x << std::endl;
+#endif
+   return x;
+}
+
+template <class T, class Policy>
+struct ibeta_roots
+{
+   ibeta_roots(T _a, T _b, T t, bool inv = false)
+      : a(_a), b(_b), target(t), invert(inv) {}
+
+   boost::math::tuple<T, T, T> operator()(T x)
+   {
+      BOOST_MATH_STD_USING // ADL of std names
+
+      BOOST_FPU_EXCEPTION_GUARD
+      
+      T f1;
+      T y = 1 - x;
+      T f = ibeta_imp(a, b, x, Policy(), invert, true, &f1) - target;
+      if(invert)
+         f1 = -f1;
+      if(y == 0)
+         y = tools::min_value<T>() * 64;
+      if(x == 0)
+         x = tools::min_value<T>() * 64;
+
+      T f2 = f1 * (-y * a + (b - 2) * x + 1);
+      if(fabs(f2) < y * x * tools::max_value<T>())
+         f2 /= (y * x);
+      if(invert)
+         f2 = -f2;
+
+      // make sure we don't have a zero derivative:
+      if(f1 == 0)
+         f1 = (invert ? -1 : 1) * tools::min_value<T>() * 64;
+
+      return boost::math::make_tuple(f, f1, f2);
+   }
+private:
+   T a, b, target;
+   bool invert;
+};
+
+template <class T, class Policy>
+T ibeta_inv_imp(T a, T b, T p, T q, const Policy& pol, T* py)
+{
+   BOOST_MATH_STD_USING  // For ADL of math functions.
+
+   //
+   // The flag invert is set to true if we swap a for b and p for q,
+   // in which case the result has to be subtracted from 1:
+   //
+   bool invert = false;
+   //
+   // Handle trivial cases first:
+   //
+   if(q == 0)
+   {
+      if(py) *py = 0;
+      return 1;
+   }
+   else if(p == 0)
+   {
+      if(py) *py = 1;
+      return 0;
+   }
+   else if(a == 1)
+   {
+      if(b == 1)
+      {
+         if(py) *py = 1 - p;
+         return p;
+      }
+      // Change things around so we can handle as b == 1 special case below:
+      std::swap(a, b);
+      std::swap(p, q);
+      invert = true;
+   }
+   //
+   // Depending upon which approximation method we use, we may end up
+   // calculating either x or y initially (where y = 1-x):
+   //
+   T x = 0; // Set to a safe zero to avoid a
+   // MSVC 2005 warning C4701: potentially uninitialized local variable 'x' used
+   // But code inspection appears to ensure that x IS assigned whatever the code path.
+   T y; 
+
+   // For some of the methods we can put tighter bounds
+   // on the result than simply [0,1]:
+   //
+   T lower = 0;
+   T upper = 1;
+   //
+   // Student's T with b = 0.5 gets handled as a special case, swap
+   // around if the arguments are in the "wrong" order:
+   //
+   if(a == 0.5f)
+   {
+      if(b == 0.5f)
+      {
+         x = sin(p * constants::half_pi<T>());
+         x *= x;
+         if(py)
+         {
+            *py = sin(q * constants::half_pi<T>());
+            *py *= *py;
+         }
+         return x;
+      }
+      else if(b > 0.5f)
+      {
+         std::swap(a, b);
+         std::swap(p, q);
+         invert = !invert;
+      }
+   }
+   //
+   // Select calculation method for the initial estimate:
+   //
+   if((b == 0.5f) && (a >= 0.5f) && (p != 1))
+   {
+      //
+      // We have a Student's T distribution:
+      x = find_ibeta_inv_from_t_dist(a, p, q, &y, pol);
+   }
+   else if(b == 1)
+   {
+      if(p < q)
+      {
+         if(a > 1)
+         {
+            x = pow(p, 1 / a);
+            y = -boost::math::expm1(log(p) / a, pol);
+         }
+         else
+         {
+            x = pow(p, 1 / a);
+            y = 1 - x;
+         }
+      }
+      else
+      {
+         x = exp(boost::math::log1p(-q, pol) / a);
+         y = -boost::math::expm1(boost::math::log1p(-q, pol) / a, pol);
+      }
+      if(invert)
+         std::swap(x, y);
+      if(py)
+         *py = y;
+      return x;
+   }
+   else if(a + b > 5)
+   {
+      //
+      // When a+b is large then we can use one of Prof Temme's
+      // asymptotic expansions, begin by swapping things around
+      // so that p < 0.5, we do this to avoid cancellations errors
+      // when p is large.
+      //
+      if(p > 0.5)
+      {
+         std::swap(a, b);
+         std::swap(p, q);
+         invert = !invert;
+      }
+      T minv = (std::min)(a, b);
+      T maxv = (std::max)(a, b);
+      if((sqrt(minv) > (maxv - minv)) && (minv > 5))
+      {
+         //
+         // When a and b differ by a small amount
+         // the curve is quite symmetrical and we can use an error
+         // function to approximate the inverse. This is the cheapest
+         // of the three Temme expantions, and the calculated value
+         // for x will never be much larger than p, so we don't have
+         // to worry about cancellation as long as p is small.
+         //
+         x = temme_method_1_ibeta_inverse(a, b, p, pol);
+         y = 1 - x;
+      }
+      else
+      {
+         T r = a + b;
+         T theta = asin(sqrt(a / r));
+         T lambda = minv / r;
+         if((lambda >= 0.2) && (lambda <= 0.8) && (r >= 10))
+         {
+            //
+            // The second error function case is the next cheapest
+            // to use, it brakes down when the result is likely to be
+            // very small, if a+b is also small, but we can use a
+            // cheaper expansion there in any case.  As before x won't
+            // be much larger than p, so as long as p is small we should
+            // be free of cancellation error.
+            //
+            T ppa = pow(p, 1/a);
+            if((ppa < 0.0025) && (a + b < 200))
+            {
+               x = ppa * pow(a * boost::math::beta(a, b, pol), 1/a);
+            }
+            else
+               x = temme_method_2_ibeta_inverse(a, b, p, r, theta, pol);
+            y = 1 - x;
+         }
+         else
+         {
+            //
+            // If we get here then a and b are very different in magnitude
+            // and we need to use the third of Temme's methods which
+            // involves inverting the incomplete gamma.  This is much more
+            // expensive than the other methods.  We also can only use this
+            // method when a > b, which can lead to cancellation errors
+            // if we really want y (as we will when x is close to 1), so
+            // a different expansion is used in that case.
+            //
+            if(a < b)
+            {
+               std::swap(a, b);
+               std::swap(p, q);
+               invert = !invert;
+            }
+            //
+            // Try and compute the easy way first:
+            //
+            T bet = 0;
+            if(b < 2)
+               bet = boost::math::beta(a, b, pol);
+            if(bet != 0)
+            {
+               y = pow(b * q * bet, 1/b);
+               x = 1 - y;
+            }
+            else 
+               y = 1;
+            if(y > 1e-5)
+            {
+               x = temme_method_3_ibeta_inverse(a, b, p, q, pol);
+               y = 1 - x;
+            }
+         }
+      }
+   }
+   else if((a < 1) && (b < 1))
+   {
+      //
+      // Both a and b less than 1,
+      // there is a point of inflection at xs:
+      //
+      T xs = (1 - a) / (2 - a - b);
+      //
+      // Now we need to ensure that we start our iteration from the
+      // right side of the inflection point:
+      //
+      T fs = boost::math::ibeta(a, b, xs, pol) - p;
+      if(fabs(fs) / p < tools::epsilon<T>() * 3)
+      {
+         // The result is at the point of inflection, best just return it:
+         *py = invert ? xs : 1 - xs;
+         return invert ? 1-xs : xs;
+      }
+      if(fs < 0)
+      {
+         std::swap(a, b);
+         std::swap(p, q);
+         invert = !invert;
+         xs = 1 - xs;
+      }
+      T xg = pow(a * p * boost::math::beta(a, b, pol), 1/a);
+      x = xg / (1 + xg);
+      y = 1 / (1 + xg);
+      //
+      // And finally we know that our result is below the inflection
+      // point, so set an upper limit on our search:
+      //
+      if(x > xs)
+         x = xs;
+      upper = xs;
+   }
+   else if((a > 1) && (b > 1))
+   {
+      //
+      // Small a and b, both greater than 1,
+      // there is a point of inflection at xs,
+      // and it's complement is xs2, we must always
+      // start our iteration from the right side of the
+      // point of inflection.
+      //
+      T xs = (a - 1) / (a + b - 2);
+      T xs2 = (b - 1) / (a + b - 2);
+      T ps = boost::math::ibeta(a, b, xs, pol) - p;
+
+      if(ps < 0)
+      {
+         std::swap(a, b);
+         std::swap(p, q);
+         std::swap(xs, xs2);
+         invert = !invert;
+      }
+      //
+      // Estimate x and y, using expm1 to get a good estimate
+      // for y when it's very small:
+      //
+      T lx = log(p * a * boost::math::beta(a, b, pol)) / a;
+      x = exp(lx);
+      y = x < 0.9 ? T(1 - x) : (T)(-boost::math::expm1(lx, pol));
+
+      if((b < a) && (x < 0.2))
+      {
+         //
+         // Under a limited range of circumstances we can improve
+         // our estimate for x, frankly it's clear if this has much effect!
+         //
+         T ap1 = a - 1;
+         T bm1 = b - 1;
+         T a_2 = a * a;
+         T a_3 = a * a_2;
+         T b_2 = b * b;
+         T terms[5] = { 0, 1 };
+         terms[2] = bm1 / ap1;
+         ap1 *= ap1;
+         terms[3] = bm1 * (3 * a * b + 5 * b + a_2 - a - 4) / (2 * (a + 2) * ap1);
+         ap1 *= (a + 1);
+         terms[4] = bm1 * (33 * a * b_2 + 31 * b_2 + 8 * a_2 * b_2 - 30 * a * b - 47 * b + 11 * a_2 * b + 6 * a_3 * b + 18 + 4 * a - a_3 + a_2 * a_2 - 10 * a_2)
+                    / (3 * (a + 3) * (a + 2) * ap1);
+         x = tools::evaluate_polynomial(terms, x, 5);
+      }
+      //
+      // And finally we know that our result is below the inflection
+      // point, so set an upper limit on our search:
+      //
+      if(x > xs)
+         x = xs;
+      upper = xs;
+   }
+   else /*if((a <= 1) != (b <= 1))*/
+   {
+      //
+      // If all else fails we get here, only one of a and b
+      // is above 1, and a+b is small.  Start by swapping
+      // things around so that we have a concave curve with b > a
+      // and no points of inflection in [0,1].  As long as we expect
+      // x to be small then we can use the simple (and cheap) power
+      // term to estimate x, but when we expect x to be large then
+      // this greatly underestimates x and leaves us trying to
+      // iterate "round the corner" which may take almost forever...
+      //
+      // We could use Temme's inverse gamma function case in that case,
+      // this works really rather well (albeit expensively) even though
+      // strictly speaking we're outside it's defined range.
+      //
+      // However it's expensive to compute, and an alternative approach
+      // which models the curve as a distorted quarter circle is much
+      // cheaper to compute, and still keeps the number of iterations
+      // required down to a reasonable level.  With thanks to Prof Temme
+      // for this suggestion.
+      //
+      if(b < a)
+      {
+         std::swap(a, b);
+         std::swap(p, q);
+         invert = !invert;
+      }
+      if(pow(p, 1/a) < 0.5)
+      {
+         x = pow(p * a * boost::math::beta(a, b, pol), 1 / a);
+         if(x == 0)
+            x = boost::math::tools::min_value<T>();
+         y = 1 - x;
+      }
+      else /*if(pow(q, 1/b) < 0.1)*/
+      {
+         // model a distorted quarter circle:
+         y = pow(1 - pow(p, b * boost::math::beta(a, b, pol)), 1/b);
+         if(y == 0)
+            y = boost::math::tools::min_value<T>();
+         x = 1 - y;
+      }
+   }
+
+   //
+   // Now we have a guess for x (and for y) we can set things up for
+   // iteration.  If x > 0.5 it pays to swap things round:
+   //
+   if(x > 0.5)
+   {
+      std::swap(a, b);
+      std::swap(p, q);
+      std::swap(x, y);
+      invert = !invert;
+      T l = 1 - upper;
+      T u = 1 - lower;
+      lower = l;
+      upper = u;
+   }
+   //
+   // lower bound for our search:
+   //
+   // We're not interested in denormalised answers as these tend to
+   // these tend to take up lots of iterations, given that we can't get
+   // accurate derivatives in this area (they tend to be infinite).
+   //
+   if(lower == 0)
+   {
+      if(invert && (py == 0))
+      {
+         //
+         // We're not interested in answers smaller than machine epsilon:
+         //
+         lower = boost::math::tools::epsilon<T>();
+         if(x < lower)
+            x = lower;
+      }
+      else
+         lower = boost::math::tools::min_value<T>();
+      if(x < lower)
+         x = lower;
+   }
+   //
+   // Figure out how many digits to iterate towards:
+   //
+   int digits = boost::math::policies::digits<T, Policy>() / 2;
+   if((x < 1e-50) && ((a < 1) || (b < 1)))
+   {
+      //
+      // If we're in a region where the first derivative is very
+      // large, then we have to take care that the root-finder
+      // doesn't terminate prematurely.  We'll bump the precision
+      // up to avoid this, but we have to take care not to set the
+      // precision too high or the last few iterations will just
+      // thrash around and convergence may be slow in this case.
+      // Try 3/4 of machine epsilon:
+      //
+      digits *= 3;  
+      digits /= 2;
+   }
+   //
+   // Now iterate, we can use either p or q as the target here
+   // depending on which is smaller:
+   //
+   boost::uintmax_t max_iter = policies::get_max_root_iterations<Policy>();
+   x = boost::math::tools::halley_iterate(
+      boost::math::detail::ibeta_roots<T, Policy>(a, b, (p < q ? p : q), (p < q ? false : true)), x, lower, upper, digits, max_iter);
+   policies::check_root_iterations<T>("boost::math::ibeta<%1%>(%1%, %1%, %1%)", max_iter, pol);
+   //
+   // We don't really want these asserts here, but they are useful for sanity
+   // checking that we have the limits right, uncomment if you suspect bugs *only*.
+   //
+   //BOOST_ASSERT(x != upper);
+   //BOOST_ASSERT((x != lower) || (x == boost::math::tools::min_value<T>()) || (x == boost::math::tools::epsilon<T>()));
+   //
+   // Tidy up, if we "lower" was too high then zero is the best answer we have:
+   //
+   if(x == lower)
+      x = 0;
+   if(py)
+      *py = invert ? x : 1 - x;
+   return invert ? 1-x : x;
+}
+
+} // namespace detail
+
+template <class T1, class T2, class T3, class T4, class Policy>
+inline typename tools::promote_args<T1, T2, T3, T4>::type  
+   ibeta_inv(T1 a, T2 b, T3 p, T4* py, const Policy& pol)
+{
+   static const char* function = "boost::math::ibeta_inv<%1%>(%1%,%1%,%1%)";
+   BOOST_FPU_EXCEPTION_GUARD
+   typedef typename tools::promote_args<T1, T2, T3, T4>::type result_type;
+   typedef typename policies::evaluation<result_type, Policy>::type value_type;
+   typedef typename policies::normalise<
+      Policy, 
+      policies::promote_float<false>, 
+      policies::promote_double<false>, 
+      policies::discrete_quantile<>,
+      policies::assert_undefined<> >::type forwarding_policy;
+
+   if(a <= 0)
+      return policies::raise_domain_error<result_type>(function, "The argument a to the incomplete beta function inverse must be greater than zero (got a=%1%).", a, pol);
+   if(b <= 0)
+      return policies::raise_domain_error<result_type>(function, "The argument b to the incomplete beta function inverse must be greater than zero (got b=%1%).", b, pol);
+   if((p < 0) || (p > 1))
+      return policies::raise_domain_error<result_type>(function, "Argument p outside the range [0,1] in the incomplete beta function inverse (got p=%1%).", p, pol);
+
+   value_type rx, ry;
+
+   rx = detail::ibeta_inv_imp(
+         static_cast<value_type>(a),
+         static_cast<value_type>(b),
+         static_cast<value_type>(p),
+         static_cast<value_type>(1 - p),
+         forwarding_policy(), &ry);
+
+   if(py) *py = policies::checked_narrowing_cast<T4, forwarding_policy>(ry, function);
+   return policies::checked_narrowing_cast<result_type, forwarding_policy>(rx, function);
+}
+
+template <class T1, class T2, class T3, class T4>
+inline typename tools::promote_args<T1, T2, T3, T4>::type  
+   ibeta_inv(T1 a, T2 b, T3 p, T4* py)
+{
+   return ibeta_inv(a, b, p, py, policies::policy<>());
+}
+
+template <class T1, class T2, class T3>
+inline typename tools::promote_args<T1, T2, T3>::type 
+   ibeta_inv(T1 a, T2 b, T3 p)
+{
+   typedef typename tools::promote_args<T1, T2, T3>::type result_type;
+   return ibeta_inv(a, b, p, static_cast<result_type*>(0), policies::policy<>());
+}
+
+template <class T1, class T2, class T3, class Policy>
+inline typename tools::promote_args<T1, T2, T3>::type 
+   ibeta_inv(T1 a, T2 b, T3 p, const Policy& pol)
+{
+   typedef typename tools::promote_args<T1, T2, T3>::type result_type;
+   return ibeta_inv(a, b, p, static_cast<result_type*>(0), pol);
+}
+
+template <class T1, class T2, class T3, class T4, class Policy>
+inline typename tools::promote_args<T1, T2, T3, T4>::type 
+   ibetac_inv(T1 a, T2 b, T3 q, T4* py, const Policy& pol)
+{
+   static const char* function = "boost::math::ibetac_inv<%1%>(%1%,%1%,%1%)";
+   BOOST_FPU_EXCEPTION_GUARD
+   typedef typename tools::promote_args<T1, T2, T3, T4>::type result_type;
+   typedef typename policies::evaluation<result_type, Policy>::type value_type;
+   typedef typename policies::normalise<
+      Policy, 
+      policies::promote_float<false>, 
+      policies::promote_double<false>, 
+      policies::discrete_quantile<>,
+      policies::assert_undefined<> >::type forwarding_policy;
+
+   if(a <= 0)
+      return policies::raise_domain_error<result_type>(function, "The argument a to the incomplete beta function inverse must be greater than zero (got a=%1%).", a, pol);
+   if(b <= 0)
+      return policies::raise_domain_error<result_type>(function, "The argument b to the incomplete beta function inverse must be greater than zero (got b=%1%).", b, pol);
+   if((q < 0) || (q > 1))
+      return policies::raise_domain_error<result_type>(function, "Argument q outside the range [0,1] in the incomplete beta function inverse (got q=%1%).", q, pol);
+
+   value_type rx, ry;
+
+   rx = detail::ibeta_inv_imp(
+         static_cast<value_type>(a),
+         static_cast<value_type>(b),
+         static_cast<value_type>(1 - q),
+         static_cast<value_type>(q),
+         forwarding_policy(), &ry);
+
+   if(py) *py = policies::checked_narrowing_cast<T4, forwarding_policy>(ry, function);
+   return policies::checked_narrowing_cast<result_type, forwarding_policy>(rx, function);
+}
+
+template <class T1, class T2, class T3, class T4>
+inline typename tools::promote_args<T1, T2, T3, T4>::type 
+   ibetac_inv(T1 a, T2 b, T3 q, T4* py)
+{
+   return ibetac_inv(a, b, q, py, policies::policy<>());
+}
+
+template <class RT1, class RT2, class RT3>
+inline typename tools::promote_args<RT1, RT2, RT3>::type 
+   ibetac_inv(RT1 a, RT2 b, RT3 q)
+{
+   typedef typename tools::promote_args<RT1, RT2, RT3>::type result_type;
+   return ibetac_inv(a, b, q, static_cast<result_type*>(0), policies::policy<>());
+}
+
+template <class RT1, class RT2, class RT3, class Policy>
+inline typename tools::promote_args<RT1, RT2, RT3>::type
+   ibetac_inv(RT1 a, RT2 b, RT3 q, const Policy& pol)
+{
+   typedef typename tools::promote_args<RT1, RT2, RT3>::type result_type;
+   return ibetac_inv(a, b, q, static_cast<result_type*>(0), pol);
+}
+
+} // namespace math
+} // namespace boost
+
+#endif // BOOST_MATH_SPECIAL_FUNCTIONS_IGAMMA_INVERSE_HPP
+
+
+
+

--- a/third_party/boost/math/special_functions/detail/t_distribution_inv.hpp
+++ b/third_party/boost/math/special_functions/detail/t_distribution_inv.hpp
@@ -1,0 +1,549 @@
+//  Copyright John Maddock 2007.
+//  Copyright Paul A. Bristow 2007
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_MATH_SF_DETAIL_INV_T_HPP
+#define BOOST_MATH_SF_DETAIL_INV_T_HPP
+
+#ifdef _MSC_VER
+#pragma once
+#endif
+
+#include <boost/math/special_functions/cbrt.hpp>
+#include <boost/math/special_functions/round.hpp>
+#include <boost/math/special_functions/trunc.hpp>
+
+namespace boost{ namespace math{ namespace detail{
+
+//
+// The main method used is due to Hill:
+//
+// G. W. Hill, Algorithm 396, Student's t-Quantiles,
+// Communications of the ACM, 13(10): 619-620, Oct., 1970.
+//
+template <class T, class Policy>
+T inverse_students_t_hill(T ndf, T u, const Policy& pol)
+{
+   BOOST_MATH_STD_USING
+   BOOST_ASSERT(u <= 0.5);
+
+   T a, b, c, d, q, x, y;
+
+   if (ndf > 1e20f)
+      return -boost::math::erfc_inv(2 * u, pol) * constants::root_two<T>();
+
+   a = 1 / (ndf - 0.5f);
+   b = 48 / (a * a);
+   c = ((20700 * a / b - 98) * a - 16) * a + 96.36f;
+   d = ((94.5f / (b + c) - 3) / b + 1) * sqrt(a * constants::pi<T>() / 2) * ndf;
+   y = pow(d * 2 * u, 2 / ndf);
+
+   if (y > (0.05f + a))
+   {
+      //
+      // Asymptotic inverse expansion about normal:
+      //
+      x = -boost::math::erfc_inv(2 * u, pol) * constants::root_two<T>();
+      y = x * x;
+
+      if (ndf < 5)
+         c += 0.3f * (ndf - 4.5f) * (x + 0.6f);
+      c += (((0.05f * d * x - 5) * x - 7) * x - 2) * x + b;
+      y = (((((0.4f * y + 6.3f) * y + 36) * y + 94.5f) / c - y - 3) / b + 1) * x;
+      y = boost::math::expm1(a * y * y, pol);
+   }
+   else
+   {
+      y = static_cast<T>(((1 / (((ndf + 6) / (ndf * y) - 0.089f * d - 0.822f)
+              * (ndf + 2) * 3) + 0.5 / (ndf + 4)) * y - 1)
+              * (ndf + 1) / (ndf + 2) + 1 / y);
+   }
+   q = sqrt(ndf * y);
+
+   return -q;
+}
+//
+// Tail and body series are due to Shaw:
+//
+// www.mth.kcl.ac.uk/~shaww/web_page/papers/Tdistribution06.pdf
+//
+// Shaw, W.T., 2006, "Sampling Student's T distribution - use of
+// the inverse cumulative distribution function."
+// Journal of Computational Finance, Vol 9 Issue 4, pp 37-73, Summer 2006
+//
+template <class T, class Policy>
+T inverse_students_t_tail_series(T df, T v, const Policy& pol)
+{
+   BOOST_MATH_STD_USING
+   // Tail series expansion, see section 6 of Shaw's paper.
+   // w is calculated using Eq 60:
+   T w = boost::math::tgamma_delta_ratio(df / 2, constants::half<T>(), pol)
+      * sqrt(df * constants::pi<T>()) * v;
+   // define some variables:
+   T np2 = df + 2;
+   T np4 = df + 4;
+   T np6 = df + 6;
+   //
+   // Calculate the coefficients d(k), these depend only on the
+   // number of degrees of freedom df, so at least in theory
+   // we could tabulate these for fixed df, see p15 of Shaw:
+   //
+   T d[7] = { 1, };
+   d[1] = -(df + 1) / (2 * np2);
+   np2 *= (df + 2);
+   d[2] = -df * (df + 1) * (df + 3) / (8 * np2 * np4);
+   np2 *= df + 2;
+   d[3] = -df * (df + 1) * (df + 5) * (((3 * df) + 7) * df -2) / (48 * np2 * np4 * np6);
+   np2 *= (df + 2);
+   np4 *= (df + 4);
+   d[4] = -df * (df + 1) * (df + 7) *
+      ( (((((15 * df) + 154) * df + 465) * df + 286) * df - 336) * df + 64 )
+      / (384 * np2 * np4 * np6 * (df + 8));
+   np2 *= (df + 2);
+   d[5] = -df * (df + 1) * (df + 3) * (df + 9)
+            * (((((((35 * df + 452) * df + 1573) * df + 600) * df - 2020) * df) + 928) * df -128)
+            / (1280 * np2 * np4 * np6 * (df + 8) * (df + 10));
+   np2 *= (df + 2);
+   np4 *= (df + 4);
+   np6 *= (df + 6);
+   d[6] = -df * (df + 1) * (df + 11)
+            * ((((((((((((945 * df) + 31506) * df + 425858) * df + 2980236) * df + 11266745) * df + 20675018) * df + 7747124) * df - 22574632) * df - 8565600) * df + 18108416) * df - 7099392) * df + 884736)
+            / (46080 * np2 * np4 * np6 * (df + 8) * (df + 10) * (df +12));
+   //
+   // Now bring everthing together to provide the result,
+   // this is Eq 62 of Shaw:
+   //
+   T rn = sqrt(df);
+   T div = pow(rn * w, 1 / df);
+   T power = div * div;
+   T result = tools::evaluate_polynomial<7, T, T>(d, power);
+   result *= rn;
+   result /= div;
+   return -result;
+}
+
+template <class T, class Policy>
+T inverse_students_t_body_series(T df, T u, const Policy& pol)
+{
+   BOOST_MATH_STD_USING
+   //
+   // Body series for small N:
+   //
+   // Start with Eq 56 of Shaw:
+   //
+   T v = boost::math::tgamma_delta_ratio(df / 2, constants::half<T>(), pol)
+      * sqrt(df * constants::pi<T>()) * (u - constants::half<T>());
+   //
+   // Workspace for the polynomial coefficients:
+   //
+   T c[11] = { 0, 1, };
+   //
+   // Figure out what the coefficients are, note these depend
+   // only on the degrees of freedom (Eq 57 of Shaw):
+   //
+   T in = 1 / df;
+   c[2] = static_cast<T>(0.16666666666666666667 + 0.16666666666666666667 * in);
+   c[3] = static_cast<T>((0.0083333333333333333333 * in
+      + 0.066666666666666666667) * in 
+      + 0.058333333333333333333);
+   c[4] = static_cast<T>(((0.00019841269841269841270 * in
+      + 0.0017857142857142857143) * in 
+      + 0.026785714285714285714) * in 
+      + 0.025198412698412698413);
+   c[5] = static_cast<T>((((2.7557319223985890653e-6 * in
+      + 0.00037477954144620811287) * in 
+      - 0.0011078042328042328042) * in 
+      + 0.010559964726631393298) * in 
+      + 0.012039792768959435626);
+   c[6] = static_cast<T>(((((2.5052108385441718775e-8 * in
+      - 0.000062705427288760622094) * in 
+      + 0.00059458674042007375341) * in 
+      - 0.0016095979637646304313) * in 
+      + 0.0061039211560044893378) * in 
+      + 0.0038370059724226390893);
+   c[7] = static_cast<T>((((((1.6059043836821614599e-10 * in
+      + 0.000015401265401265401265) * in 
+      - 0.00016376804137220803887) * in
+      + 0.00069084207973096861986) * in 
+      - 0.0012579159844784844785) * in 
+      + 0.0010898206731540064873) * in 
+      + 0.0032177478835464946576);
+   c[8] = static_cast<T>(((((((7.6471637318198164759e-13 * in
+      - 3.9851014346715404916e-6) * in
+      + 0.000049255746366361445727) * in
+      - 0.00024947258047043099953) * in 
+      + 0.00064513046951456342991) * in
+      - 0.00076245135440323932387) * in
+      + 0.000033530976880017885309) * in 
+      + 0.0017438262298340009980);
+   c[9] = static_cast<T>((((((((2.8114572543455207632e-15 * in
+      + 1.0914179173496789432e-6) * in
+      - 0.000015303004486655377567) * in
+      + 0.000090867107935219902229) * in
+      - 0.00029133414466938067350) * in
+      + 0.00051406605788341121363) * in
+      - 0.00036307660358786885787) * in
+      - 0.00031101086326318780412) * in 
+      + 0.00096472747321388644237);
+   c[10] = static_cast<T>(((((((((8.2206352466243297170e-18 * in
+      - 3.1239569599829868045e-7) * in
+      + 4.8903045291975346210e-6) * in
+      - 0.000033202652391372058698) * in
+      + 0.00012645437628698076975) * in
+      - 0.00028690924218514613987) * in
+      + 0.00035764655430568632777) * in
+      - 0.00010230378073700412687) * in
+      - 0.00036942667800009661203) * in
+      + 0.00054229262813129686486);
+   //
+   // The result is then a polynomial in v (see Eq 56 of Shaw):
+   //
+   return tools::evaluate_odd_polynomial<11, T, T>(c, v);
+}
+
+template <class T, class Policy>
+T inverse_students_t(T df, T u, T v, const Policy& pol, bool* pexact = 0)
+{
+   //
+   // df = number of degrees of freedom.
+   // u = probablity.
+   // v = 1 - u.
+   // l = lanczos type to use.
+   //
+   BOOST_MATH_STD_USING
+   bool invert = false;
+   T result = 0;
+   if(pexact)
+      *pexact = false;
+   if(u > v)
+   {
+      // function is symmetric, invert it:
+      std::swap(u, v);
+      invert = true;
+   }
+   if((floor(df) == df) && (df < 20))
+   {
+      //
+      // we have integer degrees of freedom, try for the special
+      // cases first:
+      //
+      T tolerance = ldexp(1.0f, (2 * policies::digits<T, Policy>()) / 3);
+
+      switch(itrunc(df, Policy()))
+      {
+      case 1:
+         {
+            //
+            // df = 1 is the same as the Cauchy distribution, see
+            // Shaw Eq 35:
+            //
+            if(u == 0.5)
+               result = 0;
+            else
+               result = -cos(constants::pi<T>() * u) / sin(constants::pi<T>() * u);
+            if(pexact)
+               *pexact = true;
+            break;
+         }
+      case 2:
+         {
+            //
+            // df = 2 has an exact result, see Shaw Eq 36:
+            //
+            result =(2 * u - 1) / sqrt(2 * u * v);
+            if(pexact)
+               *pexact = true;
+            break;
+         }
+      case 4:
+         {
+            //
+            // df = 4 has an exact result, see Shaw Eq 38 & 39:
+            //
+            T alpha = 4 * u * v;
+            T root_alpha = sqrt(alpha);
+            T r = 4 * cos(acos(root_alpha) / 3) / root_alpha;
+            T x = sqrt(r - 4);
+            result = u - 0.5f < 0 ? (T)-x : x;
+            if(pexact)
+               *pexact = true;
+            break;
+         }
+      case 6:
+         {
+            //
+            // We get numeric overflow in this area:
+            //
+            if(u < 1e-150)
+               return (invert ? -1 : 1) * inverse_students_t_hill(df, u, pol);
+            //
+            // Newton-Raphson iteration of a polynomial case,
+            // choice of seed value is taken from Shaw's online
+            // supplement:
+            //
+            T a = 4 * (u - u * u);//1 - 4 * (u - 0.5f) * (u - 0.5f);
+            T b = boost::math::cbrt(a);
+            static const T c = static_cast<T>(0.85498797333834849467655443627193);
+            T p = 6 * (1 + c * (1 / b - 1));
+            T p0;
+            do{
+               T p2 = p * p;
+               T p4 = p2 * p2;
+               T p5 = p * p4;
+               p0 = p;
+               // next term is given by Eq 41:
+               p = 2 * (8 * a * p5 - 270 * p2 + 2187) / (5 * (4 * a * p4 - 216 * p - 243));
+            }while(fabs((p - p0) / p) > tolerance);
+            //
+            // Use Eq 45 to extract the result:
+            //
+            p = sqrt(p - df);
+            result = (u - 0.5f) < 0 ? (T)-p : p;
+            break;
+         }
+#if 0
+         //
+         // These are Shaw's "exact" but iterative solutions
+         // for even df, the numerical accuracy of these is
+         // rather less than Hill's method, so these are disabled
+         // for now, which is a shame because they are reasonably
+         // quick to evaluate...
+         //
+      case 8:
+         {
+            //
+            // Newton-Raphson iteration of a polynomial case,
+            // choice of seed value is taken from Shaw's online
+            // supplement:
+            //
+            static const T c8 = 0.85994765706259820318168359251872L;
+            T a = 4 * (u - u * u); //1 - 4 * (u - 0.5f) * (u - 0.5f);
+            T b = pow(a, T(1) / 4);
+            T p = 8 * (1 + c8 * (1 / b - 1));
+            T p0 = p;
+            do{
+               T p5 = p * p;
+               p5 *= p5 * p;
+               p0 = p;
+               // Next term is given by Eq 42:
+               p = 2 * (3 * p + (640 * (160 + p * (24 + p * (p + 4)))) / (-5120 + p * (-2048 - 960 * p + a * p5))) / 7;
+            }while(fabs((p - p0) / p) > tolerance);
+            //
+            // Use Eq 45 to extract the result:
+            //
+            p = sqrt(p - df);
+            result = (u - 0.5f) < 0 ? -p : p;
+            break;
+         }
+      case 10:
+         {
+            //
+            // Newton-Raphson iteration of a polynomial case,
+            // choice of seed value is taken from Shaw's online
+            // supplement:
+            //
+            static const T c10 = 0.86781292867813396759105692122285L;
+            T a = 4 * (u - u * u); //1 - 4 * (u - 0.5f) * (u - 0.5f);
+            T b = pow(a, T(1) / 5);
+            T p = 10 * (1 + c10 * (1 / b - 1));
+            T p0;
+            do{
+               T p6 = p * p;
+               p6 *= p6 * p6;
+               p0 = p;
+               // Next term given by Eq 43:
+               p = (8 * p) / 9 + (218750 * (21875 + 4 * p * (625 + p * (75 + 2 * p * (5 + p))))) /
+                  (9 * (-68359375 + 8 * p * (-2343750 + p * (-546875 - 175000 * p + 8 * a * p6))));
+            }while(fabs((p - p0) / p) > tolerance);
+            //
+            // Use Eq 45 to extract the result:
+            //
+            p = sqrt(p - df);
+            result = (u - 0.5f) < 0 ? -p : p;
+            break;
+         }
+#endif
+      default:
+         goto calculate_real;
+      }
+   }
+   else
+   {
+calculate_real:
+      if(df > 0x10000000)
+      {
+         result = -boost::math::erfc_inv(2 * u, pol) * constants::root_two<T>();
+         if((pexact) && (df >= 1e20))
+            *pexact = true;
+      }
+      else if(df < 3)
+      {
+         //
+         // Use a roughly linear scheme to choose between Shaw's
+         // tail series and body series:
+         //
+         T crossover = 0.2742f - df * 0.0242143f;
+         if(u > crossover)
+         {
+            result = boost::math::detail::inverse_students_t_body_series(df, u, pol);
+         }
+         else
+         {
+            result = boost::math::detail::inverse_students_t_tail_series(df, u, pol);
+         }
+      }
+      else
+      {
+         //
+         // Use Hill's method except in the exteme tails
+         // where we use Shaw's tail series.
+         // The crossover point is roughly exponential in -df:
+         //
+         T crossover = ldexp(1.0f, iround(T(df / -0.654f), typename policies::normalise<Policy, policies::rounding_error<policies::ignore_error> >::type()));
+         if(u > crossover)
+         {
+            result = boost::math::detail::inverse_students_t_hill(df, u, pol);
+         }
+         else
+         {
+            result = boost::math::detail::inverse_students_t_tail_series(df, u, pol);
+         }
+      }
+   }
+   return invert ? (T)-result : result;
+}
+
+template <class T, class Policy>
+inline T find_ibeta_inv_from_t_dist(T a, T p, T /*q*/, T* py, const Policy& pol)
+{
+   T u = p / 2;
+   T v = 1 - u;
+   T df = a * 2;
+   T t = boost::math::detail::inverse_students_t(df, u, v, pol);
+   *py = t * t / (df + t * t);
+   return df / (df + t * t);
+}
+
+template <class T, class Policy>
+inline T fast_students_t_quantile_imp(T df, T p, const Policy& pol, const mpl::false_*)
+{
+   BOOST_MATH_STD_USING
+   //
+   // Need to use inverse incomplete beta to get
+   // required precision so not so fast:
+   //
+   T probability = (p > 0.5) ? 1 - p : p;
+   T t, x, y(0);
+   x = ibeta_inv(df / 2, T(0.5), 2 * probability, &y, pol);
+   if(df * y > tools::max_value<T>() * x)
+      t = policies::raise_overflow_error<T>("boost::math::students_t_quantile<%1%>(%1%,%1%)", 0, pol);
+   else
+      t = sqrt(df * y / x);
+   //
+   // Figure out sign based on the size of p:
+   //
+   if(p < 0.5)
+      t = -t;
+   return t;
+}
+
+template <class T, class Policy>
+T fast_students_t_quantile_imp(T df, T p, const Policy& pol, const mpl::true_*)
+{
+   BOOST_MATH_STD_USING
+   bool invert = false;
+   if((df < 2) && (floor(df) != df))
+      return boost::math::detail::fast_students_t_quantile_imp(df, p, pol, static_cast<mpl::false_*>(0));
+   if(p > 0.5)
+   {
+      p = 1 - p;
+      invert = true;
+   }
+   //
+   // Get an estimate of the result:
+   //
+   bool exact;
+   T t = inverse_students_t(df, p, T(1-p), pol, &exact);
+   if((t == 0) || exact)
+      return invert ? -t : t; // can't do better!
+   //
+   // Change variables to inverse incomplete beta:
+   //
+   T t2 = t * t;
+   T xb = df / (df + t2);
+   T y = t2 / (df + t2);
+   T a = df / 2;
+   //
+   // t can be so large that x underflows,
+   // just return our estimate in that case:
+   //
+   if(xb == 0)
+      return t;
+   //
+   // Get incomplete beta and it's derivative:
+   //
+   T f1;
+   T f0 = xb < y ? ibeta_imp(a, constants::half<T>(), xb, pol, false, true, &f1)
+      : ibeta_imp(constants::half<T>(), a, y, pol, true, true, &f1);
+
+   // Get cdf from incomplete beta result:
+   T p0 = f0 / 2  - p;
+   // Get pdf from derivative:
+   T p1 = f1 * sqrt(y * xb * xb * xb / df);
+   //
+   // Second derivative divided by p1:
+   //
+   // yacas gives:
+   //
+   // In> PrettyForm(Simplify(D(t) (1 + t^2/v) ^ (-(v+1)/2)))
+   //
+   //  |                        | v + 1     |     |
+   //  |                       -| ----- + 1 |     |
+   //  |                        |   2       |     |
+   // -|             |  2     |                   |
+   //  |             | t      |                   |
+   //  |             | -- + 1 |                   |
+   //  | ( v + 1 ) * | v      |               * t |
+   // ---------------------------------------------
+   //                       v
+   //
+   // Which after some manipulation is:
+   //
+   // -p1 * t * (df + 1) / (t^2 + df)
+   //
+   T p2 = t * (df + 1) / (t * t + df);
+   // Halley step:
+   t = fabs(t);
+   t += p0 / (p1 + p0 * p2 / 2);
+   return !invert ? -t : t;
+}
+
+template <class T, class Policy>
+inline T fast_students_t_quantile(T df, T p, const Policy& pol)
+{
+   typedef typename policies::evaluation<T, Policy>::type value_type;
+   typedef typename policies::normalise<
+      Policy, 
+      policies::promote_float<false>, 
+      policies::promote_double<false>, 
+      policies::discrete_quantile<>,
+      policies::assert_undefined<> >::type forwarding_policy;
+
+   typedef mpl::bool_<
+      (std::numeric_limits<T>::digits <= 53)
+       &&
+      (std::numeric_limits<T>::is_specialized)
+       &&
+      (std::numeric_limits<T>::radix == 2)
+   > tag_type;
+   return policies::checked_narrowing_cast<T, forwarding_policy>(fast_students_t_quantile_imp(static_cast<value_type>(df), static_cast<value_type>(p), pol, static_cast<tag_type*>(0)), "boost::math::students_t_quantile<%1%>(%1%,%1%,%1%)");
+}
+
+}}} // namespaces
+
+#endif // BOOST_MATH_SF_DETAIL_INV_T_HPP
+
+
+


### PR DESCRIPTION
That's the most common case, or at least the one needed for scipy.
The floating point case is not implemented in boost, giving up with it.

Fix #1804