### PR TITLE
Do not generate trailing loop update if not needed

### DIFF
--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -42,4 +42,5 @@ jobs:
         export CXX=`echo ${{ matrix.cpp-version }} | sed -e 's/clang/clang++/'`
         export CXXFLAGS="-fopenmp"
         export LDFLAGS="-fopenmp"
+        printf '[compiler]\nldflags=-fopenmp\ncflags=-fopenmp\n' > ~/.pythranrc
         pytest pythran/tests/test_cases.py -v --numprocesses=1

--- a/pythran/backend.py
+++ b/pythran/backend.py
@@ -600,9 +600,14 @@ class CxxFunction(ast.NodeVisitor):
         else:
             # For yield function, upper_bound is globals.
             iter_type = ""
-            # Back one step to keep Python behavior (except for break)
-            loop = [If("{} == {}".format(local_iter, upper_bound),
-                    Statement("{} -= {}".format(local_iter, step)))]
+
+            # Back one step to keep Python behavior (unless the loop index does
+            # not escape)
+            if node.target.id in self.scope[node]:
+                loop = []
+            else:
+                loop = [If("{} == {}".format(local_iter, upper_bound),
+                        Statement("{} -= {}".format(local_iter, step)))]
 
         comparison = self.handle_real_loop_comparison(args, local_iter,
                                                       upper_bound)

--- a/pythran/tests/openmp.legacy/pythran_collapse.py
+++ b/pythran/tests/openmp.legacy/pythran_collapse.py
@@ -1,5 +1,5 @@
 import numpy as np
-def collapse_bug(x, m, btx):
+def collapse_bug0(x, m, btx):
     n = int(np.log2(m))
     lv = np.zeros((x.shape[0], n))
     N = x.shape[0]
@@ -9,8 +9,19 @@ def collapse_bug(x, m, btx):
             lv[i,k] = abs(x[i]- btx[k])
     return lv
 
+def collapse_bug1(x, m, btx):
+    n = int(np.log2(m))
+    lv = np.zeros((x.shape[0], n))
+    N = x.shape[0]
+    #omp parallel for collapse(2) private(i,k)
+    for i in range(N):
+        for k in range(n):
+            lv[i,k] = abs(x[i]- btx[k])
+    return lv
+
+
 def pythran_collapse():
     from random import randint
     n = randint(50, 50)
     x = np.ones(n)
-    return collapse_bug(x, 5, 3. * x)
+    return collapse_bug0(x, 5, 3. * x), collapse_bug1(x, 5, 3. * x)


### PR DESCRIPTION
Because of the way looping works in python and C, we generally turn

    for i in range(10):
        ...

into

    for(int i = 0; i < 10; ++i)
       ...
    if ( i != 10) i = 10

Don't do that if we can prove i is not escaping the loop's scope.

Fix #2064