### PR TITLE
Raise Memory Error upon (too) large numpy alloc

### DIFF
--- a/pythran/pythonic/types/raw_array.hpp
+++ b/pythran/pythonic/types/raw_array.hpp
@@ -2,8 +2,10 @@
 #define PYTHONIC_TYPES_RAW_ARRAY_HPP
 
 #include "pythonic/include/types/raw_array.hpp"
+#include "pythonic/builtins/MemoryError.hpp"
 
 #include <cstdlib>
+#include <sstream>
 
 PYTHONIC_NS_BEGIN
 
@@ -23,6 +25,11 @@ namespace types
   raw_array<T>::raw_array(size_t n)
       : data((T *)malloc(n * sizeof(T))), external(false)
   {
+    if (!data) {
+      std::ostringstream oss;
+      oss << "unable to allocate " << n << " bytes";
+      throw types::MemoryError(oss.str());
+    }
   }
 
   template <class T>

--- a/pythran/tests/test_ndarray.py
+++ b/pythran/tests/test_ndarray.py
@@ -17,6 +17,12 @@ except AttributeError:
 @TestEnv.module
 class TestNdarray(TestEnv):
 
+    def test_ndarray_memory_error(self):
+        with self.assertRaises(MemoryError):
+            self.run_test('def ndarray_memory_error(n): import numpy as np; return np.ones(n)',
+                          999999999999,
+                          ndarray_memory_error=[int])
+
     def test_ndarray_intc(self):
         self.run_test('def ndarray_intc(a): import numpy as np; return np.intc(a), np.array([a, a], dtype=np.intc)',
                       numpy.intc(5),


### PR DESCRIPTION
That's not perfect because numpy actually raises a _ArrayMemoryError that
derives from MemoryError, but that's enough for our case.