### PR TITLE
completed portability of include-paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ docs/AUTHORS.rst
 docs/SUPPORT.rst
 
 docs/_build/*
+/.project
+/.pydevproject
+/_rbfinterp_pythran.cpp

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,3 @@ docs/AUTHORS.rst
 docs/SUPPORT.rst
 
 docs/_build/*
-/.project
-/.pydevproject
-/_rbfinterp_pythran.cpp

--- a/pythran/types/type_dependencies.py
+++ b/pythran/types/type_dependencies.py
@@ -46,8 +46,8 @@ def pytype_to_deps(t):
     """ python -> pythonic type header full path. """
     res = set()
     for hpp_dep in pytype_to_deps_hpp(t):
-        res.add(os.path.join('pythonic', 'types', hpp_dep))
-        res.add(os.path.join('pythonic', 'include', 'types', hpp_dep))
+        res.add('/'.join(["pythonic", "types", hpp_dep]))
+        res.add('/'.join(['pythonic', 'include', 'types', hpp_dep]))
     return res
 
 


### PR DESCRIPTION
Hi @serge-sans-paille 

I recognize that because you may not have access to a Windows Platform, you may find it cumbersome debugging the fix towards portable include paths.  For this reason I have **_attempted_** to complete the fix myself, since I use a Windows Platform.

So far it is working on my side.  But please take a look at the diffs to see if I did it correctly. 