### PR TITLE
Improve error message when input is a view (was `(reshaped)`)

### DIFF
--- a/pythran/pythonic/python/core.hpp
+++ b/pythran/pythonic/python/core.hpp
@@ -85,14 +85,14 @@ namespace python
           (PyArray_NDIM(arr) > 1)) {
         oss << " (with unsupported column-major layout)";
       } else if (PyArray_BASE(arr)) {
-        oss << " (reshaped)";
+        oss << " (is a view)";
       } else {
         auto const *stride = PyArray_STRIDES(arr);
         auto const *dims = PyArray_DIMS(arr);
         long current_stride = PyArray_ITEMSIZE(arr);
         for (long i = PyArray_NDIM(arr) - 1; i >= 0; i--) {
           if (stride[i] != current_stride) {
-            oss << " (strided)";
+            oss << " (is strided)";
             break;
           }
           current_stride *= dims[i];

--- a/pythran/tests/notebooks/export.ipynb
+++ b/pythran/tests/notebooks/export.ipynb
@@ -856,7 +856,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Invalid call to pythranized function `basic(int64[:] (reshaped))'\n",
+      "Invalid call to pythranized function `basic(int64[:] (is a view))'\n",
       "Candidates are:\n",
       "\n",
       "    - basic(float32)\n",


### PR DESCRIPTION
xref https://github.com/scipy/scipy/issues/14420. The `(reshaped)` bit has been confusing to me before.