### PR TITLE
BUG: use implementation-specific python_version

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python-version: [3.6, 3.8, 3.9, 3.10-dev, pypy-3.7]
+        python-version: [3.6, 3.8, 3.9, 3.10-dev, pypy-3.8]
         cpp-version: [g++-5, clang-5.0]
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python-version: [3.6, 3.8, 3.9, 3.10-dev]
+        python-version: [3.6, 3.8, 3.9, 3.10-dev, pypy-3.7]
         cpp-version: [g++-5, clang-5.0]
     steps:
     - uses: actions/checkout@v2

--- a/pythran/tests/test_distutils.py
+++ b/pythran/tests/test_distutils.py
@@ -7,7 +7,13 @@ import sysconfig
 import unittest
 
 cwd = os.path.dirname(__file__)
-python_version = "python{}.{}".format(sys.version_info.major,
+
+def _get_implementation():
+    if sys.implementation.name == 'pypy':
+        return 'pypy'
+    return 'python'
+
+python_version = "{}{}.{}".format(_get_implementation(), sys.version_info.major,
                                       sys.version_info.minor)
 
 def find_so(name, path):


### PR DESCRIPTION
Over at pypy/binary-testing there are [pythran runs](https://github.com/pypy/binary-testing/actions/workflows/pythran.yml) against pypy3.8 and pypy3.9 on ubuntu and windows. The windows tests pass, the ubuntu ones fail. One problem is this test which looks for the build product in an implementation-specific directory. I copied the code PyPy uses in `Lib/sysconfig.py` to determine the correct `python_version`.