### PR TITLE
Bug 2066 do not call t.begin() if t is empty

### DIFF
--- a/pythran/pythonic/utils/nested_container.hpp
+++ b/pythran/pythonic/utils/nested_container.hpp
@@ -3,9 +3,9 @@
 
 #include "pythonic/include/utils/nested_container.hpp"
 
-#include <limits>
 #include "pythonic/types/traits.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
+#include <limits>
 
 PYTHONIC_NS_BEGIN
 namespace utils
@@ -14,12 +14,15 @@ namespace utils
   template <class T>
   long nested_container_size<T>::flat_size(T const &t)
   {
-    return t.size() *
-           nested_container_size<typename std::conditional<
-               // If we have a scalar or a complex, we want to stop
-               // recursion, and then dispatch to bool specialization
-               types::is_dtype<typename Type::value_type>::value, bool,
-               typename Type::value_type>::type>::flat_size(*t.begin());
+    return t.size()
+               ? t.size() *
+                     nested_container_size<typename std::conditional<
+                         // If we have a scalar or a complex, we want to stop
+                         // recursion, and then dispatch to bool specialization
+                         types::is_dtype<typename Type::value_type>::value,
+                         bool, typename Type::value_type>::type>::
+                         flat_size(*t.begin())
+               : 0;
   }
 
   /* Recursion stops on bool */
@@ -28,7 +31,7 @@ namespace utils
   {
     return 1;
   }
-}
+} // namespace utils
 PYTHONIC_NS_END
 
 #endif


### PR DESCRIPTION
This is only an issue on windows.