### PR TITLE
Use pacman in ArchLinux

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,9 +74,9 @@ Depending on your setup, you may need to add the following to your ``~/.pythranr
 ArchLinux
 =========
 
-Using any working `AUR helper <https://wiki.archlinux.org/index.php/AUR_helpers>`_, say yay::
+Using ``pacman``::
 
-    $> yay -S python-pythran
+    $> pacman -S python-pythran
 
 
 Fedora


### PR DESCRIPTION
Pythran got officially packaged today, along with beniget, since it is a build time dependency for scipy now

https://archlinux.org/packages/community/any/python-pythran/