### PR TITLE
Remove template argument list from destructor name

### DIFF
--- a/pythran/pythonic/types/variant_functor.hpp
+++ b/pythran/pythonic/types/variant_functor.hpp
@@ -112,7 +112,7 @@ namespace types
     }
 
     template <class Type>
-    variant_functor_impl<Type>::~variant_functor_impl<Type>()
+    variant_functor_impl<Type>::~variant_functor_impl()
     {
       if (fun != nullptr)
         fun->~Type();


### PR DESCRIPTION
This is not valid since C++20, see https://wg21.link/cwg2237