### PR TITLE
BUG: Include pyconfig.h first to define visibility macros

### DIFF
--- a/pythran/pythonic/core.hpp
+++ b/pythran/pythonic/core.hpp
@@ -31,6 +31,8 @@
 #ifdef ENABLE_PYTHON_MODULE
 // Define python's visibility macros
 #include "pyconfig.h"
+
+// Some version of python define that macro on Windows, and it breaks compilation of some C++ headers.
 #ifdef copysign
 #undef copysign
 #endif

--- a/pythran/pythonic/core.hpp
+++ b/pythran/pythonic/core.hpp
@@ -28,6 +28,11 @@
 #define INCLUDE_FILE(U, M) STR_(U/M.hpp)
 // clang-format on
 
+#ifdef ENABLE_PYTHON_MODULE
+// Define python's visibility macros
+#include "pyconfig.h"
+#endif
+
 #include "pythonic/types/assignable.hpp"
 #include "pythonic/types/combined.hpp"
 

--- a/pythran/pythonic/core.hpp
+++ b/pythran/pythonic/core.hpp
@@ -31,6 +31,9 @@
 #ifdef ENABLE_PYTHON_MODULE
 // Define python's visibility macros
 #include "pyconfig.h"
+#ifdef copysign
+#undef copysign
+#endif
 #endif
 
 #include "pythonic/types/assignable.hpp"

--- a/pythran/toolchain.py
+++ b/pythran/toolchain.py
@@ -183,6 +183,8 @@ def generate_cxx(module_name, code, specs=None, optimizations=None,
 
         mod = PythonModule(module_name, docstrings, metainfo)
         mod.add_to_includes(
+            # Set python's visibility macros
+            Include("pyconfig.h"),
             Include("pythonic/core.hpp"),
             Include("pythonic/python/core.hpp"),
             # FIXME: only include these when needed

--- a/pythran/toolchain.py
+++ b/pythran/toolchain.py
@@ -183,8 +183,6 @@ def generate_cxx(module_name, code, specs=None, optimizations=None,
 
         mod = PythonModule(module_name, docstrings, metainfo)
         mod.add_to_includes(
-            # Set python's visibility macros
-            Include("pyconfig.h"),
             Include("pythonic/core.hpp"),
             Include("pythonic/python/core.hpp"),
             # FIXME: only include these when needed


### PR DESCRIPTION
Make sure Python's visibility macros are set before including any system headers, which are likely to include sys/features.h

My attempts to compile SciPy failed because `posix_memalign` was not declared.  This function is guarded by `_POSIX_C_SOURCE >= 200112`; my `pyconfig.h` defines `_POSIX_C_SOURCE = 200809`.  I think this is the simplest method to ensure Python's visibility macros are set before `sys/features.h` is included by a system header.