### PR TITLE
Basic support of empty arrays

### DIFF
--- a/pythran/conversion.py
+++ b/pythran/conversion.py
@@ -74,7 +74,7 @@ def size_container_folding(value):
             values = [to_ast(elt) for elt in value.values()]
             return ast.Dict(keys, values)
         elif isinstance(value, np.ndarray):
-            if len(value) == 0:
+            if np.ndim(value) == 0 or len(value) == 0:
                 shp = to_ast(value.shape)
                 shp = ast.Call(
                     ast.Attribute(

--- a/pythran/pythonic/include/numpy/empty.hpp
+++ b/pythran/pythonic/include/numpy/empty.hpp
@@ -9,6 +9,10 @@ PYTHONIC_NS_BEGIN
 
 namespace numpy
 {
+  template <class dtype = functor::float64>
+  typename dtype::type
+  empty(types::pshape<> const &shape, dtype d = dtype());
+
   template <class pS, class dtype = functor::float64>
   types::ndarray<typename dtype::type, sutils::shape_t<pS>>
   empty(pS const &shape, dtype d = dtype());

--- a/pythran/pythonic/include/numpy/ndim.hpp
+++ b/pythran/pythonic/include/numpy/ndim.hpp
@@ -3,6 +3,7 @@
 
 #include "pythonic/include/utils/functor.hpp"
 #include "pythonic/include/types/ndarray.hpp"
+#include "pythonic/include/numpy/shape.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -10,7 +11,7 @@ namespace numpy
 {
 
   template <class E>
-  auto ndim(E const &e) -> decltype(builtins::getattr(types::attr::NDIM{}, e));
+  long ndim(E const &e);
 
   DEFINE_FUNCTOR(pythonic::numpy, ndim)
 }

--- a/pythran/pythonic/include/numpy/ones.hpp
+++ b/pythran/pythonic/include/numpy/ones.hpp
@@ -10,6 +10,10 @@ PYTHONIC_NS_BEGIN
 namespace numpy
 {
 
+  template <class dtype = functor::float64>
+  typename dtype::type
+  ones(std::tuple<> const &shape, dtype d = dtype());
+
   template <class pS, class dtype = functor::float64>
   types::ndarray<typename dtype::type, sutils::shape_t<pS>>
   ones(pS const &shape, dtype d = dtype());

--- a/pythran/pythonic/include/numpy/size.hpp
+++ b/pythran/pythonic/include/numpy/size.hpp
@@ -9,8 +9,11 @@ PYTHONIC_NS_BEGIN
 namespace numpy
 {
 
+
   template <class E>
   auto size(E const &e) -> decltype(e.flat_size());
+
+  long size(...) { return 1; }
 
   DEFINE_FUNCTOR(pythonic::numpy, size)
 }

--- a/pythran/pythonic/include/numpy/zeros.hpp
+++ b/pythran/pythonic/include/numpy/zeros.hpp
@@ -9,6 +9,10 @@ PYTHONIC_NS_BEGIN
 
 namespace numpy
 {
+  template <class dtype = functor::float64>
+  typename dtype::type
+  zeros(std::tuple<> const &shape, dtype d = dtype());
+
   template <class pS, class dtype = functor::float64>
   types::ndarray<typename dtype::type, sutils::shape_t<pS>>
   zeros(pS const &shape, dtype d = dtype());

--- a/pythran/pythonic/include/types/ndarray.hpp
+++ b/pythran/pythonic/include/types/ndarray.hpp
@@ -842,15 +842,21 @@ namespace builtins
   template <class E>
   types::array<long, E::value> getattr(types::attr::SHAPE, E const &a);
 
+  types::pshape<> getattr(types::attr::SHAPE, ...) { return {}; }
+
   template <class E>
-  constexpr long getattr(types::attr::NDIM, E const &a);
+  constexpr decltype(long(E::value)) getattr(types::attr::NDIM, E const &a);
 
   template <class E>
   std::integral_constant<long, E::value> getattr(types::attr::NDIM,
                                                  E *const &a);
 
+  long getattr(types::attr::NDIM, ...) { return 0; }
+
   template <class E>
   types::array<long, E::value> getattr(types::attr::STRIDES, E const &a);
+
+  std::tuple<> getattr(types::attr::STRIDES, ...) { return {}; }
 
   template <class E>
   long getattr(types::attr::SIZE, E const &a);

--- a/pythran/pythonic/include/types/tuple.hpp
+++ b/pythran/pythonic/include/types/tuple.hpp
@@ -1173,6 +1173,8 @@ namespace sutils
     return getshape(e, utils::make_index_sequence<E::value>());
   }
 
+  inline std::tuple<> getshape(...) { return {};}
+
   template <class pS0, class pS1>
   struct concat;
 

--- a/pythran/pythonic/numpy/empty.hpp
+++ b/pythran/pythonic/numpy/empty.hpp
@@ -10,6 +10,13 @@ PYTHONIC_NS_BEGIN
 
 namespace numpy
 {
+  template <class dtype>
+  typename dtype::type
+  empty(types::pshape<> const &shape, dtype)
+  {
+    return {};
+  }
+
   template <class pS, class dtype>
   types::ndarray<typename dtype::type, sutils::shape_t<pS>>
   empty(pS const &shape, dtype)

--- a/pythran/pythonic/numpy/ndim.hpp
+++ b/pythran/pythonic/numpy/ndim.hpp
@@ -12,9 +12,9 @@ namespace numpy
 {
 
   template <class E>
-  auto ndim(E const &e) -> decltype(builtins::getattr(types::attr::NDIM{}, e))
+  long ndim(E const &e)
   {
-    return builtins::getattr(types::attr::NDIM{}, e);
+    return std::tuple_size<decltype(shape(e))>::value;
   }
 }
 PYTHONIC_NS_END

--- a/pythran/pythonic/numpy/ones.hpp
+++ b/pythran/pythonic/numpy/ones.hpp
@@ -11,6 +11,13 @@ PYTHONIC_NS_BEGIN
 namespace numpy
 {
 
+  template <class dtype>
+  typename dtype::type
+  ones(std::tuple<> const &shape, dtype d)
+  {
+    return static_cast<typename dtype::type>(1);
+  }
+
   template <class pS, class dtype>
   types::ndarray<typename dtype::type, sutils::shape_t<pS>>
   ones(pS const &shape, dtype d)

--- a/pythran/pythonic/numpy/zeros.hpp
+++ b/pythran/pythonic/numpy/zeros.hpp
@@ -10,6 +10,14 @@ PYTHONIC_NS_BEGIN
 
 namespace numpy
 {
+
+  template <class dtype>
+  typename dtype::type
+  zeros(std::tuple<> const &shape, dtype d)
+  {
+    return static_cast<typename dtype::type>(0);
+  }
+
   template <class pS, class dtype>
   types::ndarray<typename dtype::type, sutils::shape_t<pS>>
   zeros(pS const &shape, dtype d)

--- a/pythran/pythonic/types/ndarray.hpp
+++ b/pythran/pythonic/types/ndarray.hpp
@@ -1196,7 +1196,7 @@ namespace builtins
   }
 
   template <class E>
-  constexpr long getattr(types::attr::NDIM, E const &a)
+  constexpr decltype(long(E::value)) getattr(types::attr::NDIM, E const &a)
   {
     return E::value;
   }

--- a/pythran/tests/test_numpy_func0.py
+++ b/pythran/tests/test_numpy_func0.py
@@ -64,15 +64,30 @@ class TestNumpyFunc0(TestEnv):
                        numpy.ones(3, numpy.int16),
                        numpy_shape_as_function=[NDArray[numpy.int16,:]])
 
+    def test_numpy_shape_scalar(self):
+         self.run_test("def numpy_shape_scalar(a): import numpy ; return numpy.shape(a)",
+                       1.,
+                       numpy_shape_scalar=[float])
+
     def test_numpy_size_as_function(self):
          self.run_test("def numpy_size_as_function(a): import numpy ; return numpy.size(a)",
                        numpy.ones(3, numpy.int16),
                        numpy_size_as_function=[NDArray[numpy.int16,:]])
 
+    def test_numpy_size_scalar(self):
+         self.run_test("def numpy_size_scalar(a): import numpy ; return numpy.size(a)",
+                       1.,
+                       numpy_size_scalar=[float])
+
     def test_numpy_ndim_as_function(self):
          self.run_test("def numpy_ndim_as_function(a): import numpy ; return numpy.ndim(a)",
                        numpy.ones(3, numpy.int16),
                        numpy_ndim_as_function=[NDArray[numpy.int16,:]])
+
+    def test_numpy_ndim_scalar(self):
+         self.run_test("def numpy_ndim_scalar(a): import numpy ; return numpy.ndim(a)",
+                       1.,
+                       numpy_ndim_scalar=[float])
 
     def test_frexp0(self):
         self.run_test("def np_frexp0(a): import numpy as np ; return np.frexp(a)", 1.5, np_frexp0=[float])

--- a/pythran/tests/test_numpy_func2.py
+++ b/pythran/tests/test_numpy_func2.py
@@ -767,17 +767,26 @@ def test_copy0(x):
     def test_empty_integral_shape(self):
         self.run_test("def np_empty_integral_shape(n):\n from numpy import empty, uint8\n a = empty(5)\n return a.strides, len(a), n", 3, np_empty_integral_shape=[int])
 
+    def test_empty_empty_shape(self):
+        self.run_test("def np_empty_empty_shape(n):\n from numpy import empty, uint8, shape, ndim\n a = empty(())\n return a.strides, n, shape(a), ndim(a)", 3, np_empty_empty_shape=[int])
+
     def test_ones_uint_shape(self):
         self.run_test("def np_ones_uint_shape(a):\n from numpy import ones, uint32\n a = ones((uint32(a), uint32(a)))\n return a.strides, len(a)", 3, np_ones_uint_shape=[int])
 
     def test_ones_integral_shape(self):
         self.run_test("def np_ones_integral_shape(n):\n from numpy import ones, uint8\n a = ones(5)\n return a.strides, len(a), n", 3, np_ones_integral_shape=[int])
 
+    def test_ones_empty_shape(self):
+        self.run_test("def np_ones_empty_shape(n):\n from numpy import ones, uint8, shape, ndim\n a = ones(())\n return a.strides, n, shape(a), ndim(a)", 3, np_ones_empty_shape=[int])
+
     def test_zeros_uint_shape(self):
         self.run_test("def np_zeros_uint_shape(a):\n from numpy import zeros, int32\n a = zeros((int32(a), int32(a)))\n return a.strides, len(a)", 3, np_zeros_uint_shape=[int])
 
     def test_zeros_integral_shape(self):
         self.run_test("def np_zeros_integral_shape(n):\n from numpy import zeros, uint8\n a = zeros(5)\n return a.strides, len(a), n", 3, np_zeros_integral_shape=[int])
+
+    def test_zeros_empty_shape(self):
+        self.run_test("def np_zeros_empty_shape(n):\n from numpy import zeros, uint8, shape, ndim\n a = zeros(())\n return a.strides, n, shape(a), ndim(a), a.shape, a.ndim", 3, np_zeros_empty_shape=[int])
 
     def test_empty_kwargs(self):
         self.run_test("def np_empty_kwargs(a):\n from numpy import empty\n a = empty(a, dtype=int)\n return a.strides, len(a)", (3, 2), np_empty_kwargs=[Tuple[int, int]])

--- a/third_party/xsimd/arch/xsimd_scalar.hpp
+++ b/third_party/xsimd/arch/xsimd_scalar.hpp
@@ -441,7 +441,8 @@ namespace xsimd
         return !(x0 == x1);
     }
 
-#if defined(_GNU_SOURCE) && !defined(__APPLE__) && !defined(__MINGW32__) && !defined(__ANDROID__)
+    // FIXME: there must be a better way :-/
+#if defined(_GNU_SOURCE) && !defined(__APPLE__) && !defined(__MINGW32__) && !defined(__ANDROID__) && !defined(__FreeBSD__) && !defined(__NetBSD__) && !defined(__OpenBSD__) && !defined(__DragonFly__)
     inline float exp10(const float& x) noexcept
     {
         return ::exp10f(x);


### PR DESCRIPTION
Have np.ones, empty and zeros return a scalar when invoked through an empty shape. Also make a few functions / accessors etc compatible with this model.

This is slightly different from numpy's implementation in that returns a "scalar array".

Fix #2071