### PR TITLE
Fix range analysis in interprocedural context

### DIFF
--- a/pythran/analyses/range_values.py
+++ b/pythran/analyses/range_values.py
@@ -95,7 +95,7 @@ def negate(node):
 
 def bound_range(mapping, aliases, node, modified=None):
     """
-    Bound the idenifier in `mapping' with the expression in `node'.
+    Bound the identifier in `mapping' with the expression in `node'.
     `aliases' is the result of aliasing analysis and `modified' is
     updated with the set of identifiers possibly `bounded' as the result
     of the call.
@@ -411,8 +411,11 @@ class RangeValuesBase(ModuleAnalysis):
                 if alias not in self.result:
                     state = self.save_state()
                     self.parent.visit(alias)
+                    return_range = self.result[alias]
                     self.restore_state(state)
-                self.add(node, self.result[alias])
+                else:
+                    return_range = self.result[alias]
+                self.add(node, return_range)
             else:
                 self.result.pop(node, None)
                 return self.generic_visit(node)
@@ -839,11 +842,11 @@ class RangeValues(RangeValuesBase):
 
     def save_state(self):
         return (self.cfg, self.aliases, self.use_omp, self.no_backward,
-                self.no_if_split)
+                self.no_if_split, self.result.copy())
 
     def restore_state(self, state):
         (self.cfg, self.aliases, self.use_omp, self.no_backward,
-         self.no_if_split) = state
+         self.no_if_split, self.result) = state
 
     def function_visitor(self, node):
         parent_result = self.result

--- a/pythran/tables.py
+++ b/pythran/tables.py
@@ -3699,6 +3699,7 @@ MODULES = {
         "empty": ConstFunctionIntr(args=('shape', 'dtype'),
                                    defaults=("numpy.float64",),
                                    signature=_numpy_ones_signature,
+                                   global_effects=True, # to avoid folding
                                    ),
         "empty_like": ConstFunctionIntr(
             args=('a', 'dtype'),

--- a/pythran/tests/test_optimizations.py
+++ b/pythran/tests/test_optimizations.py
@@ -1,6 +1,7 @@
 from pythran.tests import TestEnv
-from pythran.typing import List
+from pythran.typing import List, NDArray
 import unittest
+import numpy
 
 import pythran
 
@@ -726,6 +727,40 @@ def range_simplify_subscript(n):
     ML[0] = n
     return ML'''
         self.run_test(code, 1, range_simplify_subscript=[int])
+
+    def test_range_simplify_call_same_identifiers(self):
+        code = '''
+import math
+import numpy
+def test_range_simplify_call_same_identifiers(b, c, y, t, m):
+    ta = ftc (b, c, y, t, m)
+    gis = 0.
+    tno = numpy.empty(shape = (2))
+    for cnum in ([0,1] if m else [0]):
+        tno[cnum] = 123.
+    for cnum in ([0,1] if m else [0]):
+        gis += cnum
+    ret = gis - ta
+    return ret
+
+def ftc (b, c, y, t, m):
+    cin = [7,8]
+    ed = []
+    for cnum in [0,1]:
+        if b < 5:
+            ed.append (456.)
+        else:
+            ed.append (0.)
+    ret = 0.
+    if (c + y) < 65 and t[y] and m and cin[1] is not None:
+        ret += 543.21
+    return ret
+'''
+        self.run_test(code,
+                      True, 60, 60, numpy.asarray([False] * 80), True,
+                      test_range_simplify_call_same_identifiers=[bool, int, int,
+                                                                 NDArray[bool,:],
+                                                                 bool])
 
     def test_insert_none0(self):
         code = '''


### PR DESCRIPTION
We should clean stack upon function's return to avoid variables cluttering each others.

Fix #2058