### PR TITLE
Add default constructor to string_iterator

### DIFF
--- a/pythran/pythonic/include/types/str.hpp
+++ b/pythran/pythonic/include/types/str.hpp
@@ -231,6 +231,7 @@ namespace types
   struct string_iterator : std::iterator<std::random_access_iterator_tag, str,
                                          std::ptrdiff_t, str *, str> {
     std::string::const_iterator curr;
+    string_iterator() = default;
     string_iterator(std::string::const_iterator iter) : curr(iter)
     {
     }


### PR DESCRIPTION
A type must be default constructible to meet the forward iterator requirements.
GCC 12 won't compile `std::reverse_iterator<string_iterator>` without
this change.