### PR TITLE
Do not throw error for boost.special functions

### DIFF
--- a/pythran/pythonic/scipy/special/binom.hpp
+++ b/pythran/pythonic/scipy/special/binom.hpp
@@ -7,7 +7,7 @@
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
 
-#define BOOST_MATH_THREAD_LOCAL thread_local
+#include "pythonic/utils/boost_local_config.hpp"
 #include <boost/math/special_functions/binomial.hpp>
 
 PYTHONIC_NS_BEGIN

--- a/pythran/pythonic/scipy/special/hankel1.hpp
+++ b/pythran/pythonic/scipy/special/hankel1.hpp
@@ -8,7 +8,7 @@
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
 
-#define BOOST_MATH_THREAD_LOCAL thread_local
+#include "pythonic/utils/boost_local_config.hpp"
 #include <boost/math/special_functions/hankel.hpp>
 
 PYTHONIC_NS_BEGIN

--- a/pythran/pythonic/scipy/special/hankel2.hpp
+++ b/pythran/pythonic/scipy/special/hankel2.hpp
@@ -8,7 +8,7 @@
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
 
-#define BOOST_MATH_THREAD_LOCAL thread_local
+#include "pythonic/utils/boost_local_config.hpp"
 #include <boost/math/special_functions/hankel.hpp>
 
 PYTHONIC_NS_BEGIN

--- a/pythran/pythonic/scipy/special/iv.hpp
+++ b/pythran/pythonic/scipy/special/iv.hpp
@@ -7,7 +7,7 @@
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
 
-#define BOOST_MATH_THREAD_LOCAL thread_local
+#include "pythonic/utils/boost_local_config.hpp"
 #include <boost/math/special_functions/bessel.hpp>
 
 PYTHONIC_NS_BEGIN

--- a/pythran/pythonic/scipy/special/ivp.hpp
+++ b/pythran/pythonic/scipy/special/ivp.hpp
@@ -7,7 +7,7 @@
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
 
-#define BOOST_MATH_THREAD_LOCAL thread_local
+#include "pythonic/utils/boost_local_config.hpp"
 #include <boost/math/special_functions/bessel_prime.hpp>
 
 PYTHONIC_NS_BEGIN

--- a/pythran/pythonic/scipy/special/jv.hpp
+++ b/pythran/pythonic/scipy/special/jv.hpp
@@ -7,7 +7,7 @@
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
 
-#define BOOST_MATH_THREAD_LOCAL thread_local
+#include "pythonic/utils/boost_local_config.hpp"
 #include <boost/math/special_functions/bessel.hpp>
 
 PYTHONIC_NS_BEGIN

--- a/pythran/pythonic/scipy/special/jvp.hpp
+++ b/pythran/pythonic/scipy/special/jvp.hpp
@@ -7,7 +7,7 @@
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
 
-#define BOOST_MATH_THREAD_LOCAL thread_local
+#include "pythonic/utils/boost_local_config.hpp"
 #include <boost/math/special_functions/bessel_prime.hpp>
 
 PYTHONIC_NS_BEGIN

--- a/pythran/pythonic/scipy/special/kv.hpp
+++ b/pythran/pythonic/scipy/special/kv.hpp
@@ -7,7 +7,7 @@
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
 
-#define BOOST_MATH_THREAD_LOCAL thread_local
+#include "pythonic/utils/boost_local_config.hpp"
 #include <boost/math/special_functions/bessel.hpp>
 
 PYTHONIC_NS_BEGIN

--- a/pythran/pythonic/scipy/special/kvp.hpp
+++ b/pythran/pythonic/scipy/special/kvp.hpp
@@ -7,7 +7,7 @@
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
 
-#define BOOST_MATH_THREAD_LOCAL thread_local
+#include "pythonic/utils/boost_local_config.hpp"
 #include <boost/math/special_functions/bessel_prime.hpp>
 
 PYTHONIC_NS_BEGIN

--- a/pythran/pythonic/scipy/special/spherical_jn.hpp
+++ b/pythran/pythonic/scipy/special/spherical_jn.hpp
@@ -7,7 +7,7 @@
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
 
-#define BOOST_MATH_THREAD_LOCAL thread_local
+#include "pythonic/utils/boost_local_config.hpp"
 #include <boost/math/special_functions/bessel.hpp>
 #include <boost/math/special_functions/bessel_prime.hpp>
 

--- a/pythran/pythonic/scipy/special/spherical_yn.hpp
+++ b/pythran/pythonic/scipy/special/spherical_yn.hpp
@@ -7,7 +7,7 @@
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
 
-#define BOOST_MATH_THREAD_LOCAL thread_local
+#include "pythonic/utils/boost_local_config.hpp"
 #include <boost/math/special_functions/bessel.hpp>
 #include <boost/math/special_functions/bessel_prime.hpp>
 

--- a/pythran/pythonic/scipy/special/yv.hpp
+++ b/pythran/pythonic/scipy/special/yv.hpp
@@ -7,7 +7,7 @@
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
 
-#define BOOST_MATH_THREAD_LOCAL thread_local
+#include "pythonic/utils/boost_local_config.hpp"
 #include <boost/math/special_functions/bessel.hpp>
 
 PYTHONIC_NS_BEGIN

--- a/pythran/pythonic/scipy/special/yvp.hpp
+++ b/pythran/pythonic/scipy/special/yvp.hpp
@@ -7,7 +7,7 @@
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
 
-#define BOOST_MATH_THREAD_LOCAL thread_local
+#include "pythonic/utils/boost_local_config.hpp"
 #include <boost/math/special_functions/bessel_prime.hpp>
 
 PYTHONIC_NS_BEGIN

--- a/pythran/pythonic/utils/boost_local_config.hpp
+++ b/pythran/pythonic/utils/boost_local_config.hpp
@@ -1,0 +1,9 @@
+#ifndef BOOST_MATH_THREAD_LOCAL
+#define BOOST_MATH_THREAD_LOCAL thread_local
+#endif
+#ifndef BOOST_MATH_OVERFLOW_ERROR_POLICY
+#define BOOST_MATH_OVERFLOW_ERROR_POLICY ignore_error
+#endif
+#ifndef BOOST_MATH_DOMAIN_ERROR_POLICY
+#define BOOST_MATH_DOMAIN_ERROR_POLICY ignore_error
+#endif

--- a/pythran/tests/test_scipy.py
+++ b/pythran/tests/test_scipy.py
@@ -142,6 +142,14 @@ try:
                               5, 4,
                               binom_scalar=[int, int])
 
+            def test_binom_error(self):
+                self.run_test("""
+                from scipy.special import binom
+                def binom_error(v, x):
+                    return binom(v, x)""",
+                              1201, 800,
+                              binom_error=[int, int])
+
             def test_binom_arg1d(self):
                 self.run_test("""
                 from scipy.special import binom


### PR DESCRIPTION
Instead rely on boost to return the right NaN / inf value

This should fix https://github.com/scipy/scipy/pull/13957