### PR TITLE
Don't use removed sysconfig.get_config_vars()["SO"] in a doctest

### DIFF
--- a/pythran/toolchain.py
+++ b/pythran/toolchain.py
@@ -451,7 +451,7 @@ def compile_pythranfile(file_path, output_file=None, module_name=None,
     Specify the output file:
 
     >>> import sysconfig
-    >>> ext = sysconfig.get_config_vars()["SO"]
+    >>> ext = sysconfig.get_config_vars()["EXT_SUFFIX"]
     >>> so_path = compile_pythranfile('pythran_test.py', output_file='foo'+ext)
     """
     if not output_file:


### PR DESCRIPTION
This was removed from Python 3.11+, see https://github.com/python/cpython/issues/91670