### PR TITLE
Avoid useless computations in argument_effects

### DIFF
--- a/pythran/graph.py
+++ b/pythran/graph.py
@@ -29,6 +29,9 @@ class DiGraph(object):
     def edges(self):
         return self._edges
 
+    def has_edge(self, src, dest):
+        return dest in self._adjacency[src]
+
     def remove_edge(self, src, dest):
         self._adjacency[src].remove(dest)
         del self._edges[(src, dest)]


### PR DESCRIPTION
intrinsic argument effect propagation is already taken care of in the
Call handler, there's no need to propagate this information back again.

Harder, Better, Faster, Stronger.