### PR TITLE
TEST: skip deprected np.alen, np.asscalar

### DIFF
--- a/pythran/tests/test_numpy_func1.py
+++ b/pythran/tests/test_numpy_func1.py
@@ -2,8 +2,12 @@ import unittest
 import sys
 from pythran.tests import TestEnv
 import numpy
+from packaging import version
 
 from pythran.typing import NDArray, List
+
+
+np_version = version.parse(numpy.version.version)
 
 
 @TestEnv.module
@@ -207,9 +211,11 @@ class TestNumpyFunc1(TestEnv):
     def test_transpose3_(self):
         self.run_test("def np_transpose3_(a): return a.transpose(2,1,0)", numpy.arange(24).reshape(2,3,4), np_transpose3_=[NDArray[int,:,:,:]])
 
+    @unittest.skipIf(np_version >= (1, 18), reason="np.alen is deprecated")
     def test_alen0(self):
         self.run_test("def np_alen0(a): from numpy import alen ; return alen(a)", numpy.ones((5,6)), np_alen0=[NDArray[float,:,:]])
 
+    @unittest.skipIf(np_version >= (1, 18), reason="np.alen is deprecated")
     def test_alen1(self):
         self.run_test("def np_alen1(a): from numpy import alen ; return alen(-a)", numpy.ones((5,6)), np_alen1=[NDArray[float,:,:]])
 

--- a/pythran/tests/test_numpy_func2.py
+++ b/pythran/tests/test_numpy_func2.py
@@ -1,8 +1,12 @@
 import unittest
 from pythran.tests import TestEnv
 import numpy
+from packaging import version
 
 from pythran.typing import NDArray, List, Tuple
+
+
+np_version = version.parse(numpy.version.version)
 
 
 @TestEnv.module
@@ -463,9 +467,11 @@ def test_copy0(x):
     def test_atleast_3d3(self):
         self.run_test("def np_atleast_3d3(a): from numpy import atleast_3d ; r = atleast_3d(a) ; return r", numpy.arange(8), np_atleast_3d3=[NDArray[int,:]])
 
+    @unittest.skipIf(np_version >= (1, 16), reason="np.asscalar is deprecated")
     def test_asscalar0(self):
         self.run_test("def np_asscalar0(a): from numpy import asscalar; return asscalar(a)", numpy.array([1], numpy.int32), np_asscalar0=[NDArray[numpy.int32,:]])
 
+    @unittest.skipIf(np_version >= (1, 16), reason="np.asscalar is deprecated")
     def test_asscalar1(self):
         self.run_test("def np_asscalar1(a): from numpy import asscalar; return asscalar(a)", numpy.array([[1]], numpy.int64), np_asscalar1=[NDArray[numpy.int64,:,:]])
 


### PR DESCRIPTION
Fixes #2006 by skipping tests with the deprecated np.alen and np.asscalar