### PR TITLE
Basic support for to_eval of np._globals._NoValueType

### DIFF
--- a/pythran/conversion.py
+++ b/pythran/conversion.py
@@ -138,6 +138,11 @@ def to_ast(value):
     # only meaningful for python3
     elif isinstance(value, (filter, map, zip)):
         return to_ast(list(value))
+    elif isinstance(value, np._globals._NoValueType):
+        return ast.Attribute(ast.Attribute(ast.Name('numpy', ast.Load(), None,
+                                                    None), '_globals',
+                                           ast.Load()),
+                             '_NoValueType', ast.Load())
     raise ToNotEval()
 
 


### PR DESCRIPTION
This is required to correctly compute the signature of numpy.mean, and should
unlock #1855