### PR TITLE
Move from networkx to a vendored solution

### DIFF
--- a/pythran/analyses/argument_effects.py
+++ b/pythran/analyses/argument_effects.py
@@ -4,11 +4,11 @@ from pythran.analyses.aliases import Aliases
 from pythran.analyses.global_declarations import GlobalDeclarations
 from pythran.passmanager import ModuleAnalysis
 from pythran.tables import MODULES
+from pythran.graph import DiGraph
 # FIXME: investigate why we need to import it that way
 from pythran import intrinsic
 
 import gast as ast
-import networkx as nx
 from functools import reduce
 
 
@@ -53,7 +53,7 @@ class ArgumentEffects(ModuleAnalysis):
     """Gathers inter-procedural effects on function arguments."""
 
     def __init__(self):
-        self.result = nx.DiGraph()
+        self.result = DiGraph()
         self.node_to_functioneffect = IntrinsicArgumentEffects.copy()
         for fe in IntrinsicArgumentEffects.values():
             self.result.add_node(fe)

--- a/pythran/analyses/cfg.py
+++ b/pythran/analyses/cfg.py
@@ -2,9 +2,9 @@
 
 from pythran.passmanager import FunctionAnalysis
 from pythran.utils import isnum
+from pythran.graph import DiGraph
 
 import gast as ast
-import networkx as nx
 
 
 def is_true_predicate(node):
@@ -36,7 +36,7 @@ class CFG(FunctionAnalysis):
     NIL = object()
 
     def __init__(self):
-        self.result = nx.DiGraph()
+        self.result = DiGraph()
         super(CFG, self).__init__()
 
     def visit_FunctionDef(self, node):

--- a/pythran/analyses/global_effects.py
+++ b/pythran/analyses/global_effects.py
@@ -4,10 +4,10 @@ from pythran.analyses.aliases import Aliases
 from pythran.analyses.global_declarations import GlobalDeclarations
 from pythran.passmanager import ModuleAnalysis
 from pythran.tables import MODULES
+from pythran.graph import DiGraph
 import pythran.intrinsic as intrinsic
 
 import gast as ast
-import networkx as nx
 from functools import reduce
 
 
@@ -35,7 +35,7 @@ class GlobalEffects(ModuleAnalysis):
                 raise NotImplementedError
 
     def __init__(self):
-        self.result = nx.DiGraph()
+        self.result = DiGraph()
         self.node_to_functioneffect = dict()
         super(GlobalEffects, self).__init__(Aliases, GlobalDeclarations)
 

--- a/pythran/graph.py
+++ b/pythran/graph.py
@@ -1,0 +1,130 @@
+'''
+Minimal directed graph replacement for networkx.DiGraph
+
+This has the sole advantage of being a standalone file that doesn't bring any
+dependency with it.
+'''
+
+class DiGraph(object):
+    def __init__(self):
+        # adjacency[i][j] = True means j is a successor of i
+        self._adjacency = {}
+        self._edges = {}
+
+    def successors(self, node):
+        return (n for n in self._adjacency[node])
+
+    def predecessors(self, node):
+        return (k for k, v in self._adjacency.items() if node in v)
+
+    def add_node(self, node):
+        self._adjacency.setdefault(node, set())
+
+    def add_edge(self, src, dest, **props):
+        self.add_node(dest)
+        self._adjacency.setdefault(src, set()).add(dest)
+        self._edges[(src, dest)] = props
+
+    @property
+    def edges(self):
+        return self._edges
+
+    def remove_edge(self, src, dest):
+        self._adjacency[src].remove(dest)
+        del self._edges[(src, dest)]
+
+    def __len__(self):
+        return len(self._adjacency)
+
+    def __iter__(self):
+        return iter(self._adjacency.keys())
+
+    def __contains__(self, value):
+        return value in self._adjacency
+
+    def __getitem__(self, node):
+        return self._adjacency[node]
+
+class Unfeasible(RuntimeError):
+    pass
+
+def has_path(graph, src, dest):
+    visited = set()
+    worklist = [src]
+    while worklist:
+        current = worklist.pop()
+        if current in visited:
+            continue
+        visited.add(current)
+        if dest in graph.successors(current):
+            return True
+        worklist.extend(graph.successors(current))
+    return False
+
+# Copied verbatim from NetworkX
+#
+# NetworkX is distributed with the 3-clause BSD license.
+#
+# ::
+#
+#   Copyright (C) 2004-2021, NetworkX Developers
+#   Aric Hagberg <hagberg@lanl.gov>
+#   Dan Schult <dschult@colgate.edu>
+#   Pieter Swart <swart@lanl.gov>
+#   All rights reserved.
+#
+#   Redistribution and use in source and binary forms, with or without
+#   modification, are permitted provided that the following conditions are
+#   met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above
+#       copyright notice, this list of conditions and the following
+#       disclaimer in the documentation and/or other materials provided
+#       with the distribution.
+#
+#     * Neither the name of the NetworkX Developers nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+#   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#   OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+def _all_simple_paths_graph(G, source, targets, cutoff):
+    visited = dict.fromkeys([source])
+    stack = [iter(G[source])]
+    while stack:
+        children = stack[-1]
+        child = next(children, None)
+        if child is None:
+            stack.pop()
+            visited.popitem()
+        elif len(visited) < cutoff:
+            if child in visited:
+                continue
+            if child in targets:
+                yield list(visited) + [child]
+            visited[child] = None
+            if targets - set(visited.keys()):  # expand stack until find all targets
+                stack.append(iter(G[child]))
+            else:
+                visited.popitem()  # maybe other ways to child
+        else:  # len(visited) == cutoff:
+            for target in (targets & (set(children) | {child})) - set(visited.keys()):
+                yield list(visited) + [target]
+            stack.pop()
+            visited.popitem()
+
+def all_simple_paths(graph, src, target):
+    return _all_simple_paths_graph(graph, src, {target},  len(graph) - 1)

--- a/pythran/optimizations/forward_substitution.py
+++ b/pythran/optimizations/forward_substitution.py
@@ -6,10 +6,10 @@ computation code.
 from pythran.analyses import LazynessAnalysis, UseDefChains, DefUseChains
 from pythran.analyses import Literals, Ancestors, Identifiers, CFG, IsAssigned
 from pythran.passmanager import Transformation
+import pythran.graph as graph
 
 from collections import defaultdict
 import gast as ast
-import networkx as nx
 
 try:
     from math import isfinite
@@ -139,7 +139,7 @@ class ForwardSubstitution(Transformation):
                 ids = self.gather(Identifiers, value)
                 node_stmt = next(reversed([s for s in self.ancestors[node]
                                  if isinstance(s, ast.stmt)]))
-                all_paths = nx.all_simple_paths(self.cfg, parent, node_stmt)
+                all_paths = graph.all_simple_paths(self.cfg, parent, node_stmt)
                 for path in all_paths:
                     for stmt in path[1:-1]:
                         assigned_ids = {n.id

--- a/pythran/types/type_dependencies.py
+++ b/pythran/types/type_dependencies.py
@@ -4,14 +4,13 @@ import gast as ast
 import itertools
 import os
 
-import networkx as nx
-
 from pythran.analyses import GlobalDeclarations
 from pythran.errors import PythranInternalError
 from pythran.passmanager import ModuleAnalysis
 from pythran.types.conversion import PYTYPE_TO_CTYPE_TABLE
 from pythran.utils import get_variable
 from pythran.typing import List, Set, Dict, NDArray, Tuple, Pointer, Fun
+from pythran.graph import DiGraph
 
 
 def pytype_to_deps_hpp(t):
@@ -70,7 +69,7 @@ class TypeDependencies(ModuleAnalysis):
     ... def copy(n):
     ...     return n == 2''')
     >>> res = pm.gather(TypeDependencies, node)
-    >>> len(res.edges())
+    >>> len(res.edges)
     3
 
     foo result depend on : NoDeps and copy
@@ -84,7 +83,7 @@ class TypeDependencies(ModuleAnalysis):
     ... def copy(n):
     ...     return n == 2''')
     >>> res = pm.gather(TypeDependencies, node)
-    >>> len(res.edges())
+    >>> len(res.edges)
     3
 
     foo result depend on : NoDeps and copy
@@ -101,7 +100,7 @@ class TypeDependencies(ModuleAnalysis):
     ... def copy(n):
     ...     return n == 2''')
     >>> res = pm.gather(TypeDependencies, node)
-    >>> len(res.edges())
+    >>> len(res.edges)
     5
 
     bar result depend on : NoDeps
@@ -119,7 +118,7 @@ class TypeDependencies(ModuleAnalysis):
     ...         n = 4
     ...     return 1 or n''')
     >>> res = pm.gather(TypeDependencies, node)
-    >>> len(res.edges())
+    >>> len(res.edges)
     3
 
     Check we do not add everything from a conditional statement.
@@ -134,7 +133,7 @@ class TypeDependencies(ModuleAnalysis):
     ...         n = 4
     ...     return 1 or n''')
     >>> res = pm.gather(TypeDependencies, node)
-    >>> len(res.edges())
+    >>> len(res.edges)
     2
 
     bar result depend on : NoDeps
@@ -149,7 +148,7 @@ class TypeDependencies(ModuleAnalysis):
     ...         i = 2
     ...     return i''')
     >>> res = pm.gather(TypeDependencies, node)
-    >>> len(res.edges())
+    >>> len(res.edges)
     2
 
     bar result depend on : NoDeps
@@ -165,7 +164,7 @@ class TypeDependencies(ModuleAnalysis):
     ...         pass
     ...     return i''')
     >>> res = pm.gather(TypeDependencies, node)
-    >>> len(res.edges())
+    >>> len(res.edges)
     3
 
     bar result depend on : NoDeps
@@ -180,7 +179,7 @@ class TypeDependencies(ModuleAnalysis):
     ...         pass
     ...     return i''')
     >>> res = pm.gather(TypeDependencies, node)
-    >>> len(res.edges())
+    >>> len(res.edges)
     2
 
     bar result depend on : NoDeps
@@ -194,7 +193,7 @@ class TypeDependencies(ModuleAnalysis):
     ...         res = foo(n - 1)
     ...     return res''')
     >>> res = pm.gather(TypeDependencies, node)
-    >>> len(res.edges())
+    >>> len(res.edges)
     2
 
     foo result depend on : NoDeps and foo
@@ -215,7 +214,7 @@ class TypeDependencies(ModuleAnalysis):
     ..         j = bar2(n)
     ..     return j''')
     >> res = pm.gather(TypeDependencies, node)
-    >> len(res.edges())
+    >> len(res.edges)
     4
 
     bar result depend on : NoDeps
@@ -227,7 +226,7 @@ class TypeDependencies(ModuleAnalysis):
 
     def __init__(self):
         """ Create empty result graph and gather global declarations. """
-        self.result = nx.DiGraph()
+        self.result = DiGraph()
         self.current_function = None
         self.naming = dict()  # variable to dependencies for current function.
         # variable to dependencies for current conditional statement

--- a/pythran/typing.py
+++ b/pythran/typing.py
@@ -1,6 +1,3 @@
-from six import with_metaclass
-
-
 class FunMeta(type):
 
     def __getitem__(cls, item):
@@ -81,47 +78,47 @@ class Type(type):
         pass
 
 
-class Fun(with_metaclass(FunMeta, Type)):
+class Fun(Type, metaclass=FunMeta):
     pass
 
 
-class Dict(with_metaclass(DictMeta, Type)):
+class Dict(Type, metaclass=DictMeta):
     pass
 
 
-class Union(with_metaclass(UnionMeta, Type)):
+class Union(Type, metaclass=UnionMeta):
     pass
 
 
-class Set(with_metaclass(SetMeta, Type)):
+class Set(Type, metaclass=SetMeta):
     pass
 
 
-class List(with_metaclass(ListMeta, Type)):
+class List(Type, metaclass=ListMeta):
     pass
 
 
-class Iterable(with_metaclass(IterableMeta, Type)):
+class Iterable(Type, metaclass=IterableMeta):
     pass
 
 
-class Generator(with_metaclass(GeneratorMeta, Type)):
+class Generator(Type, metaclass=GeneratorMeta):
     pass
 
 
-class Tuple(with_metaclass(TupleMeta, Type)):
+class Tuple(Type, metaclass=TupleMeta):
     pass
 
 
-class Optional(with_metaclass(OptionalMeta, Type)):
+class Optional(Type, metaclass=OptionalMeta):
     pass
 
 
-class NDArray(with_metaclass(NDArrayMeta, Type)):
+class NDArray(Type, metaclass=NDArrayMeta):
     pass
 
 
-class Pointer(with_metaclass(PointerMeta, Type)):
+class Pointer(Type, metaclass=PointerMeta):
     pass
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,4 @@
 ply>=3.4
-networkx>=2
-decorator
 gast~=0.5.0
-six
 numpy
 beniget~=0.4.0


### PR DESCRIPTION
Pythran only uses a small subset of networkx, and networkx brings a lot of
dependencies with it, including scipy, which implies a circular dependency when
using pythran to compile scipy.

As quoted by « someone on the internet » it's a good property for a compiler to
have minimal dependencies because it's used to build other stuff.

As a side effect also prune the dependency on decorator and six.