### PR TITLE
Increase and parametrize the maximum number of heterogeneous type in …

### DIFF
--- a/docs/MANUAL.rst
+++ b/docs/MANUAL.rst
@@ -613,15 +613,20 @@ Another internal setting stuff. This controls the accuracy of the typing phase. 
 
     [typing]
 
-    # maximum number of container access taken into account during type inference
-    # increasing this value inreases typing accuracy
-    # but slows down compilation time, to the point of making g++ crash
-    max_container_type = 2
-
     # maximum number of combiner per user function
     # increasing this value inreases typing accuracy
     # but slows down compilation time, to the point of making g++ crash
     max_combiner = 2
+
+    # above this number of overloads, pythran specifications are considered invalid
+    # as it generates ultra-large binaries
+    max_export_overloads = 128
+
+    # to the notable exceptions of tuple, pythran sequences are homogeneous. It is
+    # however possible to store functions objects in a sequence and a variant
+    # functor is created. This value bounds the number of different types within
+    # a sequence
+    max_heterogeneous_sequence_size = 16
 
 ``[backend]``
 *************

--- a/pythran/pythran.cfg
+++ b/pythran/pythran.cfg
@@ -37,6 +37,12 @@ max_combiner = 2
 # as it generates ultra-large binaries
 max_export_overloads = 128
 
+# to the notable exceptions of tuple, pythran sequences are homogeneous. It is
+# however possible to store functions objects in a sequence and a variant
+# functor is created. This value bounds the number of different types within
+# a sequence
+max_heterogeneous_sequence_size = 16
+
 [backend]
 
 # set to true if you want intermediate C++ code to be annotated with a reference


### PR DESCRIPTION
…a sequence

This only partially fixes #2040.

It does increase the bound, and it is now possible to change it using --config typing.max_heterogeneous_sequence_size=32.

There is however a subtle error with invalid lookup that requires more care, and probably another commit!