### PR TITLE
Fix corner case when a numpy_gexpr is initialized from another gexpr

### DIFF
--- a/pythran/pythonic/include/types/tuple.hpp
+++ b/pythran/pythonic/include/types/tuple.hpp
@@ -144,10 +144,12 @@ namespace types
   {
     return value;
   }
-  template <long N>
+
+  template <long N, long P>
   std::integral_constant<long, N> check_type(std::integral_constant<long, N>,
-                                             std::integral_constant<long, N>)
+                                             std::integral_constant<long, P>)
   {
+    assert(N == P && "consistent init");
     return {};
   }
   template <long N>

--- a/pythran/pythonic/types/numpy_gexpr.hpp
+++ b/pythran/pythonic/types/numpy_gexpr.hpp
@@ -442,6 +442,8 @@ namespace types
       buffer = arg.buffer + (expr.buffer - expr.arg.buffer);
       _shape = expr._shape;
       _strides = expr._strides;
+      assert(sutils::getshape(*this) == sutils::getshape(expr) &&
+             "compatible sizes");
       return *this;
     } else {
       return _copy(expr);


### PR DESCRIPTION
But with a different, static shape, which may trigger an irrelevant static
check. Replace the check by an assert.