### PR TITLE
General implementation of supporting immediate arguments

### DIFF
--- a/pythran/analyses/immediates.py
+++ b/pythran/analyses/immediates.py
@@ -17,25 +17,12 @@ class Immediates(NodeAnalysis):
 
     def visit_Call(self, node):
         func_aliases = self.aliases[node.func]
-        if len(func_aliases) == 1 and next(iter(func_aliases)) is MODULES['numpy']['mean']:
-            if len(node.args) >= 5:
-                keepdims = node.args[4]
-                if isinstance(keepdims, ast.Constant):
-                    self.result.add(keepdims)
-
-        if len(func_aliases) == 1 and next(iter(func_aliases)) is MODULES['numpy']['unique']:
-            if len(node.args) >= 2:
-                return_index = node.args[1]
-                if isinstance(return_index, ast.Constant):
-                    self.result.add(return_index)
-            if len(node.args) >= 3:
-                return_inverse = node.args[2]
-                if isinstance(return_inverse, ast.Constant):    
-                    self.result.add(return_inverse)
-            if len(node.args) >= 4:
-                return_counts = node.args[3]
-                if isinstance(return_counts, ast.Constant): 
-                    self.result.add(return_counts)
+        for alias in func_aliases:
+            if getattr(alias, "immediate_arguments", []):
+                for i, arg in enumerate(node.args):
+                    if i in alias.immediate_arguments:
+                        if isinstance(arg, ast.Constant):
+                            self.result.add(arg)
 
         if len(func_aliases) == 1 and next(iter(func_aliases)) is _make_shape:
             self.result.update(a for a in node.args

--- a/pythran/intrinsic.py
+++ b/pythran/intrinsic.py
@@ -118,6 +118,10 @@ class FunctionIntr(Intrinsic):
                         self.return_range = bool_values
         else:
             self.signature = Any
+        if 'immediate_arguments' in kwargs:
+            self.immediate_arguments = kwargs['immediate_arguments']
+        else:
+            self.immediate_arguments = []
 
     def isfunction(self):
         return True

--- a/pythran/tables.py
+++ b/pythran/tables.py
@@ -3819,7 +3819,7 @@ MODULES = {
             REDUCED_BINARY_UFUNC,
             signature=_numpy_binary_op_signature
         ),
-        "mean": ConstMethodIntr(),
+        "mean": ConstMethodIntr(immediate_arguments=[4]),
         "median": ConstFunctionIntr(
             signature=_numpy_unary_op_sum_axis_signature
         ),
@@ -4027,7 +4027,7 @@ MODULES = {
         "uint8": ConstFunctionIntr(signature=_int_signature),
         "ulonglong": ConstFunctionIntr(signature=_int_signature),
         "union1d": ConstFunctionIntr(),
-        "unique": ConstFunctionIntr(),
+        "unique": ConstFunctionIntr(immediate_arguments=[1, 2, 3]),
         "unwrap": ConstFunctionIntr(),
         "unravel_index": ConstFunctionIntr(),
         "ushort": ConstFunctionIntr(signature=_int_signature),


### PR DESCRIPTION
At first, I tried to use keywords name rather than offset:
```
            for k, v in node.kwargs.items():
                if k in alias.immediate_arguments:
                    if isinstance(v, ast.Constant):
                        self.result.add(v)     
```

but got the following error, saying no attribute `kwargs`, so I chose to use offset instead.
```
    def visit_Call(self, node):
        func_aliases = self.aliases[node.func]
        for alias in func_aliases:
>           for k, v in node.kwargs.items():
E           AttributeError: 'Call' object has no attribute 'kwargs'
 
pythran/analyses/immediates.py:21: AttributeError
```
 With my current offset implementation, I can pass the tests for `unique` in my local machine, but I can't pass tests for `mean` even on the master branch on my local machine:

```
------------------------------------------------ Captured stderr call -------------------------------------------------
In file included from /var/folders/j_/zm2rmlh549733gxckfkzj9000000gn/T/tmp2_dotauw.cpp:15:
In file included from /Users/charlotte/Desktop/internship/gsoc/pythran/pythran/pythonic/numpy/mean.hpp:8:
In file included from /Users/charlotte/Desktop/internship/gsoc/pythran/pythran/pythonic/numpy/sum.hpp:5:
In file included from /Users/charlotte/Desktop/internship/gsoc/pythran/pythran/pythonic/numpy/reduce.hpp:9:
In file included from /Users/charlotte/Desktop/internship/gsoc/pythran/pythran/pythonic/utils/neutral.hpp:4:
In file included from /Users/charlotte/Desktop/internship/gsoc/pythran/pythran/pythonic/include/utils/neutral.hpp:8:
In file included from /Users/charlotte/Desktop/internship/gsoc/pythran/pythran/pythonic/include/operator_/imax.hpp:5:
/Users/charlotte/Desktop/internship/gsoc/pythran/pythran/pythonic/include/numpy/maximum.hpp:9:10: fatal error: 'xsimd/xsimd.hpp' file not found
#include <xsimd/xsimd.hpp>
         ^~~~~~~~~~~~~~~~~
1 error generated.
WARNING: Compilation error, trying hard to find its origin...
WARNING: Nop, I'm going to flood you with C++ errors!
```
seems it is related to `xsimd`, do you know how to fix it?

I'll clean the code later :)



