### PR TITLE
Support  boolean arguments in numpy unique

### DIFF
--- a/pythran/analyses/immediates.py
+++ b/pythran/analyses/immediates.py
@@ -23,6 +23,20 @@ class Immediates(NodeAnalysis):
                 if isinstance(keepdims, ast.Constant):
                     self.result.add(keepdims)
 
+        if len(func_aliases) == 1 and next(iter(func_aliases)) is MODULES['numpy']['unique']:
+            if len(node.args) >= 2:
+                return_index = node.args[1]
+                if isinstance(return_index, ast.Constant):
+                    self.result.add(return_index)
+            if len(node.args) >= 3:
+                return_inverse = node.args[2]
+                if isinstance(return_inverse, ast.Constant):    
+                    self.result.add(return_inverse)
+            if len(node.args) >= 4:
+                return_counts = node.args[3]
+                if isinstance(return_counts, ast.Constant): 
+                    self.result.add(return_counts)
+
         if len(func_aliases) == 1 and next(iter(func_aliases)) is _make_shape:
             self.result.update(a for a in node.args
                                if isnum(a)

--- a/pythran/pythonic/include/numpy/unique.hpp
+++ b/pythran/pythonic/include/numpy/unique.hpp
@@ -15,21 +15,83 @@ namespace numpy
   template <class E>
   std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
              types::ndarray<long, types::pshape<long>>>
-  unique(E const &expr, bool return_index);
+  unique(E const &expr, std::true_type return_index);
+
+  template <class E>
+  types::ndarray<typename E::dtype, types::pshape<long>>
+  unique(E const &expr, std::false_type return_index);
+
+  template <class E>
+  std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
+             types::ndarray<long, types::pshape<long>>>
+  unique(E const &expr, std::false_type return_index, std::true_type return_inverse);
+
+  template <class E>
+  types::ndarray<typename E::dtype, types::pshape<long>>
+  unique(E const &expr, std::false_type return_index, std::false_type return_inverse);
+
+  template <class E>
+  std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
+             types::ndarray<long, types::pshape<long>>>
+  unique(E const &expr, std::true_type return_index, std::false_type return_inverse);
 
   template <class E>
   std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
              types::ndarray<long, types::pshape<long>>,
              types::ndarray<long, types::pshape<long>>>
-  unique(E const &expr, bool return_index, bool return_inverse);
+  unique(E const &expr, std::true_type return_index, std::true_type return_inverse);
 
   template <class E>
   std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
              types::ndarray<long, types::pshape<long>>,
              types::ndarray<long, types::pshape<long>>,
              types::ndarray<long, types::pshape<long>>>
-  unique(E const &expr, bool return_index, bool return_inverse,
-         bool return_counts);
+  unique(E const &expr, std::true_type return_index, std::true_type return_inverse,
+         std::true_type return_counts);
+  
+  template <class E>
+  std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
+             types::ndarray<long, types::pshape<long>>,
+             types::ndarray<long, types::pshape<long>>>
+  unique(E const &expr, std::true_type return_index, std::true_type return_inverse,
+         std::false_type return_counts);
+
+  template <class E>
+  std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
+             types::ndarray<long, types::pshape<long>>>
+  unique(E const &expr, std::true_type return_index, std::false_type return_inverse,
+         std::false_type return_counts);
+
+  template <class E>
+  std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
+             types::ndarray<long, types::pshape<long>>,
+             types::ndarray<long, types::pshape<long>>>
+  unique(E const &expr, std::true_type return_index, std::false_type return_inverse,
+         std::true_type return_counts);
+
+  template <class E>
+  std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
+             types::ndarray<long, types::pshape<long>>>
+  unique(E const &expr, std::false_type return_index, std::true_type return_inverse,
+         std::false_type return_counts);
+
+  template <class E>
+  std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
+             types::ndarray<long, types::pshape<long>>,
+             types::ndarray<long, types::pshape<long>>>
+  unique(E const &expr, std::false_type return_index, std::true_type return_inverse,
+         std::true_type return_counts);
+
+  template <class E>
+  types::ndarray<typename E::dtype, types::pshape<long>> 
+  unique(E const &expr, std::false_type return_index, std::false_type return_inverse,
+         std::false_type return_counts);
+
+  template <class E>
+  std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
+             types::ndarray<long, types::pshape<long>>>
+  unique(E const &expr, std::false_type return_index, std::false_type return_inverse,
+         std::true_type return_counts);
 
   DEFINE_FUNCTOR(pythonic::numpy, unique)
 }

--- a/pythran/pythonic/numpy/unique.hpp
+++ b/pythran/pythonic/numpy/unique.hpp
@@ -87,7 +87,83 @@ namespace numpy
         _unique4((*begin).begin(), (*begin).end(), out1, out2, out3, i,
                  utils::int_<N - 1>());
     }
+    template <class I, class O0, class O2>
+    void _unique5(I begin, I end, O0 &out0, O2 &out2, long &i,
+                  utils::int_<1>)
+    {
+      for (; begin != end; ++begin, ++i) {
+        auto pair = out0.insert(*begin);
+        out2[i] = std::distance(out0.begin(), pair.first);
+      }
+    }
+    template <class I, class O0, class O2, size_t N>
+    void _unique5(I begin, I end, O0 &out0, O2 &out2, long &i,
+                  utils::int_<N>)
+    {
+      for (; begin != end; ++begin)
+        _unique5((*begin).begin(), (*begin).end(), out0, out2, i,
+                 utils::int_<N - 1>());
+    }
+
+    template <class I, class O1, class O3>
+    void _unique6(I begin, I end, O1 &out1, O3 &out3, long &i,
+                  utils::int_<1>)
+    {
+      for (; begin != end; ++begin, ++i) {
+        auto res = out3.insert(std::make_pair(*begin, 0));
+        res.first->second += 1;
+        if (res.second) {
+          out1.push_back(i);
+        }
+      }
+    }
+    template <class I, class O1, class O3, size_t N>
+    void _unique6(I begin, I end, O1 &out1, O3 &out3, long &i,
+                  utils::int_<N>)
+    {
+      for (; begin != end; ++begin)
+        _unique6((*begin).begin(), (*begin).end(), out1, out3, i,
+                 utils::int_<N - 1>());
+    }
+
+    template <class I, class O2, class O3>
+    void _unique7(I begin, I end, O2 &out2, O3 &out3, long &i,
+                  utils::int_<1>)
+    {
+      for (; begin != end; ++begin, ++i) {
+        auto res = out3.insert(std::make_pair(*begin, 0));
+        res.first->second += 1;
+        out2[i] = std::distance(out3.begin(), res.first);
+      }
+    }
+    template <class I, class O2, class O3, size_t N>
+    void _unique7(I begin, I end, O2 &out2, O3 &out3, long &i,
+                  utils::int_<N>)
+    {
+      for (; begin != end; ++begin)
+        _unique7((*begin).begin(), (*begin).end(), out2, out3, i,
+                 utils::int_<N - 1>());
+    }
+
+    template <class I, class O3>
+    void _unique8(I begin, I end, O3 &out3, long &i,
+                  utils::int_<1>)
+    {
+      for (; begin != end; ++begin, ++i) {
+        auto res = out3.insert(std::make_pair(*begin, 0));
+        res.first->second += 1;
+      }
+    }
+    template <class I,  class O3, size_t N>
+    void _unique8(I begin, I end, O3 &out3, long &i,
+                  utils::int_<N>)
+    {
+      for (; begin != end; ++begin)
+        _unique8((*begin).begin(), (*begin).end(), out3, i,
+                 utils::int_<N - 1>());
+    }
   }
+
   template <class E>
   types::ndarray<typename E::dtype, types::pshape<long>> unique(E const &expr)
   {
@@ -99,7 +175,7 @@ namespace numpy
   template <class E>
   std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
              types::ndarray<long, types::pshape<long>>>
-  unique(E const &expr, bool return_index)
+  unique(E const &expr, std::true_type return_index)
   {
     std::set<typename E::dtype> res;
     std::vector<long> return_index_res;
@@ -112,10 +188,52 @@ namespace numpy
   }
 
   template <class E>
+  types::ndarray<typename E::dtype, types::pshape<long>>
+  unique(E const &expr, std::false_type return_index)
+  {
+    std::set<typename E::dtype> res;
+    _unique1(expr.begin(), expr.end(), res, utils::int_<E::value>());
+    return {res};
+  }
+
+  template <class E>
+  std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
+             types::ndarray<long, types::pshape<long>>>
+  unique(E const &expr, std::false_type return_index, std::true_type return_inverse)
+  {
+    std::set<typename E::dtype> res;
+    types::ndarray<long, types::pshape<long>> return_inverse_res(
+        types::pshape<long>{expr.flat_size()}, builtins::None);
+    long i = 0;
+    _unique5(expr.begin(), expr.end(), res, 
+             return_inverse_res, i, utils::int_<E::value>());
+    return std::make_tuple(
+        types::ndarray<typename E::dtype, types::pshape<long>>(res),
+        return_inverse_res);
+  }
+
+  template <class E>
+  types::ndarray<typename E::dtype, types::pshape<long>>
+  unique(E const &expr, std::false_type return_index, std::false_type return_inverse)
+  {
+    std::set<typename E::dtype> res;
+    _unique1(expr.begin(), expr.end(), res, utils::int_<E::value>());
+    return {res};
+  }
+
+  template <class E>
+  std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
+             types::ndarray<long, types::pshape<long>>>
+  unique(E const &expr, std::true_type return_index, std::false_type return_inverse)
+  {
+    return unique(expr, return_index);
+  }
+
+  template <class E>
   std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
              types::ndarray<long, types::pshape<long>>,
              types::ndarray<long, types::pshape<long>>>
-  unique(E const &expr, bool return_index, bool return_inverse)
+  unique(E const &expr, std::true_type return_index, std::true_type return_inverse)
   {
     assert(return_inverse && "invalid signature otherwise");
 
@@ -137,8 +255,8 @@ namespace numpy
              types::ndarray<long, types::pshape<long>>,
              types::ndarray<long, types::pshape<long>>,
              types::ndarray<long, types::pshape<long>>>
-  unique(E const &expr, bool return_index, bool return_inverse,
-         bool return_counts)
+  unique(E const &expr, std::true_type return_index, std::true_type return_inverse,
+         std::true_type return_counts)
   {
     assert(return_counts && "invalid signature otherwise");
 
@@ -172,6 +290,147 @@ namespace numpy
         unique_array,
         types::ndarray<long, types::pshape<long>>(return_index_res),
         return_inverse_res, return_counts_array);
+  }
+
+  template <class E>
+  std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
+             types::ndarray<long, types::pshape<long>>,
+             types::ndarray<long, types::pshape<long>>>
+  unique(E const &expr, std::true_type return_index, std::true_type return_inverse,
+         std::false_type return_counts)
+  {
+    return unique(expr, return_index, return_inverse);
+  }
+
+  template <class E>
+  std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
+             types::ndarray<long, types::pshape<long>>>
+  unique(E const &expr, std::true_type return_index, std::false_type return_inverse,
+         std::false_type return_counts)
+  {
+    return unique(expr, return_index);
+  }
+
+  template <class E>
+  std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
+             types::ndarray<long, types::pshape<long>>,
+             types::ndarray<long, types::pshape<long>>>
+  unique(E const &expr, std::true_type return_index, std::false_type return_inverse,
+         std::true_type return_counts)
+  {
+    std::vector<long> return_index_res;
+
+    std::map<typename E::dtype, long> return_counts_map;
+    {
+      long i = 0;
+      _unique6(expr.begin(), expr.end(), return_index_res, 
+               return_counts_map, i, utils::int_<E::value>());
+    }
+
+    types::pshape<long> shp{(long)return_counts_map.size()};
+
+    types::ndarray<long, types::pshape<long>> unique_array(shp, builtins::None);
+    types::ndarray<long, types::pshape<long>> return_counts_array(
+        shp, builtins::None);
+
+    {
+      long i = 0;
+      for (auto it = return_counts_map.begin(); it != return_counts_map.end();
+           ++i, ++it) {
+        unique_array.fast(i) = it->first;
+        return_counts_array.fast(i) = it->second;
+      }
+    }
+
+    return std::make_tuple(
+        unique_array,
+        types::ndarray<long, types::pshape<long>>(return_index_res),
+        return_counts_array);
+  }
+
+  template <class E>
+  std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
+             types::ndarray<long, types::pshape<long>>>
+  unique(E const &expr, std::false_type return_index, std::true_type return_inverse,
+         std::false_type return_counts)
+  {
+    return unique(expr, return_index, return_inverse);
+  }
+
+  template <class E>
+  std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
+             types::ndarray<long, types::pshape<long>>,
+             types::ndarray<long, types::pshape<long>>>
+  unique(E const &expr, std::false_type return_index, std::true_type return_inverse,
+         std::true_type return_counts)
+  {
+    types::ndarray<long, types::pshape<long>> return_inverse_res(
+        types::pshape<long>{expr.flat_size()}, builtins::None);
+
+    std::map<typename E::dtype, long> return_counts_map;
+    {
+      long i = 0;
+      _unique7(expr.begin(), expr.end(), return_inverse_res,
+               return_counts_map, i, utils::int_<E::value>());
+    }
+
+    types::pshape<long> shp{(long)return_counts_map.size()};
+
+    types::ndarray<long, types::pshape<long>> unique_array(shp, builtins::None);
+    types::ndarray<long, types::pshape<long>> return_counts_array(
+        shp, builtins::None);
+
+    {
+      long i = 0;
+      for (auto it = return_counts_map.begin(); it != return_counts_map.end();
+           ++i, ++it) {
+        unique_array.fast(i) = it->first;
+        return_counts_array.fast(i) = it->second;
+      }
+    }
+
+    return std::make_tuple(
+        unique_array, return_inverse_res, return_counts_array);
+  }
+  
+  template <class E>
+  types::ndarray<typename E::dtype, types::pshape<long>> 
+  unique(E const &expr, std::false_type return_index, std::false_type return_inverse,
+         std::false_type return_counts)
+  {
+    return unique(expr);
+  }
+
+  template <class E>
+  std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
+             types::ndarray<long, types::pshape<long>>>
+  unique(E const &expr, std::false_type return_index, std::false_type return_inverse,
+         std::true_type return_counts)
+  {
+    std::map<typename E::dtype, long> return_counts_map;
+    {
+      long i = 0;
+      _unique8(expr.begin(), expr.end(), 
+               return_counts_map, i, utils::int_<E::value>());
+    }
+
+    types::pshape<long> shp{(long)return_counts_map.size()};
+
+    types::ndarray<long, types::pshape<long>> unique_array(shp, builtins::None);
+    types::ndarray<long, types::pshape<long>> return_counts_array(
+        shp, builtins::None);
+
+    {
+      long i = 0;
+      for (auto it = return_counts_map.begin(); it != return_counts_map.end();
+           ++i, ++it) {
+        unique_array.fast(i) = it->first;
+        return_counts_array.fast(i) = it->second;
+      }
+    }
+
+    return std::make_tuple(
+        unique_array, return_counts_array);
   }
 }
 PYTHONIC_NS_END

--- a/pythran/tests/test_numpy_func3.py
+++ b/pythran/tests/test_numpy_func3.py
@@ -443,6 +443,45 @@ def np_trim_zeros2(x):
     def test_unique4(self):
         self.run_test("def np_unique4(x): from numpy import unique ; return unique(x, True, True, True)", numpy.array([1,1,2,2,2,1,5]), np_unique4=[NDArray[int,:]])
 
+    def test_unique5(self):
+        self.run_test("def np_unique5(x): from numpy import unique ; return unique(x, False)", numpy.array([1,1,2,2,2,1,5]), np_unique5=[NDArray[int,:]])
+
+    def test_unique6(self):
+        self.run_test("def np_unique6(x): from numpy import unique ; return unique(x, False, True)", numpy.array([1,1,2,2,2,1,5]), np_unique6=[NDArray[int,:]])
+
+    def test_unique7(self):
+        self.run_test("def np_unique7(x): from numpy import unique ; return unique(x, False, False)", numpy.array([1,1,2,2,2,1,5]), np_unique7=[NDArray[int,:]])
+
+    def test_unique8(self):
+        self.run_test("def np_unique8(x): from numpy import unique ; return unique(x, return_inverse=True)", numpy.array([1,1,2,2,2,1,5]), np_unique8=[NDArray[int,:]])
+
+    def test_unique9(self):
+        self.run_test("def np_unique9(x): from numpy import unique ; return unique(x, True, False)", numpy.array([1,1,2,2,2,1,5]), np_unique9=[NDArray[int,:]])
+
+    def test_unique10(self):
+        self.run_test("def np_unique10(x): from numpy import unique ; return unique(x, True, True, False)", numpy.array([1,1,2,2,2,1,5]), np_unique10=[NDArray[int,:]])
+
+    def test_unique11(self):
+        self.run_test("def np_unique11(x): from numpy import unique ; return unique(x, True, False, False)", numpy.array([1,1,2,2,2,1,5]), np_unique11=[NDArray[int,:]])
+
+    def test_unique12(self):
+        self.run_test("def np_unique12(x): from numpy import unique ; return unique(x, True, False, True)", numpy.array([1,1,2,2,2,1,5]), np_unique12=[NDArray[int,:]])
+
+    def test_unique13(self):
+        self.run_test("def np_unique13(x): from numpy import unique ; return unique(x, False, True, False)", numpy.array([1,1,2,2,2,1,5]), np_unique13=[NDArray[int,:]])
+
+    def test_unique14(self):
+        self.run_test("def np_unique14(x): from numpy import unique ; return unique(x, False, True, True)", numpy.array([1,1,2,2,2,1,5]), np_unique14=[NDArray[int,:]])
+
+    def test_unique15(self):
+        self.run_test("def np_unique15(x): from numpy import unique ; return unique(x, False, False, False)", numpy.array([1,1,2,2,2,1,5]), np_unique15=[NDArray[int,:]])
+
+    def test_unique16(self):
+        self.run_test("def np_unique16(x): from numpy import unique ; return unique(x, False, False, True)", numpy.array([1,1,2,2,2,1,5]), np_unique16=[NDArray[int,:]])
+
+    def test_unique17(self):
+        self.run_test("def np_unique17(x): from numpy import unique ; return unique(x, return_counts=True)", numpy.array([1,1,2,2,2,1,5]), np_unique17=[NDArray[int,:]])
+
     def test_unwrap0(self):
         self.run_test("def np_unwrap0(x): from numpy import unwrap, pi ; x[:3] += 2.6*pi; return unwrap(x)", numpy.arange(6, dtype=float), np_unwrap0=[NDArray[float,:]])
 


### PR DESCRIPTION
https://github.com/serge-sans-paille/pythran/issues/1842#issuecomment-896320261

Hard code boolean arguments in numpy unique, at first, I only consider the case `len(node.args) >= 4` & `return_index` is true & `return_inverse` is true & `return_counts` is true.  

Next:
- [done]consider the case when `len(node.args) == 3` or `2` 
- [done] support `return_index` is true/false & `return_inverse` is true/false & `return_counts` is true/false.  
- use offset to generalize