### PR TITLE
WIP: support keepdims in numpy mean

### DIFF
--- a/pythran/analyses/immediates.py
+++ b/pythran/analyses/immediates.py
@@ -1,6 +1,8 @@
 """ Immediates gathers immediates. For now, only integers within shape are
 considered as immediates """
 
+import gast as ast
+from pythran.tables import MODULES
 from pythran.analyses import Aliases
 from pythran.passmanager import NodeAnalysis
 from pythran.utils import pythran_builtin, isnum
@@ -15,6 +17,12 @@ class Immediates(NodeAnalysis):
 
     def visit_Call(self, node):
         func_aliases = self.aliases[node.func]
+        if len(func_aliases) == 1 and next(iter(func_aliases)) is MODULES['numpy']['mean']:
+            if len(node.args) >= 5:
+                keep_dims = node.args[4]
+                if isinstance(keep_dims, ast.Constant):
+                    self.result.add(keep_dims)
+
         if len(func_aliases) == 1 and next(iter(func_aliases)) is _make_shape:
             self.result.update(a for a in node.args
                                if isnum(a)

--- a/pythran/analyses/immediates.py
+++ b/pythran/analyses/immediates.py
@@ -19,9 +19,9 @@ class Immediates(NodeAnalysis):
         func_aliases = self.aliases[node.func]
         if len(func_aliases) == 1 and next(iter(func_aliases)) is MODULES['numpy']['mean']:
             if len(node.args) >= 5:
-                keep_dims = node.args[4]
-                if isinstance(keep_dims, ast.Constant):
-                    self.result.add(keep_dims)
+                keepdims = node.args[4]
+                if isinstance(keepdims, ast.Constant):
+                    self.result.add(keepdims)
 
         if len(func_aliases) == 1 and next(iter(func_aliases)) is _make_shape:
             self.result.update(a for a in node.args

--- a/pythran/backend.py
+++ b/pythran/backend.py
@@ -957,7 +957,7 @@ class CxxFunction(ast.NodeVisitor):
     def visit_Constant(self, node):
         if node in self.immediates and isinstance(node.value, bool):
             ret = "std::integral_constant<%s, %s>{}" % (
-                PYTYPE_TO_CTYPE_TABLE[type(node.value)], node.value)
+                PYTYPE_TO_CTYPE_TABLE[type(node.value)], str(node.value).lower())
         elif node.value is None:
             ret = 'pythonic::builtins::None'
         elif isinstance(node.value, bool):

--- a/pythran/backend.py
+++ b/pythran/backend.py
@@ -955,7 +955,10 @@ class CxxFunction(ast.NodeVisitor):
             return "{}({})".format(func, ", ".join(args))
 
     def visit_Constant(self, node):
-        if node.value is None:
+        if node in self.immediates and isinstance(node.value, bool):
+            ret = "std::integral_constant<%s, %s>{}" % (
+                PYTYPE_TO_CTYPE_TABLE[type(node.value)], node.value)
+        elif node.value is None:
             ret = 'pythonic::builtins::None'
         elif isinstance(node.value, bool):
             ret = str(node.value).lower()

--- a/pythran/pythonic/numpy/mean.hpp
+++ b/pythran/pythonic/numpy/mean.hpp
@@ -2,7 +2,9 @@
 #define PYTHONIC_NUMPY_MEAN_HPP
 
 #include "pythonic/include/numpy/mean.hpp"
-
+#include "pythonic/utils/functor.hpp"
+#include "pythonic/numpy/asarray.hpp"
+#include "pythonic/numpy/expand_dims.hpp"
 #include "pythonic/numpy/sum.hpp"
 #include "pythonic/builtins/None.hpp"
 
@@ -22,6 +24,39 @@ namespace numpy
   {
     return sum(expr, axis) /=
            typename dtype::type(sutils::getshape(expr)[axis]);
+  }
+
+  template <class E, class dtype>
+  auto mean(E const &expr, types::none_type axis, dtype d, std::false_type keepdims)
+      -> decltype(sum(expr) / typename dtype::type(expr.flat_size()))
+  {
+    return sum(expr) / typename dtype::type(expr.flat_size());
+  }
+
+  template <class E, class dtype>
+  auto mean(E const &expr, long axis, dtype d, std::false_type keepdims) 
+      -> decltype(sum(expr, axis))
+  {
+    return sum(expr, axis) /=
+           typename dtype::type(sutils::getshape(expr)[axis]);
+  }
+
+  template <class E, class dtype>
+  auto mean(E const &expr, types::none_type axis, dtype d, std::true_type keepdims)
+  {
+    const long N = E::value;
+    types::array<long, N> out_shape;
+    std::fill_n (out_shape, N, 1);
+    return numpy::functor::asarray{}(sum(expr) / 
+           typename dtype::type(expr.flat_size())).reshape(out_shape);
+  }
+
+  template <class E, class dtype>
+  auto mean(E const &expr, long axis, dtype d, std::true_type keepdims) 
+      -> decltype(expand_dims(sum(expr, axis), axis))
+  {
+    return expand_dims(sum(expr, axis) /=
+           typename dtype::type(sutils::getshape(expr)[axis]), axis);
   }
 }
 PYTHONIC_NS_END

--- a/pythran/pythonic/numpy/mean.hpp
+++ b/pythran/pythonic/numpy/mean.hpp
@@ -27,32 +27,32 @@ namespace numpy
   }
 
   template <class E, class dtype>
-  auto mean(E const &expr, types::none_type axis, dtype d, std::false_type keepdims)
+  auto mean(E const &expr, types::none_type axis, dtype d, types::none_type out, std::false_type keepdims)
       -> decltype(sum(expr) / typename dtype::type(expr.flat_size()))
   {
     return sum(expr) / typename dtype::type(expr.flat_size());
   }
 
   template <class E, class dtype>
-  auto mean(E const &expr, long axis, dtype d, std::false_type keepdims) 
+  auto mean(E const &expr, long axis, dtype d, types::none_type out, std::false_type keepdims) 
       -> decltype(sum(expr, axis))
   {
     return sum(expr, axis) /=
            typename dtype::type(sutils::getshape(expr)[axis]);
   }
 
-  template <class E, class dtype>
-  auto mean(E const &expr, types::none_type axis, dtype d, std::true_type keepdims)
-  {
-    const long N = E::value;
-    types::array<long, N> out_shape;
-    std::fill_n (out_shape, N, 1);
-    return numpy::functor::asarray{}(sum(expr) / 
-           typename dtype::type(expr.flat_size())).reshape(out_shape);
-  }
+  // template <class E, class dtype>
+  // auto mean(E const &expr, types::none_type axis, dtype d, types::none_type out, std::true_type keepdims)
+  // {
+  //   const long N = E::value;
+  //   types::array<long, N> out_shape;
+  //   std::fill_n (out_shape, N, 1);
+  //   return numpy::functor::asarray{}(sum(expr) / 
+  //          typename dtype::type(expr.flat_size())).reshape(out_shape);
+  // }
 
   template <class E, class dtype>
-  auto mean(E const &expr, long axis, dtype d, std::true_type keepdims) 
+  auto mean(E const &expr, long axis, dtype d, types::none_type out, std::true_type keepdims) 
       -> decltype(expand_dims(sum(expr, axis), axis))
   {
     return expand_dims(sum(expr, axis) /=

--- a/pythran/tests/test_numpy_func0.py
+++ b/pythran/tests/test_numpy_func0.py
@@ -285,6 +285,12 @@ def np_rosen_der(x):
     def test_mean5(self):
         self.run_test("def np_mean5(a): from numpy import mean ; return mean(a, 2)", numpy.array([[[1, 2], [3, 4.]]]), np_mean5=[NDArray[float,:,:,:]])
 
+    def test_mean6(self):
+        self.run_test("def np_mean6(a): from numpy import mean ; return mean(a, 2, keepdims=False)", numpy.array([[[1, 2], [3, 4.]]]), np_mean6=[NDArray[float,:,:,:]])
+
+    def test_mean7(self):
+        self.run_test("def np_mean7(a): from numpy import mean ; return mean(a, keepdims=False)", numpy.array([[[1, 2], [3, 4.]]]), np_mean7=[NDArray[float,:,:,:]])
+
     def test_var0(self):
         self.run_test("def np_var0(a): return a.var()", numpy.array([[1, 2], [3, 4]], dtype=float), np_var0=[NDArray[float,:,:]])
 

--- a/pythran/tests/test_numpy_func0.py
+++ b/pythran/tests/test_numpy_func0.py
@@ -286,10 +286,16 @@ def np_rosen_der(x):
         self.run_test("def np_mean5(a): from numpy import mean ; return mean(a, 2)", numpy.array([[[1, 2], [3, 4.]]]), np_mean5=[NDArray[float,:,:,:]])
 
     def test_mean6(self):
-        self.run_test("def np_mean6(a): from numpy import mean ; return mean(a, 2, keepdims=False)", numpy.array([[[1, 2], [3, 4.]]]), np_mean6=[NDArray[float,:,:,:]])
+        self.run_test("def np_mean6(a): from numpy import mean ; from numpy import float64; return mean(a, 2, float64, None, False)", numpy.array([[[1, 2], [3, 4.]]]), np_mean6=[NDArray[float,:,:,:]])
 
     def test_mean7(self):
-        self.run_test("def np_mean7(a): from numpy import mean ; return mean(a, keepdims=False)", numpy.array([[[1, 2], [3, 4.]]]), np_mean7=[NDArray[float,:,:,:]])
+        self.run_test("def np_mean7(a): from numpy import mean ; return mean(a, 2, out=None, keepdims=False)", numpy.array([[[1, 2], [3, 4.]]]), np_mean7=[NDArray[float,:,:,:]])
+
+    def test_mean8(self):
+        self.run_test("def np_mean8(a): from numpy import mean ; return mean(a, 2, keepdims=False)", numpy.array([[[1, 2], [3, 4.]]]), np_mean8=[NDArray[float,:,:,:]])
+
+    def test_mean9(self):
+        self.run_test("def np_mean9(a): from numpy import mean ; return mean(a, keepdims=False)", numpy.array([[[1, 2], [3, 4.]]]), np_mean9=[NDArray[float,:,:,:]])
 
     def test_var0(self):
         self.run_test("def np_var0(a): return a.var()", numpy.array([[1, 2], [3, 4]], dtype=float), np_var0=[NDArray[float,:,:]])


### PR DESCRIPTION
My current implementation, I haven't tested it and I'm not sure if my understanding is correct. I added four new functions in `numpy/mean.hpp `:

- `auto mean(E const &expr, types::none_type axis, dtype d, std::false_type keepdims)`: simply copy the codes in `auto mean(E const &expr, types::none_type axis, dtype d)`
- `auto mean(E const &expr, long axis, dtype d, std::false_type keepdims)`: simply copy the codes in `auto mean(E const &expr, types::none_type axis, dtype d)`
- `auto mean(E const &expr, types::none_type axis, dtype d, std::true_type keepdims)`: reshape the value array to support `keepdims`, but I'm not sure how can I specify the return type for this function.

```
>>> np.mean(np.array([[[1,2],[3,4]],[[5,6],[7,8]]]),  keepdims=False)
4.5
>>> >>> np.mean(np.array([[[1,2],[3,4]],[[5,6],[7,8]]]),  keepdims=True)
array([[[4.5]]])
>>> np.mean(np.array([[[1,2],[3,4]],[[5,6],[7,8]]]),  keepdims=False).reshape((1,1,1))
array([[[4.5]]])
```
- `auto mean(E const &expr, long axis, dtype d, std::true_type keepdims)`: expand the array `axis` dim to support `keepdims`.

```
>>> np.mean(np.array([[[1,2],[3,4]],[[5,6],[7,8]]]), axis=2, keepdims=True)
array([[[1.5],
        [3.5]],

       [[5.5],
        [7.5]]])
>>> np.expand_dims(np.mean(np.array([[[1,2],[3,4]],[[5,6],[7,8]]]), axis=2, keepdims=False), 2)
array([[[1.5],
        [3.5]],

       [[5.5],
        [7.5]]])
```

Some concerns: I found that `keepdims` is the 5th argument in `numpy.mean` while `out` is the fourth argument and we didn't support `out`.  Will it be a problem...? 

cc @serge-sans-paille @rgommers 