### PR TITLE
Introduce --config=backend.annotate=true

### DIFF
--- a/docs/MANUAL.rst
+++ b/docs/MANUAL.rst
@@ -627,6 +627,15 @@ Another internal setting stuff. This controls the accuracy of the typing phase. 
     # This algorithms generates code difficult to compile for g++, but not clang++
     enable_two_steps_typing = False
 
+``[backend]``
+*************
+
+This controls some behavior of the C++ backend, so the default should be safe::
+
+    # set to true if you want intermediate C++ code to be annotated with a reference
+    # to the original python code
+    annotate = false
+
 
 F.A.Q.
 ------

--- a/docs/TUTORIAL.rst
+++ b/docs/TUTORIAL.rst
@@ -53,10 +53,10 @@ One first need to instantiate a pass manager with a module name::
   >>> from pythran import passmanager
   >>> pm = passmanager.PassManager("tutorial_module")
 
-The pass manager has 3 methods and two attributes::
+The pass manager has three methods and three attributes::
 
   >>> [x for x in dir(pm) if not x.startswith('_')]
-  ['apply', 'dump', 'gather', 'module_dir', 'module_name']
+  ['apply', 'code', 'dump', 'gather', 'module_dir', 'module_name']
 
 ``apply``
     applies a code transformation

--- a/pythran/cxxgen.py
+++ b/pythran/cxxgen.py
@@ -314,6 +314,15 @@ class Label(object):
     def generate(self):
         yield self.label + ':;'
 
+class LineInfo(object):
+    def __init__(self, filepath, lineno):
+        self.filepath = filepath
+        self.lineno = lineno
+
+    def generate(self):
+        if self.filename and self.lineno:
+            yield '#line {} {}'.format(self.lineno, self.filepath)
+
 
 class Statement(object):
     def __init__(self, text):
@@ -332,6 +341,16 @@ class AnnotatedStatement(object):
         for directive in self.annotations:
             pragma = "#pragma " + directive.s
             yield pragma.format(*directive.deps)
+        for s in self.stmt.generate():
+            yield s
+
+class StatementWithComments(object):
+    def __init__(self, stmt, comment):
+        self.stmt = stmt
+        self.comment = comment
+
+    def generate(self):
+        yield '// {}'.format(self.comment)
         for s in self.stmt.generate():
             yield s
 

--- a/pythran/passmanager.py
+++ b/pythran/passmanager.py
@@ -205,9 +205,10 @@ class PassManager(object):
     '''
     Front end to the pythran pass system.
     '''
-    def __init__(self, module_name, module_dir=None):
+    def __init__(self, module_name, module_dir=None, code=None):
         self.module_name = module_name
         self.module_dir = module_dir or os.getcwd()
+        self.code = code
         self._cache = {}
 
     def gather(self, analysis, node, run_times = None):

--- a/pythran/pythran.cfg
+++ b/pythran/pythran.cfg
@@ -40,3 +40,9 @@ enable_two_steps_typing = False
 # above this number of overloads, pythran specifications are considered invalid
 # as it generates ultra-large binaries
 max_export_overloads = 128
+
+[backend]
+
+# set to true if you want intermediate C++ code to be annotated with a reference
+# to the original python code
+annotate = false

--- a/pythran/toolchain.py
+++ b/pythran/toolchain.py
@@ -90,7 +90,7 @@ def front_middle_end(module_name, code, optimizations=None, module_dir=None,
                      entry_points=None, report_times = False):
     """Front-end and middle-end compilation steps"""
 
-    pm = PassManager(module_name, module_dir)
+    pm = PassManager(module_name, module_dir, code)
 
     # front end
     ir, docstrings = frontend.parse(pm, code)


### PR DESCRIPTION
When on, this option generates chunk of python code as comments within the C++
code, making it easier to track failures.

Fix #2001