### PR TITLE
Only use `numpy.distutils` conditionally

### DIFF
--- a/omp/__init__.py
+++ b/omp/__init__.py
@@ -2,12 +2,10 @@
 
 from ctypes.util import find_library
 from subprocess import check_output, CalledProcessError, DEVNULL
-from numpy.distutils.misc_util import (
-    msvc_runtime_major, get_shared_lib_extension
-)
 import ctypes
 import os
 import sys
+import sysconfig
 
 try:
     # there may be an environ modification when loading config
@@ -16,6 +14,70 @@ except ImportError:
     def compiler():
         return os.environ.get('CXX', 'c++')
 cxx = compiler()
+
+
+def get_shared_lib_extension(is_python_ext=False):
+    """Return the correct file extension for shared libraries.
+
+    Parameters
+    ----------
+    is_python_ext : bool, optional
+        Whether the shared library is a Python extension.  Default is False.
+
+    Returns
+    -------
+    so_ext : str
+        The shared library extension.
+
+    Notes
+    -----
+    For Python shared libs, `so_ext` will typically be '.so' on Linux and OS X,
+    and '.pyd' on Windows.  For Python >= 3.2 `so_ext` has a tag prepended on
+    POSIX systems according to PEP 3149.
+
+    """
+    confvars = sysconfig.get_config_vars()
+    so_ext = confvars.get('EXT_SUFFIX', '')
+
+    if not is_python_ext:
+        # hardcode some known values to avoid some old distutils bugs
+        if (sys.platform.startswith('linux') or
+            sys.platform.startswith('gnukfreebsd')):
+            so_ext = '.so'
+        elif sys.platform.startswith('darwin'):
+            so_ext = '.dylib'
+        elif sys.platform.startswith('win'):
+            so_ext = '.dll'
+        else:
+            # don't use long extension (e.g., .cpython-310-x64_64-linux-gnu.so',
+            # see PEP 3149), but subtract that Python-specific part here
+            so_ext = so_ext.replace('.' + confvars.get('SOABI'), '', 1)
+
+    return so_ext
+
+
+def msvc_runtime_version():
+    "Return version of MSVC runtime library, as defined by __MSC_VER__ macro"
+    msc_pos = sys.version.find('MSC v.')
+    if msc_pos != -1:
+        msc_ver = int(sys.version[msc_pos+6:msc_pos+10])
+    else:
+        msc_ver = None
+    return msc_ver
+
+
+def msvc_runtime_major():
+    "Return major version of MSVC runtime coded like get_build_msvc_version"
+    major = {1300:  70,  # MSVC 7.0
+             1310:  71,  # MSVC 7.1
+             1400:  80,  # MSVC 8
+             1500:  90,  # MSVC 9  (aka 2008)
+             1600: 100,  # MSVC 10 (aka 2010)
+             1900: 140,  # MSVC 14 (aka 2015)
+             1910: 141,  # MSVC 141 (aka 2017)
+             1920: 142,  # MSVC 142 (aka 2019)
+    }.get(msvc_runtime_version(), None)
+    return major
 
 
 class OpenMP(object):
@@ -28,6 +90,12 @@ class OpenMP(object):
     """
 
     def __init__(self):
+        # FIXME: this is broken, for at least two reasons:
+        #   (1) checking how Python was built is not a good way to determine if
+        #       MSVC is being used right now,
+        #   (2) the `msvc_runtime_major` function above came from
+        #       `numpy.distutils`, where it did not have entries for 1910/1920
+        #       and returned None instead
         ver = msvc_runtime_major()
         if ver is None:
             self.init_not_msvc()

--- a/omp/__init__.py
+++ b/omp/__init__.py
@@ -16,6 +16,8 @@ except ImportError:
 cxx = compiler()
 
 
+# This function and the `msvc_runtime_*` ones below are taken over from
+# numpy.distutils
 def get_shared_lib_extension(is_python_ext=False):
     """Return the correct file extension for shared libraries.
 

--- a/pythran/config.py
+++ b/pythran/config.py
@@ -9,6 +9,8 @@ import os
 from shlex import split as shsplit
 import sys
 
+import numpy
+
 logger = logging.getLogger('pythran')
 
 
@@ -221,7 +223,6 @@ def make_extension(python, **extra):
 
     # numpy specific
     if python:
-        import numpy
         extension['include_dirs'].append(numpy.get_include())
 
     # blas dependency
@@ -260,9 +261,11 @@ def make_extension(python, **extra):
                         numpy_blas.get('library_dirs', []))
                     extension['include_dirs'].extend(
                         numpy_blas.get('include_dirs', []))
-            except Exception:
-                # This may fail, because of setuptools backwards compat issues
-                pass
+            except Exception as exc:
+                raise RuntimeError(
+                    "The likely cause of this failure is an incompatibility "
+                    "between `setuptools` and `numpy.distutils. "
+                ) from exc
 
     # final macro normalization
     extension["define_macros"] = [

--- a/pythran/dist.py
+++ b/pythran/dist.py
@@ -19,7 +19,7 @@ try:
     # `numpy.distutils` is deprecated, and won't be present on Python >=3.12
     # If it is installed, we need to use it though, so try-import it:
     from numpy.distutils.extension import Extension
-except:
+except ImportError:
     from distutils.extension import Extension
 
 

--- a/pythran/dist.py
+++ b/pythran/dist.py
@@ -15,7 +15,13 @@ import os
 
 from distutils.command.build_ext import build_ext as LegacyBuildExt
 
-from numpy.distutils.extension import Extension
+try:
+    # `numpy.distutils` is deprecated, and won't be present on Python >=3.12
+    # If it is installed, we need to use it though, so try-import it:
+    from numpy.distutils.extension import Extension
+except:
+    from distutils.extension import Extension
+
 
 
 class PythranBuildExtMixIn(object):

--- a/pythran/toolchain.py
+++ b/pythran/toolchain.py
@@ -25,7 +25,11 @@ import pythran.frontend as frontend
 from datetime import datetime
 from distutils.errors import CompileError
 from distutils import sysconfig
-from numpy.distutils.core import setup
+try:
+    # `numpy.distutils is deprecated, may not be present, or broken
+    from numpy.distutils.core import setup
+except Exception:
+    from distutils.core import setup
 
 from tempfile import mkdtemp, NamedTemporaryFile
 import gast as ast


### PR DESCRIPTION
It's deprecated, is easily broken by new setuptools releases, and will not be present at all for Python >= 3.12

Closes gh-2048