### PR TITLE
Allow implicit conversion for immediate parameter

### DIFF
--- a/pythran/pythonic/include/numpy/mean.hpp
+++ b/pythran/pythonic/include/numpy/mean.hpp
@@ -4,6 +4,7 @@
 #include "pythonic/include/numpy/sum.hpp"
 #include "pythonic/include/numpy/expand_dims.hpp"
 #include "pythonic/include/builtins/None.hpp"
+#include "pythonic/include/types/immediate.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -36,23 +37,24 @@ namespace numpy
 
   template <class E, class dtype = types::none_type>
   auto mean(E const &expr, types::none_type axis = {}, dtype d = {},
-            types::none_type out = {}, std::false_type keep_dims = {})
+            types::none_type out = {}, types::false_immediate keep_dims = {})
       -> decltype(sum(expr, axis, d) /
                   details::dtype_or_double<dtype>(expr.flat_size()));
 
   template <class E, class dtype = types::none_type>
   auto mean(E const &expr, long axis, dtype d = {}, types::none_type out = {},
-            std::false_type keep_dims = {}) -> decltype(sum(expr, axis, d));
+            types::false_immediate keep_dims = {})
+      -> decltype(sum(expr, axis, d));
 
   template <class E, class dtype>
   types::ndarray<details::dtype_or_double<dtype>,
                  typename details::make_scalar_pshape<E::value>::type>
   mean(E const &expr, types::none_type axis, dtype d, types::none_type out,
-       std::true_type keep_dims);
+       types::true_immediate keep_dims);
 
   template <class E, class dtype>
   auto mean(E const &expr, long axis, dtype d, types::none_type out,
-            std::true_type keep_dims)
+            types::true_immediate keep_dims)
       -> decltype(expand_dims(mean(expr, axis, d), axis));
 
   DEFINE_FUNCTOR(pythonic::numpy, mean);

--- a/pythran/pythonic/include/numpy/unique.hpp
+++ b/pythran/pythonic/include/numpy/unique.hpp
@@ -4,6 +4,7 @@
 #include "pythonic/include/utils/functor.hpp"
 #include "pythonic/include/types/ndarray.hpp"
 #include "pythonic/include/types/tuple.hpp"
+#include "pythonic/include/types/immediate.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -15,83 +16,95 @@ namespace numpy
   template <class E>
   std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
              types::ndarray<long, types::pshape<long>>>
-  unique(E const &expr, std::true_type return_index);
+  unique(E const &expr, types::true_immediate return_index);
 
   template <class E>
   types::ndarray<typename E::dtype, types::pshape<long>>
-  unique(E const &expr, std::false_type return_index);
+  unique(E const &expr, types::false_immediate return_index);
 
   template <class E>
   std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
              types::ndarray<long, types::pshape<long>>>
-  unique(E const &expr, std::false_type return_index, std::true_type return_inverse);
+  unique(E const &expr, types::false_immediate return_index,
+         types::true_immediate return_inverse);
 
   template <class E>
   types::ndarray<typename E::dtype, types::pshape<long>>
-  unique(E const &expr, std::false_type return_index, std::false_type return_inverse);
+  unique(E const &expr, types::false_immediate return_index,
+         types::false_immediate return_inverse);
 
   template <class E>
   std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
              types::ndarray<long, types::pshape<long>>>
-  unique(E const &expr, std::true_type return_index, std::false_type return_inverse);
-
-  template <class E>
-  std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
-             types::ndarray<long, types::pshape<long>>,
-             types::ndarray<long, types::pshape<long>>>
-  unique(E const &expr, std::true_type return_index, std::true_type return_inverse);
-
-  template <class E>
-  std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
-             types::ndarray<long, types::pshape<long>>,
-             types::ndarray<long, types::pshape<long>>,
-             types::ndarray<long, types::pshape<long>>>
-  unique(E const &expr, std::true_type return_index, std::true_type return_inverse,
-         std::true_type return_counts);
-  
-  template <class E>
-  std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
-             types::ndarray<long, types::pshape<long>>,
-             types::ndarray<long, types::pshape<long>>>
-  unique(E const &expr, std::true_type return_index, std::true_type return_inverse,
-         std::false_type return_counts);
-
-  template <class E>
-  std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
-             types::ndarray<long, types::pshape<long>>>
-  unique(E const &expr, std::true_type return_index, std::false_type return_inverse,
-         std::false_type return_counts);
+  unique(E const &expr, types::true_immediate return_index,
+         types::false_immediate return_inverse);
 
   template <class E>
   std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
              types::ndarray<long, types::pshape<long>>,
              types::ndarray<long, types::pshape<long>>>
-  unique(E const &expr, std::true_type return_index, std::false_type return_inverse,
-         std::true_type return_counts);
+  unique(E const &expr, types::true_immediate return_index,
+         types::true_immediate return_inverse);
 
   template <class E>
   std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
+             types::ndarray<long, types::pshape<long>>,
+             types::ndarray<long, types::pshape<long>>,
              types::ndarray<long, types::pshape<long>>>
-  unique(E const &expr, std::false_type return_index, std::true_type return_inverse,
-         std::false_type return_counts);
+  unique(E const &expr, types::true_immediate return_index,
+         types::true_immediate return_inverse,
+         types::true_immediate return_counts);
 
   template <class E>
   std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
              types::ndarray<long, types::pshape<long>>,
              types::ndarray<long, types::pshape<long>>>
-  unique(E const &expr, std::false_type return_index, std::true_type return_inverse,
-         std::true_type return_counts);
-
-  template <class E>
-  types::ndarray<typename E::dtype, types::pshape<long>> 
-  unique(E const &expr, std::false_type return_index, std::false_type return_inverse,
-         std::false_type return_counts);
+  unique(E const &expr, types::true_immediate return_index,
+         types::true_immediate return_inverse,
+         types::false_immediate return_counts);
 
   template <class E>
   std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
              types::ndarray<long, types::pshape<long>>>
-  unique(E const &expr, std::false_type return_index, std::false_type return_inverse,
-         std::true_type return_counts);
+  unique(E const &expr, types::true_immediate return_index,
+         types::false_immediate return_inverse,
+         types::false_immediate return_counts);
+
+  template <class E>
+  std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
+             types::ndarray<long, types::pshape<long>>,
+             types::ndarray<long, types::pshape<long>>>
+  unique(E const &expr, types::true_immediate return_index,
+         types::false_immediate return_inverse,
+         types::true_immediate return_counts);
+
+  template <class E>
+  std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
+             types::ndarray<long, types::pshape<long>>>
+  unique(E const &expr, types::false_immediate return_index,
+         types::true_immediate return_inverse,
+         types::false_immediate return_counts);
+
+  template <class E>
+  std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
+             types::ndarray<long, types::pshape<long>>,
+             types::ndarray<long, types::pshape<long>>>
+  unique(E const &expr, types::false_immediate return_index,
+         types::true_immediate return_inverse,
+         types::true_immediate return_counts);
+
+  template <class E>
+  types::ndarray<typename E::dtype, types::pshape<long>>
+  unique(E const &expr, types::false_immediate return_index,
+         types::false_immediate return_inverse,
+         types::false_immediate return_counts);
+
+  template <class E>
+  std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
+             types::ndarray<long, types::pshape<long>>>
+  unique(E const &expr, types::false_immediate return_index,
+         types::false_immediate return_inverse,
+         types::true_immediate return_counts);
 
   DEFINE_FUNCTOR(pythonic::numpy, unique)
 }

--- a/pythran/pythonic/include/types/immediate.hpp
+++ b/pythran/pythonic/include/types/immediate.hpp
@@ -1,0 +1,33 @@
+#ifndef PYTHONIC_INCLUDE_TYPES_IMMEDIATE_HPP
+#define PYTHONIC_INCLUDE_TYPES_IMMEDIATE_HPP
+
+PYTHONIC_NS_BEGIN
+
+namespace types
+{
+
+  template <class T, T Val>
+  struct immediate {
+    immediate() = default;
+    immediate(immediate const &) = default;
+    immediate(immediate &&) = default;
+
+    operator T() const
+    {
+      return Val;
+    }
+
+    template <class U, U Wal,
+              class _ = typename std::enable_if<Val == (T)Wal, void>::type>
+    immediate(std::integral_constant<U, Wal>)
+    {
+    }
+  };
+
+  using true_immediate = immediate<bool, true>;
+  using false_immediate = immediate<bool, false>;
+}
+
+PYTHONIC_NS_END
+
+#endif

--- a/pythran/pythonic/numpy/mean.hpp
+++ b/pythran/pythonic/numpy/mean.hpp
@@ -15,7 +15,7 @@ namespace numpy
 
   template <class E, class dtype>
   auto mean(E const &expr, types::none_type axis, dtype d, types::none_type out,
-            std::false_type keepdims)
+            types::false_immediate keepdims)
       -> decltype(sum(expr, axis, d) /
                   details::dtype_or_double<dtype>(expr.flat_size()))
   {
@@ -25,7 +25,7 @@ namespace numpy
 
   template <class E, class dtype>
   auto mean(E const &expr, long axis, dtype d, types::none_type out,
-            std::false_type keepdims) -> decltype(sum(expr, axis, d))
+            types::false_immediate keepdims) -> decltype(sum(expr, axis, d))
   {
     return sum(expr, axis, d) /=
            details::dtype_or_double<dtype>(sutils::getshape(expr)[axis]);
@@ -35,7 +35,7 @@ namespace numpy
   types::ndarray<details::dtype_or_double<dtype>,
                  typename details::make_scalar_pshape<E::value>::type>
   mean(E const &expr, types::none_type axis, dtype d, types::none_type out,
-       std::true_type keep_dims)
+       types::true_immediate keep_dims)
   {
     return {typename details::make_scalar_pshape<E::value>::type(),
             mean(expr, axis, d, out)};
@@ -43,7 +43,7 @@ namespace numpy
 
   template <class E, class dtype>
   auto mean(E const &expr, long axis, dtype d, types::none_type out,
-            std::true_type keepdims)
+            types::true_immediate keepdims)
       -> decltype(expand_dims(mean(expr, axis, d), axis))
   {
     return expand_dims(mean(expr, axis, d), axis);

--- a/pythran/pythonic/numpy/unique.hpp
+++ b/pythran/pythonic/numpy/unique.hpp
@@ -88,8 +88,7 @@ namespace numpy
                  utils::int_<N - 1>());
     }
     template <class I, class O0, class O2>
-    void _unique5(I begin, I end, O0 &out0, O2 &out2, long &i,
-                  utils::int_<1>)
+    void _unique5(I begin, I end, O0 &out0, O2 &out2, long &i, utils::int_<1>)
     {
       for (; begin != end; ++begin, ++i) {
         auto pair = out0.insert(*begin);
@@ -97,8 +96,7 @@ namespace numpy
       }
     }
     template <class I, class O0, class O2, size_t N>
-    void _unique5(I begin, I end, O0 &out0, O2 &out2, long &i,
-                  utils::int_<N>)
+    void _unique5(I begin, I end, O0 &out0, O2 &out2, long &i, utils::int_<N>)
     {
       for (; begin != end; ++begin)
         _unique5((*begin).begin(), (*begin).end(), out0, out2, i,
@@ -106,8 +104,7 @@ namespace numpy
     }
 
     template <class I, class O1, class O3>
-    void _unique6(I begin, I end, O1 &out1, O3 &out3, long &i,
-                  utils::int_<1>)
+    void _unique6(I begin, I end, O1 &out1, O3 &out3, long &i, utils::int_<1>)
     {
       for (; begin != end; ++begin, ++i) {
         auto res = out3.insert(std::make_pair(*begin, 0));
@@ -118,8 +115,7 @@ namespace numpy
       }
     }
     template <class I, class O1, class O3, size_t N>
-    void _unique6(I begin, I end, O1 &out1, O3 &out3, long &i,
-                  utils::int_<N>)
+    void _unique6(I begin, I end, O1 &out1, O3 &out3, long &i, utils::int_<N>)
     {
       for (; begin != end; ++begin)
         _unique6((*begin).begin(), (*begin).end(), out1, out3, i,
@@ -127,8 +123,7 @@ namespace numpy
     }
 
     template <class I, class O2, class O3>
-    void _unique7(I begin, I end, O2 &out2, O3 &out3, long &i,
-                  utils::int_<1>)
+    void _unique7(I begin, I end, O2 &out2, O3 &out3, long &i, utils::int_<1>)
     {
       for (; begin != end; ++begin, ++i) {
         auto res = out3.insert(std::make_pair(*begin, 0));
@@ -137,8 +132,7 @@ namespace numpy
       }
     }
     template <class I, class O2, class O3, size_t N>
-    void _unique7(I begin, I end, O2 &out2, O3 &out3, long &i,
-                  utils::int_<N>)
+    void _unique7(I begin, I end, O2 &out2, O3 &out3, long &i, utils::int_<N>)
     {
       for (; begin != end; ++begin)
         _unique7((*begin).begin(), (*begin).end(), out2, out3, i,
@@ -146,17 +140,15 @@ namespace numpy
     }
 
     template <class I, class O3>
-    void _unique8(I begin, I end, O3 &out3, long &i,
-                  utils::int_<1>)
+    void _unique8(I begin, I end, O3 &out3, long &i, utils::int_<1>)
     {
       for (; begin != end; ++begin, ++i) {
         auto res = out3.insert(std::make_pair(*begin, 0));
         res.first->second += 1;
       }
     }
-    template <class I,  class O3, size_t N>
-    void _unique8(I begin, I end, O3 &out3, long &i,
-                  utils::int_<N>)
+    template <class I, class O3, size_t N>
+    void _unique8(I begin, I end, O3 &out3, long &i, utils::int_<N>)
     {
       for (; begin != end; ++begin)
         _unique8((*begin).begin(), (*begin).end(), out3, i,
@@ -175,7 +167,7 @@ namespace numpy
   template <class E>
   std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
              types::ndarray<long, types::pshape<long>>>
-  unique(E const &expr, std::true_type return_index)
+  unique(E const &expr, types::true_immediate return_index)
   {
     std::set<typename E::dtype> res;
     std::vector<long> return_index_res;
@@ -189,7 +181,7 @@ namespace numpy
 
   template <class E>
   types::ndarray<typename E::dtype, types::pshape<long>>
-  unique(E const &expr, std::false_type return_index)
+  unique(E const &expr, types::false_immediate return_index)
   {
     std::set<typename E::dtype> res;
     _unique1(expr.begin(), expr.end(), res, utils::int_<E::value>());
@@ -199,14 +191,15 @@ namespace numpy
   template <class E>
   std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
              types::ndarray<long, types::pshape<long>>>
-  unique(E const &expr, std::false_type return_index, std::true_type return_inverse)
+  unique(E const &expr, types::false_immediate return_index,
+         types::true_immediate return_inverse)
   {
     std::set<typename E::dtype> res;
     types::ndarray<long, types::pshape<long>> return_inverse_res(
         types::pshape<long>{expr.flat_size()}, builtins::None);
     long i = 0;
-    _unique5(expr.begin(), expr.end(), res, 
-             return_inverse_res, i, utils::int_<E::value>());
+    _unique5(expr.begin(), expr.end(), res, return_inverse_res, i,
+             utils::int_<E::value>());
     return std::make_tuple(
         types::ndarray<typename E::dtype, types::pshape<long>>(res),
         return_inverse_res);
@@ -214,7 +207,8 @@ namespace numpy
 
   template <class E>
   types::ndarray<typename E::dtype, types::pshape<long>>
-  unique(E const &expr, std::false_type return_index, std::false_type return_inverse)
+  unique(E const &expr, types::false_immediate return_index,
+         types::false_immediate return_inverse)
   {
     std::set<typename E::dtype> res;
     _unique1(expr.begin(), expr.end(), res, utils::int_<E::value>());
@@ -224,7 +218,8 @@ namespace numpy
   template <class E>
   std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
              types::ndarray<long, types::pshape<long>>>
-  unique(E const &expr, std::true_type return_index, std::false_type return_inverse)
+  unique(E const &expr, types::true_immediate return_index,
+         types::false_immediate return_inverse)
   {
     return unique(expr, return_index);
   }
@@ -233,7 +228,8 @@ namespace numpy
   std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
              types::ndarray<long, types::pshape<long>>,
              types::ndarray<long, types::pshape<long>>>
-  unique(E const &expr, std::true_type return_index, std::true_type return_inverse)
+  unique(E const &expr, types::true_immediate return_index,
+         types::true_immediate return_inverse)
   {
     assert(return_inverse && "invalid signature otherwise");
 
@@ -255,8 +251,9 @@ namespace numpy
              types::ndarray<long, types::pshape<long>>,
              types::ndarray<long, types::pshape<long>>,
              types::ndarray<long, types::pshape<long>>>
-  unique(E const &expr, std::true_type return_index, std::true_type return_inverse,
-         std::true_type return_counts)
+  unique(E const &expr, types::true_immediate return_index,
+         types::true_immediate return_inverse,
+         types::true_immediate return_counts)
   {
     assert(return_counts && "invalid signature otherwise");
 
@@ -296,8 +293,9 @@ namespace numpy
   std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
              types::ndarray<long, types::pshape<long>>,
              types::ndarray<long, types::pshape<long>>>
-  unique(E const &expr, std::true_type return_index, std::true_type return_inverse,
-         std::false_type return_counts)
+  unique(E const &expr, types::true_immediate return_index,
+         types::true_immediate return_inverse,
+         types::false_immediate return_counts)
   {
     return unique(expr, return_index, return_inverse);
   }
@@ -305,8 +303,9 @@ namespace numpy
   template <class E>
   std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
              types::ndarray<long, types::pshape<long>>>
-  unique(E const &expr, std::true_type return_index, std::false_type return_inverse,
-         std::false_type return_counts)
+  unique(E const &expr, types::true_immediate return_index,
+         types::false_immediate return_inverse,
+         types::false_immediate return_counts)
   {
     return unique(expr, return_index);
   }
@@ -315,16 +314,17 @@ namespace numpy
   std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
              types::ndarray<long, types::pshape<long>>,
              types::ndarray<long, types::pshape<long>>>
-  unique(E const &expr, std::true_type return_index, std::false_type return_inverse,
-         std::true_type return_counts)
+  unique(E const &expr, types::true_immediate return_index,
+         types::false_immediate return_inverse,
+         types::true_immediate return_counts)
   {
     std::vector<long> return_index_res;
 
     std::map<typename E::dtype, long> return_counts_map;
     {
       long i = 0;
-      _unique6(expr.begin(), expr.end(), return_index_res, 
-               return_counts_map, i, utils::int_<E::value>());
+      _unique6(expr.begin(), expr.end(), return_index_res, return_counts_map, i,
+               utils::int_<E::value>());
     }
 
     types::pshape<long> shp{(long)return_counts_map.size()};
@@ -351,8 +351,9 @@ namespace numpy
   template <class E>
   std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
              types::ndarray<long, types::pshape<long>>>
-  unique(E const &expr, std::false_type return_index, std::true_type return_inverse,
-         std::false_type return_counts)
+  unique(E const &expr, types::false_immediate return_index,
+         types::true_immediate return_inverse,
+         types::false_immediate return_counts)
   {
     return unique(expr, return_index, return_inverse);
   }
@@ -361,8 +362,9 @@ namespace numpy
   std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
              types::ndarray<long, types::pshape<long>>,
              types::ndarray<long, types::pshape<long>>>
-  unique(E const &expr, std::false_type return_index, std::true_type return_inverse,
-         std::true_type return_counts)
+  unique(E const &expr, types::false_immediate return_index,
+         types::true_immediate return_inverse,
+         types::true_immediate return_counts)
   {
     types::ndarray<long, types::pshape<long>> return_inverse_res(
         types::pshape<long>{expr.flat_size()}, builtins::None);
@@ -370,8 +372,8 @@ namespace numpy
     std::map<typename E::dtype, long> return_counts_map;
     {
       long i = 0;
-      _unique7(expr.begin(), expr.end(), return_inverse_res,
-               return_counts_map, i, utils::int_<E::value>());
+      _unique7(expr.begin(), expr.end(), return_inverse_res, return_counts_map,
+               i, utils::int_<E::value>());
     }
 
     types::pshape<long> shp{(long)return_counts_map.size()};
@@ -389,14 +391,15 @@ namespace numpy
       }
     }
 
-    return std::make_tuple(
-        unique_array, return_inverse_res, return_counts_array);
+    return std::make_tuple(unique_array, return_inverse_res,
+                           return_counts_array);
   }
-  
+
   template <class E>
-  types::ndarray<typename E::dtype, types::pshape<long>> 
-  unique(E const &expr, std::false_type return_index, std::false_type return_inverse,
-         std::false_type return_counts)
+  types::ndarray<typename E::dtype, types::pshape<long>>
+  unique(E const &expr, types::false_immediate return_index,
+         types::false_immediate return_inverse,
+         types::false_immediate return_counts)
   {
     return unique(expr);
   }
@@ -404,14 +407,15 @@ namespace numpy
   template <class E>
   std::tuple<types::ndarray<typename E::dtype, types::pshape<long>>,
              types::ndarray<long, types::pshape<long>>>
-  unique(E const &expr, std::false_type return_index, std::false_type return_inverse,
-         std::true_type return_counts)
+  unique(E const &expr, types::false_immediate return_index,
+         types::false_immediate return_inverse,
+         types::true_immediate return_counts)
   {
     std::map<typename E::dtype, long> return_counts_map;
     {
       long i = 0;
-      _unique8(expr.begin(), expr.end(), 
-               return_counts_map, i, utils::int_<E::value>());
+      _unique8(expr.begin(), expr.end(), return_counts_map, i,
+               utils::int_<E::value>());
     }
 
     types::pshape<long> shp{(long)return_counts_map.size()};
@@ -429,8 +433,7 @@ namespace numpy
       }
     }
 
-    return std::make_tuple(
-        unique_array, return_counts_array);
+    return std::make_tuple(unique_array, return_counts_array);
   }
 }
 PYTHONIC_NS_END

--- a/pythran/tests/test_numpy_func0.py
+++ b/pythran/tests/test_numpy_func0.py
@@ -301,7 +301,7 @@ def np_rosen_der(x):
         self.run_test("def np_mean10(a): from numpy import mean ; return mean(a, 2, dtype=int, keepdims=True)", numpy.array([[[0, 2], [3, 4.]]]), np_mean10=[NDArray[float,:,:,:]])
 
     def test_mean11(self):
-        self.run_test("def np_mean11(a): from numpy import mean ; return mean(a, 2, keepdims=True)", numpy.array([[[1, 2], [3, 4.]]]), np_mean11=[NDArray[float,:,:,:]])
+        self.run_test("def np_mean11(a): from numpy import mean ; return mean(a, 2, keepdims=1)", numpy.array([[[1, 2], [3, 4.]]]), np_mean11=[NDArray[float,:,:,:]])
 
     def test_mean12(self):
         self.run_test("def np_mean12(a): from numpy import mean ; return mean(a, keepdims=True)", numpy.array([[[1, 2], [3, 4.]]]), np_mean12=[NDArray[float,:,:,:]])

--- a/pythran/tests/test_numpy_func3.py
+++ b/pythran/tests/test_numpy_func3.py
@@ -480,7 +480,7 @@ def np_trim_zeros2(x):
         self.run_test("def np_unique16(x): from numpy import unique ; return unique(x, False, False, True)", numpy.array([1,1,2,2,2,1,5]), np_unique16=[NDArray[int,:]])
 
     def test_unique17(self):
-        self.run_test("def np_unique17(x): from numpy import unique ; return unique(x, return_counts=True)", numpy.array([1,1,2,2,2,1,5]), np_unique17=[NDArray[int,:]])
+        self.run_test("def np_unique17(x): from numpy import unique ; return unique(x, return_counts=1)", numpy.array([1,1,2,2,2,1,5]), np_unique17=[NDArray[int,:]])
 
     def test_unwrap0(self):
         self.run_test("def np_unwrap0(x): from numpy import unwrap, pi ; x[:3] += 2.6*pi; return unwrap(x)", numpy.arange(6, dtype=float), np_unwrap0=[NDArray[float,:]])


### PR DESCRIPTION
This allows to pass keep_dims=1 even though a bool is expected.