### PR TITLE
Use iterator for index, fixes #1819

### DIFF
--- a/pythran/pythonic/numpy/bincount.hpp
+++ b/pythran/pythonic/numpy/bincount.hpp
@@ -46,7 +46,7 @@ namespace numpy
                                 std::declval<typename E::dtype>()),
                        types::pshape<long>>>::type
     out(types::pshape<long>(length), 0L);
-    auto iweight = weights.fbegin();
+    auto iweight = weights.begin();
     for (auto iter = expr.fbegin(), end = expr.fend(); iter != end;
          ++iter, ++iweight)
       out[*iter] += *iweight;

--- a/pythran/tests/test_numpy_func2.py
+++ b/pythran/tests/test_numpy_func2.py
@@ -385,6 +385,9 @@ def test_copy0(x):
     def test_bincount2(self):
         self.run_test("def np_bincount2(a, w): from numpy import bincount; return bincount(a + 1,w)", numpy.array([0, 1, 1, 2, 2, 2]), numpy.array([0.3, 0.5, 0.2, 0.7, 1., -0.6]), np_bincount2=[NDArray[int,:], NDArray[float,:]])
 
+    def test_bincount3(self):
+        self.run_test("def np_bincount3(a): from numpy import bincount,ones; x=ones((a.shape[0]+2), dtype=int); return bincount(a, x[:-2])", numpy.array([0, 1, 1, 2, 2, 2]), np_bincount3=[NDArray[int,:]])
+
     def test_binary_repr0(self):
         self.run_test("def np_binary_repr0(a): from numpy import binary_repr ; return binary_repr(a)", 3, np_binary_repr0=[int])
 


### PR DESCRIPTION
I'm unsure if this is the correct fix (I don't think I properly understand the difference between begin and fbegin), however this fixes bincount if the weightsvector is a slice, which causes the error in #1819 