### PR TITLE
force logical operator expr which  in `if-orelse stmt`to boolean

### DIFF
--- a/pythran/middlend.py
+++ b/pythran/middlend.py
@@ -20,11 +20,11 @@ def refine(pm, node, optimizations):
     """ Refine node in place until it matches pythran's expectations. """
     # Sanitize input
     pm.apply(RemoveDeadFunctions, node)
-    pm.apply(LogicOperateToBool, node)
     pm.apply(ExpandGlobals, node)
     pm.apply(ExpandImportAll, node)
     pm.apply(NormalizeTuples, node)
     pm.apply(RemoveFStrings, node)
+    pm.apply(LogicOperateToBool, node)
     pm.apply(ExpandBuiltins, node)
     pm.apply(ExpandImports, node)
     pm.apply(NormalizeMethodCalls, node)

--- a/pythran/middlend.py
+++ b/pythran/middlend.py
@@ -2,7 +2,8 @@
 
 from pythran.analyses import ExtendedSyntaxCheck
 from pythran.optimizations import (ComprehensionPatterns, ListCompToGenexp,
-                                   RemoveDeadFunctions)
+                                   RemoveDeadFunctions, ExpandBooleanOperator,
+                                   CombineBoolCall)
 from pythran.transformations import (ExpandBuiltins, ExpandImports,
                                      ExpandImportAll, FalsePolymorphism,
                                      NormalizeCompare, NormalizeException,
@@ -24,8 +25,12 @@ def refine(pm, node, optimizations):
     pm.apply(ExpandImportAll, node)
     pm.apply(NormalizeTuples, node)
     pm.apply(RemoveFStrings, node)
+
     pm.apply(LogicOperateToBool, node)
     pm.apply(ExpandBuiltins, node)
+    pm.apply(ExpandBooleanOperator, node)
+    pm.apply(CombineBoolCall, node)
+    
     pm.apply(ExpandImports, node)
     pm.apply(NormalizeMethodCalls, node)
     pm.apply(NormalizeIfElse, node)

--- a/pythran/middlend.py
+++ b/pythran/middlend.py
@@ -13,13 +13,14 @@ from pythran.transformations import (ExpandBuiltins, ExpandImports,
                                      ExpandGlobals, NormalizeIsNone,
                                      NormalizeIfElse,
                                      NormalizeStaticIf, SplitStaticExpression,
-                                     RemoveFStrings)
+                                     RemoveFStrings, LogicOperateToBool)
 
 
 def refine(pm, node, optimizations):
     """ Refine node in place until it matches pythran's expectations. """
     # Sanitize input
     pm.apply(RemoveDeadFunctions, node)
+    pm.apply(LogicOperateToBool, node)
     pm.apply(ExpandGlobals, node)
     pm.apply(ExpandImportAll, node)
     pm.apply(NormalizeTuples, node)

--- a/pythran/optimizations/__init__.py
+++ b/pythran/optimizations/__init__.py
@@ -28,3 +28,4 @@ from .list_to_tuple import ListToTuple
 from .tuple_to_shape import TupleToShape
 from .remove_dead_functions import RemoveDeadFunctions
 from .simplify_except import SimplifyExcept
+from .expand_boolean_operator import ExpandBooleanOperator, CombineBoolCall

--- a/pythran/optimizations/expand_boolean_operator.py
+++ b/pythran/optimizations/expand_boolean_operator.py
@@ -1,0 +1,174 @@
+"""
+expand boolean logical operators
+"""
+
+from typing import Union
+import gast as ast
+from pythran.passmanager import Transformation
+
+def _is_bool_call(node: ast.Call) -> bool:
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    return len(node.args) == 1 and not node.keywords and\
+        isinstance(func, ast.Attribute) and \
+        func.attr == "bool" and \
+        isinstance(func.value, ast.Name) and \
+        func.value.id == "builtins"
+
+def _boolean_BoolOp(op: ast.BoolOp):
+    for i, val in enumerate(op.values):
+        if _is_bool_call(val):
+            continue
+        op.values[i] = _boolean_stmt(val)
+    return op
+
+def _boolean_stmt(stmt: ast.AST) -> ast.Call:
+    if isinstance(stmt, ast.BoolOp):
+        return _boolean_BoolOp(stmt)
+    return ast.Call(
+        func=ast.Attribute(
+            value=ast.Name(
+                id='builtins', ctx=ast.Load(),
+                annotation=None, type_comment=None
+            ),
+            attr='bool',
+            ctx=ast.Load()
+        ),
+        args=[stmt],
+        keywords=[]
+    )
+
+
+class ExpandBooleanOperator(Transformation):
+
+    """Expand bool() to each logical element of BoolOp node.
+
+    This optimization should work after ExpandBuiltins
+    
+    >>> import gast as ast
+    >>> from pythran import passmanager, backend
+    >>> code = '''
+    ... def foo(a, b, c, d):
+    ...     if builtins.bool(a and b) or builtins.bool(c or d):
+    ...         return b or d
+    ...     elif builtins.bool( bar(c or a) or bar(b and d) ):
+    ...         return a
+    ...     else:
+    ...         return b and d'''
+    >>> node = ast.parse(code)
+    >>> pm = passmanager.PassManager("test")
+    >>> _, node = pm.apply(ExpandBooleanOperator, node)
+    >>> print(pm.dump(backend.Python, node))
+    def foo(a, b, c, d):
+        if ((builtins.bool(a) and builtins.bool(b)) or (builtins.bool(c) or builtins.bool(d))):
+            return (b or d)
+        elif (builtins.bool(bar((c or a))) or builtins.bool(bar((b and d)))):
+            return a
+        else:
+            return (b and d)
+    """
+
+    def __init__(self):
+        super(ExpandBooleanOperator, self).__init__()
+        self._bool_call = False
+        self._is_logical = False
+
+    def visit_Call(self, node: ast.Call) -> Union[ast.Call, ast.BoolOp]:
+
+        old_bool_call = self._bool_call
+        old_is_logical = self._is_logical
+
+        cur = node
+        while _is_bool_call(cur):
+            cur = cur.args[0]
+
+        self._bool_call = cur is not node
+
+        if cur is node:     # to avoid recursive call
+            res = self.generic_visit(cur)
+        elif not isinstance(cur, ast.BoolOp):
+            self._is_logical = False
+            res = _boolean_stmt(self.visit(cur))
+        else:
+            self._is_logical = True
+            res = self.visit(cur)               # handle bool(x and y)
+
+        self._is_logical = old_is_logical
+        self._bool_call = old_bool_call
+        return res
+
+    def visit(self, node: ast.AST) -> ast.AST:
+        old_is_logical = self._is_logical
+
+        # we should expand expr like bool(a and (b + (c and d)) ) 
+        # into bool(a) and bool( b + (c and d) ), rather than
+        # bool(a) and (  bool(b) + ( bool(c) and bool(d) )  )
+        # so if meet other kind AST, such as ast.Add, we set 
+        # `_is_logical` to `False`, when we are in `logical_bool_call`
+        # status.
+        if self._is_logical_bool_call() and not \
+                isinstance(node, ast.BoolOp):
+            self._is_logical = False
+
+        res = super().visit(node)
+        self._is_logical = old_is_logical
+        return res
+
+    def visit_BoolOp(self, node: ast.BoolOp) -> ast.BoolOp:
+        if self._is_logical_bool_call():
+            values = [_boolean_stmt(self.visit(v)) for v in node.values]
+        else:
+            values = [ self.visit(v) for v in node.values ]
+        node.values[:] = values
+        return node
+
+    def _is_logical_bool_call(self) -> bool:
+        return self._is_logical and self._bool_call
+
+
+class CombineBoolCall(Transformation):
+
+    """combine continious bool() to single, like bool(bool(bool(x))) => bool(x)
+    
+    This optimization should work following ExpandBooleanOperator
+
+    >>> import gast as ast
+    >>> from pythran import passmanager, backend
+    >>> code = '''
+    ... def expand_bool(a, b, c, d):
+    ...     if ((builtins.bool(builtins.bool(a)) and builtins.bool(builtins.bool(b))) or builtins.bool(d)):
+    ...         return (a and c)
+    ...     elif bar(opt=builtins.bool(builtins.bool(a))):
+    ...         return foo(builtins.bool(builtins.bool(c)))'''
+    >>> node = ast.parse(code)
+    >>> pm = passmanager.PassManager("test")
+    >>> _, node = pm.apply(CombineBoolCall, node)
+    >>> print(pm.dump(backend.Python, node))
+    def expand_bool(a, b, c, d):
+        if ((builtins.bool(a) and builtins.bool(b)) or builtins.bool(d)):
+            return (a and c)
+        elif bar(opt=builtins.bool(a)):
+            return foo(builtins.bool(c))
+    """
+
+    def __init__(self):
+        super(CombineBoolCall, self).__init__()
+
+
+    def visit_Call(self, node: ast.Call):
+        cur = node
+        while _is_bool_call(cur):
+            cur = cur.args[0]
+
+        if cur is node:
+            res = self.generic_visit(cur)
+        else:
+            res = _boolean_stmt(self.visit(cur))
+        return res
+
+
+
+if __name__ == "__main__":
+    import doctest
+    doctest.testmod()

--- a/pythran/tests/test_optimizations.py
+++ b/pythran/tests/test_optimizations.py
@@ -715,3 +715,35 @@ def range_simplify_subscript(n):
                 else:
                     return 0'''
         self.run_test(code, [], insert_none0=[List[int]])
+
+    def test_boolean_logical(self):
+        init = """
+def expand_bool(a, b, c, d):
+    if bool(a and bool(b)) or int(d - c or a) :
+        return a and c
+    elif (b or d and a or not c):
+        return c or d
+    elif bool(b + (d or c + (a and d))):
+        tmp = a or b and c
+        return tmp if tmp else 1
+    else:
+        return b and d"""
+
+        ref = """
+def expand_bool(a, b, c, d):
+    if ((builtins.bool(a) and builtins.bool(b)) or builtins.bool(builtins.int(((d - c) or a)))):
+        return (a and c)
+    elif (builtins.bool(b) or (builtins.bool(d) and builtins.bool(a)) or builtins.bool((not c))):
+        return (c or d)
+    elif builtins.bool((b + (d or (c + (a and d))))):
+        tmp = (a or (b and c))
+        return (tmp if tmp else 1)
+    else:
+        return (b and d)
+        """
+        self.check_ast(init, ref, [
+            "pythran.transformations.LogicOperateToBool",
+            "pythran.transformations.ExpandBuiltins",
+            "pythran.optimizations.ExpandBooleanOperator",
+            "pythran.optimizations.CombineBoolCall"
+        ])

--- a/pythran/tests/test_str.py
+++ b/pythran/tests/test_str.py
@@ -276,3 +276,17 @@ class TestStr(TestEnv):
         def str_slice_assign2(s1):
             sample_datatype(s1)
             return s1''', "LEFT-B6", str_slice_assign2=[str])
+
+    def test_str_logical_and(self):
+        code = "def test_and_op(s: str, s1: str, s2: str):\n"\
+               "    if s and s1 == s2:\n"\
+               "        return s1 and s2\n"\
+               "    return s1 or s2"
+        self.run_test(code, ("1", "2", "3"), test_and_op=[str, str, str])
+
+    def test_str_logical_or(self):
+        code = "def test_or_op(s: str, s1: str, s2: str):\n"\
+               "    if s or s1 == s2:\n"\
+               "        return s1 or s2\n"\
+               "    return s1 and s2"
+        self.run_test(code, ("", "2", "3"), test_or_op=[str, str, str])

--- a/pythran/transformations/__init__.py
+++ b/pythran/transformations/__init__.py
@@ -32,3 +32,4 @@ from .remove_nested_functions import RemoveNestedFunctions
 from .unshadow_parameters import UnshadowParameters
 from .remove_named_arguments import RemoveNamedArguments
 from .remove_fstrings import RemoveFStrings
+from .boolean_logical_op import LogicOperateToBool

--- a/pythran/transformations/boolean_logical_op.py
+++ b/pythran/transformations/boolean_logical_op.py
@@ -22,21 +22,21 @@ class LogicOperateToBool(Transformation):
     ...         return tmp if tmp else 1
     ...     elif (lambda x, y: x and y if x or y else y)(a, b):
     ...         return b or d
-    ...     else
+    ...     else:
     ...         return b and d'''
     >>> node = ast.parse(code)
     >>> pm = passmanager.PassManager("test")
     >>> _, node = pm.apply(LogicOperateToBool, node)
     >>> print(pm.dump(backend.Python, node))
     def foo(a, b, c, d):
-        if (bool(bar((a and b))) or bool(d)):
+        if (builtins.bool(bar((a and b))) or builtins.bool(d)):
             return (a and c)
-        elif (bool(c) and bool(bar((c and d)))):
+        elif (builtins.bool(c) and builtins.bool(bar((c and d)))):
             return (c or d)
         elif bar((d or c)):
             tmp = (a or (b and c))
             return (tmp if tmp else 1)
-        elif (lambda x, y: ((x and y) if (bool(x) or bool(y)) else y))(a, b):
+        elif (lambda x, y: ((x and y) if (builtins.bool(x) or builtins.bool(y)) else y))(a, b):
             return (b or d)
         else:
             return (b and d)
@@ -62,9 +62,12 @@ class LogicOperateToBool(Transformation):
 
         for value in node.values:
             val = ast.Call(
-                func=ast.Name(
-                    id="bool", ctx=ast.Load(), 
-                    annotation=None, type_comment=None),
+                func=ast.Attribute(
+                    value=ast.Name(id='builtins', ctx=ast.Load(), 
+                        annotation=None, type_comment=None),
+                    attr='bool',
+                    ctx=ast.Load(),
+                ),
                 args=[value],
                 keywords=[]
             )

--- a/pythran/transformations/boolean_logical_op.py
+++ b/pythran/transformations/boolean_logical_op.py
@@ -1,0 +1,64 @@
+"""
+Boolean logical operators in if-orelse stmt
+"""
+
+import gast as ast
+from pythran.passmanager import Transformation
+
+class LogicOperateToBool(Transformation):
+    """
+    Boolean logical operators in if-orelse stmt
+
+    >>> import gast as ast
+    >>> from pythran import passmanager, backend
+    >>> code = '''
+    ... def foo():
+    ...     if a and b in c:
+    ...         return 1
+    ...     else:
+    ...         return 0'''
+    >>> node = ast.parse(code)
+    >>> pm = passmanager.PassManager("test")
+    >>> _, node = pm.apply(LogicOperateToBool, node)
+    >>> print(pm.dump(backend.Python, node))
+    def foo():
+        if bool(a) and bool(b in c):
+            return 1
+        else:
+            return 0
+    """
+    
+    def __init__(self):
+        super(LogicOperateToBool, self).__init__()
+        self._if_stmt = False
+    
+    def visit_If(self, node: ast.If) -> ast.If:
+        self._if_stmt = True
+        node.test = self.visit(node.test)
+
+        orelse = []
+        for stmt in node.orelse:
+            orelse.append(
+                self.visit(stmt)
+            )
+        node.orelse[:] = orelse
+        self._if_stmt = False
+        return node
+
+    def visit_BoolOp(self, node: ast.BoolOp) -> ast.BoolOp:
+        if not self._if_stmt:
+            return node
+
+        values = []
+
+        for value in node.values:
+            val = ast.Call(
+                func=ast.Name(
+                    id="bool", ctx=ast.Load(), 
+                    annotation=None, type_comment=None),
+                args=[value],
+                keywords=[]
+            )
+            values.append(val)
+        node.values[:] = values
+        return node


### PR DESCRIPTION
type of logical operator stmt in python,  such as `a and b`, `a or b`  is ambiguous. For example

```python
a = ""
b = False
c = a and b     # type(c) is str

a = "1"
c = a and b    # type(c) is bool
```

In current implementation of `pythonic::builtins::pythran::and_`, 

```cpp
template <class T0, class T1>
types::lazy_combined_t<T0, T1> and_(T0 &&v0, T1 &&v1)
{
    auto &&val0 = std::forward<T0>(v0)();
    if (val0)
      return (types::lazy_combined_t<T0, T1>)std::forward<T1>(v1)();
    else
      return (types::lazy_combined_t<T0, T1>)val0;
}
```

when `a == "1"`, variable `b` will be converted to `types::str tmp_str_b` implicitly via


```cpp
template <class T>
str::str(T const &s)
{
    std::ostringstream oss;
    oss << s;
    *data = oss.str();
}
```

then converted `bool tmp_bool_b`  via

```cpp
str::operator bool() const
{
    return !data->empty();
}
```

which always `tmp_bool_b === true`。so, expr `if "1" and False` in python is `if False`, in c++ is `if (true)`


This pull request force `expr` in 'if-orelse' stmt to `bool(expr)` to avoid implicit type coversion in `pythonic::builtins::pythran::and_`

here is the test code

```python
# pythran export test_and_op(str, str, str)
def test_and_op(s: str, s1: str, s2: str):
    expr = " '%s' and '%s' == '%s'  is "  % (s, s1, s2)
    if s and s1 == s2:
        return expr + "True"
    else:
        return expr + "False"


# pythran export test_or_op(str, str, str)
def test_or_op(s: str, s1: str, s2: str):
    expr = " '%s' or '%s' == '%s'  is "  % (s, s1, s2)
    if s or s1 == s2:
        return expr + "True"
    else:
        return expr + "False"

# test_and_op("a", "2", "1")
# test_or_op("", "2","1")
```