### PR TITLE
Better libomp detection on macOS

### DIFF
--- a/omp/__init__.py
+++ b/omp/__init__.py
@@ -102,8 +102,8 @@ class OpenMP(object):
                 if libomp_path:
                     break
                 path = path.strip()
-                if os.path.isdir(path):
-                    libomp_path = find_library(os.path.join(str(path), libomp_name))
+                if os.path.isfile(os.path.join(path, libomp_name)):
+                    libomp_path = os.path.join(path, libomp_name)
 
             if libomp_path:
                 # Load the library

--- a/omp/__init__.py
+++ b/omp/__init__.py
@@ -69,10 +69,16 @@ class OpenMP(object):
 
     def init_not_msvc(self):
         """ Find OpenMP library and try to load if using ctype interface. """
-        # find_library() does not search automatically LD_LIBRARY_PATH
+        # find_library() does not automatically search LD_LIBRARY_PATH
+        # until Python 3.6+, so we explicitly add it.
+        # LD_LIBRARY_PATH is used on Linux, while macOS uses DYLD_LIBRARY_PATH
+        # and DYLD_FALLBACK_LIBRARY_PATH.
         paths = os.environ.get('LD_LIBRARY_PATH', '').split(':')
+        paths += os.environ.get('DYLD_LIBRARY_PATH', '').split(':')
+        paths += os.environ.get('DYLD_FALLBACK_LIBRARY_PATH', '').split(':')
 
-        for libomp_name in self.get_libomp_names():
+        libomp_names = self.get_libomp_names()
+        for libomp_name in libomp_names:
             if cxx is None or sys.platform == 'win32':
                 # Note: Clang supports -print-file-name, but not yet for
                 # clang-cl as of v12.0.0 (April '21)
@@ -87,29 +93,31 @@ class OpenMP(object):
             except (OSError, CalledProcessError):
                 pass
 
-        # Try to load find libgomp shared library using loader search dirs
-        libgomp_path = find_library("gomp")
+        for libomp_name in libomp_names:
+            # Try to load find libomp shared library using loader search dirs
+            libomp_path = find_library(libomp_name)
 
-        # Try to use custom paths if lookup failed
-        for path in paths:
-            if libgomp_path:
-                break
-            path = path.strip()
-            if os.path.isdir(path):
-                libgomp_path = find_library(os.path.join(str(path), "libgomp"))
+            # Try to use custom paths if lookup failed
+            for path in paths:
+                if libomp_path:
+                    break
+                path = path.strip()
+                if os.path.isdir(path):
+                    libomp_path = find_library(os.path.join(str(path), libomp_name))
 
-        if not libgomp_path:
-            raise ImportError("I can't find a shared library for libgomp,"
-                              " you may need to install it or adjust the "
-                              "LD_LIBRARY_PATH environment variable.")
-        else:
-            # Load the library
-            try:
-                self.libomp = ctypes.CDLL(libgomp_path)
-            except OSError:
-                raise ImportError("found openMP library '{}' but couldn't load it. "
-                                  "This may happen if you are cross-compiling.".format(libgomp_path))
-            self.version = 45
+            if libomp_path:
+                # Load the library
+                try:
+                    self.libomp = ctypes.CDLL(libomp_path)
+                except OSError:
+                    raise ImportError("found openMP library '{}' but couldn't load it. "
+                                      "This may happen if you are cross-compiling.".format(libomp_path))
+                self.version = 45
+                return
+
+        raise ImportError("I can't find a shared library for libomp,"
+                          " you may need to install it or adjust the "
+                          "LD_LIBRARY_PATH environment variable.")
 
     def __getattr__(self, name):
         """

--- a/omp/__init__.py
+++ b/omp/__init__.py
@@ -76,7 +76,7 @@ class OpenMP(object):
         env_vars = []
         if sys.platform == 'darwin':
             env_vars = ['DYLD_LIBRARY_PATH', 'DYLD_FALLBACK_LIBRARY_PATH']
-        elif sys.platform.startswith('linux'):
+        else:
             env_vars = ['LD_LIBRARY_PATH']
 
         paths = []
@@ -121,15 +121,9 @@ class OpenMP(object):
                 self.version = 45
                 return
 
-        msg = "I can't find a shared library for libomp, you may need to install it"
-        if env_vars:
-            msg += " or adjust the "
-            msg += " or ".join(env_vars)
-            msg += " environment variable"
-            if len(env_vars) > 1:
-                msg += "s"
-        msg += "."
-        raise ImportError(msg)
+        raise ImportError("I can't find a shared library for libomp, you may need to install it "
+                          "or adjust the {} environment variable.".format(env_vars[O]))
+
 
     def __getattr__(self, name):
         """

--- a/omp/__init__.py
+++ b/omp/__init__.py
@@ -73,9 +73,15 @@ class OpenMP(object):
         # until Python 3.6+, so we explicitly add it.
         # LD_LIBRARY_PATH is used on Linux, while macOS uses DYLD_LIBRARY_PATH
         # and DYLD_FALLBACK_LIBRARY_PATH.
-        paths = os.environ.get('LD_LIBRARY_PATH', '').split(':')
-        paths += os.environ.get('DYLD_LIBRARY_PATH', '').split(':')
-        paths += os.environ.get('DYLD_FALLBACK_LIBRARY_PATH', '').split(':')
+        env_vars = []
+        if sys.platform == 'darwin':
+            env_vars = ['DYLD_LIBRARY_PATH', 'DYLD_FALLBACK_LIBRARY_PATH']
+        elif sys.platform.startswith('linux'):
+            env_vars = ['LD_LIBRARY_PATH']
+
+        paths = []
+        for env_var in env_vars:
+            paths += os.environ.get(env_var, '').split(os.pathsep)
 
         libomp_names = self.get_libomp_names()
         for libomp_name in libomp_names:
@@ -115,9 +121,15 @@ class OpenMP(object):
                 self.version = 45
                 return
 
-        raise ImportError("I can't find a shared library for libomp,"
-                          " you may need to install it or adjust the "
-                          "LD_LIBRARY_PATH environment variable.")
+        msg = "I can't find a shared library for libomp, you may need to install it"
+        if env_vars:
+            msg += " or adjust the "
+            msg += " or ".join(env_vars)
+            msg += " environment variable"
+            if len(env_vars) > 1:
+                msg += "s"
+        msg += "."
+        raise ImportError(msg)
 
     def __getattr__(self, name):
         """


### PR DESCRIPTION
This PR fixes three issues with libomp detection on macOS:

- [x] macOS uses `DYLD_LIBRARY_PATH` and `DYLD_FALLBACK_LIBRARY_PATH`, not `LD_LIBRARY_PATH`
- [x] libomp may have many different names (`libomp` in my case), search for all of them, not just `libgomp`
- [x] `ctypes.util.find_library()` does not support absolute paths

There may still be problems with other compilers but I only encountered issues with Apple Clang on macOS.