### PR TITLE
Provide an extra assert overload without default argument

### DIFF
--- a/pythran/pythonic/builtins/assert.hpp
+++ b/pythran/pythonic/builtins/assert.hpp
@@ -8,6 +8,14 @@
 
 PYTHONIC_NS_BEGIN
 
+void pythran_assert(bool cond)
+{
+#ifndef NDEBUG
+  if (!cond)
+    throw types::AssertionError();
+#endif
+}
+
 void pythran_assert(bool cond, types::str const &what)
 {
 #ifndef NDEBUG

--- a/pythran/pythonic/include/builtins/assert.hpp
+++ b/pythran/pythonic/include/builtins/assert.hpp
@@ -4,7 +4,8 @@
 #include "pythonic/include/types/str.hpp"
 
 PYTHONIC_NS_BEGIN
-void pythran_assert(bool cond, types::str const &what = "");
+void pythran_assert(bool cond);
+void pythran_assert(bool cond, types::str const &what);
 PYTHONIC_NS_END
 
 #endif


### PR DESCRIPTION
Otherwise the creation of the optional argument is not costless, which prevents
``assert cond`` to be a no-op under -DNDEBUG