### PR TITLE
Backport 995ba19886255c84024afb5531154f314c840967 from xsimd

### DIFF
--- a/third_party/xsimd/arch/xsimd_scalar.hpp
+++ b/third_party/xsimd/arch/xsimd_scalar.hpp
@@ -441,8 +441,16 @@ namespace xsimd
         return !(x0 == x1);
     }
 
-    // FIXME: there must be a better way :-/
-#if defined(_GNU_SOURCE) && !defined(__APPLE__) && !defined(__MINGW32__) && !defined(__ANDROID__) && !defined(__FreeBSD__) && !defined(__NetBSD__) && !defined(__OpenBSD__) && !defined(__DragonFly__)
+#if defined(__APPLE__)
+    inline float exp10(const float& x) noexcept
+    {
+        return __exp10f(x);
+    }
+    inline double exp10(const double& x) noexcept
+    {
+        return __exp10(x);
+    }
+#elif defined(__GLIBC__)
     inline float exp10(const float& x) noexcept
     {
         return ::exp10f(x);
@@ -451,14 +459,16 @@ namespace xsimd
     {
         return ::exp10(x);
     }
-#endif
-
-    template <class T, class = typename std::enable_if<std::is_scalar<T>::value>::type>
-    inline T exp10(const T& x) noexcept
+#else
+    inline float exp10(const float& x) noexcept
     {
-        // FIXME: very inefficient
-        return std::pow(T(10), x);
+        return std::exp(0x1.26bb1cp+1f * x);
     }
+    inline double exp10(const double& x) noexcept
+    {
+        return std::exp(0x1.26bb1bbb55516p+1 * x);
+    }
+#endif
 
     template <class T, class = typename std::enable_if<std::is_scalar<T>::value>::type>
     inline auto rsqrt(const T& x) noexcept -> decltype(std::sqrt(x))


### PR DESCRIPTION
This fixes xsimd on targets that don't use glibc.

Fix #2070