### PR TITLE
Get rid of unused functions warnings

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -30,7 +30,8 @@ jobs:
     - name: Setup
       run: |
         python setup.py install
-        printf '[commpiler]\nblas=openblas\n' > ~/.pythranrc
+        printf '[compiler]\nblas=openblas\n' > ~/.config/.pythranrc
+        printf 'cflags=-std=c++11 -Wall -Werror -Wno-unknown-pragmas -Wno-unused-local-typedefs -Wno-cpp -Wno-deprecated-declarations -Wno-absolute-value\n' >> ~/.config/.pythranrc
     - name: Testing minimal CLI
       run: |
         pythran --version

--- a/pythran/pythonic/builtins/assert.hpp
+++ b/pythran/pythonic/builtins/assert.hpp
@@ -8,7 +8,7 @@
 
 PYTHONIC_NS_BEGIN
 
-void pythran_assert(bool cond)
+inline void pythran_assert(bool cond)
 {
 #ifndef NDEBUG
   if (!cond)
@@ -16,7 +16,7 @@ void pythran_assert(bool cond)
 #endif
 }
 
-void pythran_assert(bool cond, types::str const &what)
+inline void pythran_assert(bool cond, types::str const &what)
 {
 #ifndef NDEBUG
   if (!cond)

--- a/pythran/pythonic/builtins/bool_.hpp
+++ b/pythran/pythonic/builtins/bool_.hpp
@@ -3,8 +3,8 @@
 
 #include "pythonic/include/builtins/bool_.hpp"
 
-#include "pythonic/utils/functor.hpp"
 #include "pythonic/types/tuple.hpp"
+#include "pythonic/utils/functor.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -31,12 +31,12 @@ namespace builtins
       return N;
     }
 
-    bool bool_::operator()() const
+    inline bool bool_::operator()() const
     {
       return false;
     }
-  }
-}
+  } // namespace functor
+} // namespace builtins
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/builtins/complex.hpp
+++ b/pythran/pythonic/builtins/complex.hpp
@@ -13,12 +13,12 @@ namespace builtins
 
   namespace functor
   {
-    complex::type complex::operator()(double v0, double v1) const
+    inline complex::type complex::operator()(double v0, double v1) const
     {
       return {v0, v1};
     }
-  }
-}
+  } // namespace functor
+} // namespace builtins
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/builtins/dict.hpp
+++ b/pythran/pythonic/builtins/dict.hpp
@@ -16,7 +16,7 @@ namespace builtins
 
   namespace anonymous
   {
-    types::empty_dict dict()
+    inline types::empty_dict dict()
     {
       return types::empty_dict();
     }
@@ -40,8 +40,8 @@ namespace builtins
         out[std::get<0>(i)] = std::get<1>(i);
       return out;
     }
-  }
-}
+  } // namespace anonymous
+} // namespace builtins
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/builtins/file/close.hpp
+++ b/pythran/pythonic/builtins/file/close.hpp
@@ -14,16 +14,16 @@ namespace builtins
   namespace file
   {
 
-    void close(types::file &f)
+    inline void close(types::file &f)
     {
       f.close();
     }
 
-    void close(types::file &&f)
+    inline void close(types::file &&f)
     {
       f.close();
     }
-  }
-}
+  } // namespace file
+} // namespace builtins
 PYTHONIC_NS_END
 #endif

--- a/pythran/pythonic/builtins/file/flush.hpp
+++ b/pythran/pythonic/builtins/file/flush.hpp
@@ -14,16 +14,16 @@ namespace builtins
   namespace file
   {
 
-    void flush(types::file &f)
+    inline void flush(types::file &f)
     {
       f.flush();
     }
 
-    void flush(types::file &&f)
+    inline void flush(types::file &&f)
     {
       f.flush();
     }
-  }
-}
+  } // namespace file
+} // namespace builtins
 PYTHONIC_NS_END
 #endif

--- a/pythran/pythonic/builtins/file/read.hpp
+++ b/pythran/pythonic/builtins/file/read.hpp
@@ -15,15 +15,15 @@ namespace builtins
   namespace file
   {
 
-    types::str read(types::file &f, long size)
+    inline types::str read(types::file &f, long size)
     {
       return f.read(size);
     }
-    types::str read(types::file &&f, long size)
+    inline types::str read(types::file &&f, long size)
     {
       return f.read(size);
     }
-  }
-}
+  } // namespace file
+} // namespace builtins
 PYTHONIC_NS_END
 #endif

--- a/pythran/pythonic/builtins/file/readline.hpp
+++ b/pythran/pythonic/builtins/file/readline.hpp
@@ -15,16 +15,16 @@ namespace builtins
   namespace file
   {
 
-    types::str readline(types::file &f, long size)
+    inline types::str readline(types::file &f, long size)
     {
       return size < 0 ? f.readline() : f.readline(size);
     }
 
-    types::str readline(types::file &&f, long size)
+    inline types::str readline(types::file &&f, long size)
     {
       return size < 0 ? f.readline() : f.readline(size);
     }
-  }
-}
+  } // namespace file
+} // namespace builtins
 PYTHONIC_NS_END
 #endif

--- a/pythran/pythonic/builtins/file/seek.hpp
+++ b/pythran/pythonic/builtins/file/seek.hpp
@@ -14,26 +14,26 @@ namespace builtins
   namespace file
   {
 
-    void seek(types::file &f, long offset)
+    inline void seek(types::file &f, long offset)
     {
       f.seek(offset);
     }
 
-    void seek(types::file &&f, long offset)
+    inline void seek(types::file &&f, long offset)
     {
       // Nothing have to be done as it is a lvalue
     }
 
-    void seek(types::file &f, long offset, long whence)
+    inline void seek(types::file &f, long offset, long whence)
     {
       f.seek(offset, whence);
     }
 
-    void seek(types::file &&f, long offset, long whence)
+    inline void seek(types::file &&f, long offset, long whence)
     {
       // Nothing have to be done as it is a lvalue
     }
-  }
-}
+  } // namespace file
+} // namespace builtins
 PYTHONIC_NS_END
 #endif

--- a/pythran/pythonic/builtins/file/truncate.hpp
+++ b/pythran/pythonic/builtins/file/truncate.hpp
@@ -14,26 +14,26 @@ namespace builtins
   namespace file
   {
 
-    void truncate(types::file &f)
+    inline void truncate(types::file &f)
     {
       f.truncate();
     }
 
-    void truncate(types::file &&f)
+    inline void truncate(types::file &&f)
     {
       f.truncate();
     }
 
-    void truncate(types::file &f, long size)
+    inline void truncate(types::file &f, long size)
     {
       f.truncate(size);
     }
 
-    void truncate(types::file &&f, long size)
+    inline void truncate(types::file &&f, long size)
     {
       f.truncate(size);
     }
-  }
-}
+  } // namespace file
+} // namespace builtins
 PYTHONIC_NS_END
 #endif

--- a/pythran/pythonic/builtins/file/write.hpp
+++ b/pythran/pythonic/builtins/file/write.hpp
@@ -15,16 +15,16 @@ namespace builtins
   namespace file
   {
 
-    long write(types::file &f, types::str const &str)
+    inline long write(types::file &f, types::str const &str)
     {
       return f.write(str);
     }
 
-    long write(types::file &&f, types::str const &str)
+    inline long write(types::file &&f, types::str const &str)
     {
       return f.write(str);
     }
-  }
-}
+  } // namespace file
+} // namespace builtins
 PYTHONIC_NS_END
 #endif

--- a/pythran/pythonic/builtins/float_.hpp
+++ b/pythran/pythonic/builtins/float_.hpp
@@ -18,12 +18,12 @@ namespace builtins
       return static_cast<float_::type>(t);
     }
 
-    float_::type float_::operator()() const
+    inline float_::type float_::operator()() const
     {
       return 0.;
     }
-  }
-}
+  } // namespace functor
+} // namespace builtins
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/builtins/id.hpp
+++ b/pythran/pythonic/builtins/id.hpp
@@ -23,21 +23,21 @@ namespace builtins
     return t.id();
   }
 
-  long id(long const &t)
+  inline long id(long const &t)
   {
     return reinterpret_cast<uintptr_t>(&t);
   }
 
-  long id(double const &t)
+  inline long id(double const &t)
   {
     return reinterpret_cast<uintptr_t>(&t);
   }
 
-  long id(bool const &t)
+  inline long id(bool const &t)
   {
     return reinterpret_cast<uintptr_t>(&t);
   }
-}
+} // namespace builtins
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/builtins/int_.hpp
+++ b/pythran/pythonic/builtins/int_.hpp
@@ -14,15 +14,15 @@ namespace builtins
 
   namespace functor
   {
-    int_::type int_::operator()(char const t[], long base) const
+    inline int_::type int_::operator()(char const t[], long base) const
     {
       return std::strtol(t, nullptr, base);
     }
-    int_::type int_::operator()(types::str const &t, long base) const
+    inline int_::type int_::operator()(types::str const &t, long base) const
     {
       return (*this)(t.c_str(), base);
     }
-    int_::type int_::operator()(types::chr const &t, long base) const
+    inline int_::type int_::operator()(types::chr const &t, long base) const
     {
       char tmp[2] = {t.c, 0};
       return (*this)(&tmp[0], base);
@@ -34,12 +34,12 @@ namespace builtins
       return static_cast<int_::type>(t);
     }
 
-    int_::type int_::operator()() const
+    inline int_::type int_::operator()() const
     {
       return 0L;
     }
-  }
-}
+  } // namespace functor
+} // namespace builtins
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/builtins/pow.hpp
+++ b/pythran/pythonic/builtins/pow.hpp
@@ -10,7 +10,7 @@ PYTHONIC_NS_BEGIN
 
 namespace builtins
 {
-  double pow(long x, long y)
+  inline double pow(long x, long y)
   {
     return std::pow((double)x, (double)y);
   }
@@ -30,12 +30,12 @@ namespace builtins
   }
 
   template <class... Types>
-  auto pow(Types &&... args)
+  auto pow(Types &&...args)
       -> decltype(numpy::functor::power{}(std::forward<Types>(args)...))
   {
     return numpy::functor::power{}(std::forward<Types>(args)...);
   }
-}
+} // namespace builtins
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/builtins/print.hpp
+++ b/pythran/pythonic/builtins/print.hpp
@@ -19,19 +19,19 @@ namespace builtins
       return os << t;
     }
 
-    std::ostream &print(std::ostream &os, bool const &t)
+    inline std::ostream &print(std::ostream &os, bool const &t)
     {
       static char const repr[2][6] = {"False", "True\0"};
       return os << repr[t];
     }
-  }
+  } // namespace details
 
-  void print_nonl()
+  inline void print_nonl()
   {
   }
 
   template <typename T, typename... Types>
-  void print_nonl(T const &value, Types const &... values)
+  void print_nonl(T const &value, Types const &...values)
   {
     details::print(std::cout, value);
     if (sizeof...(Types) > 0)
@@ -39,20 +39,20 @@ namespace builtins
     print_nonl(values...);
   }
 
-  void print()
+  inline void print()
   {
     std::cout << std::endl;
   }
 
   template <typename T, typename... Types>
-  void print(T const &value, Types const &... values)
+  void print(T const &value, Types const &...values)
   {
     details::print(std::cout, value);
     if (sizeof...(values) > 0)
       std::cout << ' ';
     print(values...);
   }
-}
+} // namespace builtins
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/builtins/range.hpp
+++ b/pythran/pythonic/builtins/range.hpp
@@ -15,7 +15,7 @@ namespace builtins
   namespace
   {
 
-    long _init_last(long _begin, long _end, long _step)
+    inline long _init_last(long _begin, long _end, long _step)
     {
       if (_step > 0)
         return _begin +
@@ -24,114 +24,114 @@ namespace builtins
         return _begin +
                std::min(0L, _step * ((_end - _begin + _step + 1) / _step));
     }
-  }
+  } // namespace
 
-  range_iterator::range_iterator(long v, long s) : value_(v), step_(s)
+  inline range_iterator::range_iterator(long v, long s) : value_(v), step_(s)
   {
   }
 
-  long range_iterator::operator*() const
+  inline long range_iterator::operator*() const
   {
     return value_;
   }
 
-  range_iterator &range_iterator::operator++()
+  inline range_iterator &range_iterator::operator++()
   {
     value_ += step_;
     return *this;
   }
 
-  range_iterator range_iterator::operator++(int)
+  inline range_iterator range_iterator::operator++(int)
   {
     range_iterator self(*this);
     value_ += step_;
     return self;
   }
 
-  range_iterator &range_iterator::operator+=(long n)
+  inline range_iterator &range_iterator::operator+=(long n)
   {
     value_ += step_ * n;
     return *this;
   }
 
-  range_iterator &range_iterator::operator--()
+  inline range_iterator &range_iterator::operator--()
   {
     value_ -= step_;
     return *this;
   }
 
-  range_iterator range_iterator::operator--(int)
+  inline range_iterator range_iterator::operator--(int)
   {
     range_iterator self(*this);
     value_ -= step_;
     return self;
   }
 
-  range_iterator &range_iterator::operator-=(long n)
+  inline range_iterator &range_iterator::operator-=(long n)
   {
     value_ -= step_ * n;
     return *this;
   }
 
-  bool range_iterator::operator!=(range_iterator const &other) const
+  inline bool range_iterator::operator!=(range_iterator const &other) const
   {
     return value_ != other.value_;
   }
 
-  bool range_iterator::operator==(range_iterator const &other) const
+  inline bool range_iterator::operator==(range_iterator const &other) const
   {
     return value_ == other.value_;
   }
 
-  bool range_iterator::operator<(range_iterator const &other) const
+  inline bool range_iterator::operator<(range_iterator const &other) const
   {
     const long sign = +1 | (step_ >> (sizeof(long) * CHAR_BIT - 1));
     return sign * value_ < sign * other.value_;
   }
 
-  long range_iterator::operator-(range_iterator const &other) const
+  inline long range_iterator::operator-(range_iterator const &other) const
   {
     return (value_ - other.value_) / step_;
   }
 
-  range::range(long b, long e, long s)
+  inline range::range(long b, long e, long s)
       : begin_(b), end_(_init_last(b, e, s)), step_(s)
   {
   }
 
-  range::range(long e) : begin_(0), end_(e), step_(1)
+  inline range::range(long e) : begin_(0), end_(e), step_(1)
   {
   }
 
-  range_iterator range::begin() const
+  inline range_iterator range::begin() const
   {
     return range_iterator(begin_, step_);
   }
 
-  range_iterator range::end() const
+  inline range_iterator range::end() const
   {
     return range_iterator(end_, step_);
   }
 
-  typename range::reverse_iterator range::rbegin() const
+  inline typename range::reverse_iterator range::rbegin() const
   {
     return {end_ - step_, -step_};
   }
 
-  typename range::reverse_iterator range::rend() const
+  inline typename range::reverse_iterator range::rend() const
   {
     return {begin_ - step_, -step_};
   }
 
-  long range::size() const
+  inline long range::size() const
   {
     return (end_ - begin_) / step_;
   }
-  long range::operator[](long i) const
+  inline long range::operator[](long i) const
   {
     return begin_ + i * step_;
   }
-}
+} // namespace builtins
 PYTHONIC_NS_END
 
 /* overload std::get */
@@ -142,6 +142,6 @@ namespace std
   {
     return t[I];
   }
-}
+} // namespace std
 
 #endif

--- a/pythran/pythonic/builtins/set/difference.hpp
+++ b/pythran/pythonic/builtins/set/difference.hpp
@@ -15,13 +15,13 @@ namespace builtins
   {
 
     template <typename T, typename... Types>
-    types::set<T> difference(types::set<T> const &set, Types const &... others)
+    types::set<T> difference(types::set<T> const &set, Types const &...others)
     {
       return set.difference(others...);
     }
 
     template <typename T, typename... Types>
-    types::set<T> difference(types::set<T> &&set, Types const &... others)
+    types::set<T> difference(types::set<T> &&set, Types const &...others)
     {
       set.difference_update(others...);
       return set;
@@ -29,7 +29,7 @@ namespace builtins
 
     template <typename... Types>
     types::empty_set difference(types::empty_set const &set,
-                                Types const &... others)
+                                Types const &...others)
     {
       return types::empty_set();
     }
@@ -46,11 +46,11 @@ namespace builtins
       return set;
     }
 
-    types::empty_set difference(types::empty_set const &set)
+    inline types::empty_set difference(types::empty_set const &set)
     {
       return types::empty_set();
     }
-  }
-}
+  } // namespace set
+} // namespace builtins
 PYTHONIC_NS_END
 #endif

--- a/pythran/pythonic/builtins/set/union_.hpp
+++ b/pythran/pythonic/builtins/set/union_.hpp
@@ -16,14 +16,14 @@ namespace builtins
 
     template <typename T, typename... Types>
     typename __combined<types::set<T>, Types...>::type
-    union_(types::set<T> const &set, Types const &... others)
+    union_(types::set<T> const &set, Types const &...others)
     {
       return set.union_(others...);
     }
 
     template <typename... Types>
     typename __combined<types::empty_set, Types...>::type
-    union_(types::empty_set const &init, Types const &... others)
+    union_(types::empty_set const &init, Types const &...others)
     {
       return union_(others...);
     }
@@ -40,11 +40,11 @@ namespace builtins
       return {set};
     }
 
-    types::empty_set union_(types::empty_set const &init)
+    inline types::empty_set union_(types::empty_set const &init)
     {
       return types::empty_set();
     }
-  }
-}
+  } // namespace set
+} // namespace builtins
 PYTHONIC_NS_END
 #endif

--- a/pythran/pythonic/builtins/slice.hpp
+++ b/pythran/pythonic/builtins/slice.hpp
@@ -11,22 +11,22 @@ namespace builtins
 
   namespace anonymous
   {
-    types::contiguous_slice slice(types::none<long> stop)
+    inline types::contiguous_slice slice(types::none<long> stop)
     {
       return {types::none<long>(), stop};
     }
-    types::contiguous_slice slice(types::none<long> start,
-                                  types::none<long> stop)
+    inline types::contiguous_slice slice(types::none<long> start,
+                                         types::none<long> stop)
     {
       return {start, stop};
     }
-    types::slice slice(types::none<long> start, types::none<long> stop,
-                       types::none<long> step)
+    inline types::slice slice(types::none<long> start, types::none<long> stop,
+                              types::none<long> step)
     {
       return {start, stop, step};
     }
-  }
-}
+  } // namespace anonymous
+} // namespace builtins
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/builtins/str/find.hpp
+++ b/pythran/pythonic/builtins/str/find.hpp
@@ -14,8 +14,8 @@ namespace builtins
   namespace str
   {
 
-    long find(types::str const &s, types::str const &value, long start,
-              long end)
+    inline long find(types::str const &s, types::str const &value, long start,
+                     long end)
     {
       if (end < 0)
         end += s.size();
@@ -23,16 +23,16 @@ namespace builtins
       return (a > end) ? -1 : a;
     }
 
-    long find(types::str const &s, types::str const &value, long start)
+    inline long find(types::str const &s, types::str const &value, long start)
     {
       return find(s, value, start, s.size());
     }
 
-    long find(types::str const &s, types::str const &value)
+    inline long find(types::str const &s, types::str const &value)
     {
       return find(s, value, 0, s.size());
     }
-  }
-}
+  } // namespace str
+} // namespace builtins
 PYTHONIC_NS_END
 #endif

--- a/pythran/pythonic/builtins/str/split.hpp
+++ b/pythran/pythonic/builtins/str/split.hpp
@@ -4,8 +4,8 @@
 #include "pythonic/include/builtins/str/split.hpp"
 
 #include "pythonic/builtins/str/strip.hpp"
-#include "pythonic/types/list.hpp"
 #include "pythonic/types/NoneType.hpp"
+#include "pythonic/types/list.hpp"
 #include "pythonic/types/str.hpp"
 #include "pythonic/utils/functor.hpp"
 
@@ -17,8 +17,8 @@ namespace builtins
   namespace str
   {
 
-    types::list<types::str> split(types::str const &in, types::str const &sep,
-                                  long maxsplit)
+    inline types::list<types::str> split(types::str const &in,
+                                         types::str const &sep, long maxsplit)
     {
       types::str s = strip(in);
       types::list<types::str> res(0);
@@ -41,8 +41,8 @@ namespace builtins
       return res;
     }
 
-    types::list<types::str> split(types::str const &in,
-                                  types::none_type const &, long maxsplit)
+    inline types::list<types::str>
+    split(types::str const &in, types::none_type const &, long maxsplit)
     {
       types::str s = strip(in);
       types::list<types::str> res(0);
@@ -66,7 +66,7 @@ namespace builtins
       }
       return res;
     }
-  }
-}
+  } // namespace str
+} // namespace builtins
 PYTHONIC_NS_END
 #endif

--- a/pythran/pythonic/include/builtins/pythran/is_none.hpp
+++ b/pythran/pythonic/include/builtins/pythran/is_none.hpp
@@ -1,8 +1,8 @@
 #ifndef PYTHONIC_INCLUDE_BUILTIN_PYTHRAN_IS_NONE_HPP
 #define PYTHONIC_INCLUDE_BUILTIN_PYTHRAN_IS_NONE_HPP
 
-#include "pythonic/include/utils/functor.hpp"
 #include "pythonic/include/types/NoneType.hpp"
+#include "pythonic/include/utils/functor.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -60,35 +60,35 @@ namespace types
     }
   };
 
-  false_type true_type::operator!() const
+  inline false_type true_type::operator!() const
   {
     return {};
   }
-  true_type true_type::operator&(true_type) const
+  inline true_type true_type::operator&(true_type) const
   {
     return {};
   }
-  false_type true_type::operator&(false_type) const
+  inline false_type true_type::operator&(false_type) const
   {
     return {};
   }
-  true_type true_type::operator|(true_type) const
+  inline true_type true_type::operator|(true_type) const
   {
     return {};
   }
-  true_type true_type::operator|(false_type) const
+  inline true_type true_type::operator|(false_type) const
   {
     return {};
   }
-  true_type true_type::operator==(true_type) const
+  inline true_type true_type::operator==(true_type) const
   {
     return {};
   }
-  false_type true_type::operator==(false_type) const
+  inline false_type true_type::operator==(false_type) const
   {
     return {};
   }
-}
+} // namespace types
 
 namespace builtins
 {
@@ -107,14 +107,14 @@ namespace builtins
       return n.is_none;
     };
 
-    types::true_type is_none(types::none_type const &)
+    inline types::true_type is_none(types::none_type const &)
     {
       return {};
     };
 
     DEFINE_FUNCTOR(pythonic::builtins::pythran, is_none);
-  }
-}
+  } // namespace pythran
+} // namespace builtins
 
 #ifdef ENABLE_PYTHON_MODULE
 

--- a/pythran/pythonic/include/builtins/pythran/kwonly.hpp
+++ b/pythran/pythonic/include/builtins/pythran/kwonly.hpp
@@ -9,20 +9,20 @@ namespace types
 {
   struct kwonly {
   };
-}
+} // namespace types
 
 namespace builtins
 {
   namespace pythran
   {
-    types::kwonly kwonly()
+    inline types::kwonly kwonly()
     {
       return {};
     };
 
     DEFINE_FUNCTOR(pythonic::builtins::pythran, kwonly);
-  }
-}
+  } // namespace pythran
+} // namespace builtins
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/include/builtins/pythran/static_list.hpp
+++ b/pythran/pythonic/include/builtins/pythran/static_list.hpp
@@ -1,9 +1,9 @@
 #ifndef PYTHONIC_INCLUDE_BUILTIN_PYTHRAN_STATIC_LIST_HPP
 #define PYTHONIC_INCLUDE_BUILTIN_PYTHRAN_STATIC_LIST_HPP
 
-#include "pythonic/include/utils/functor.hpp"
 #include "pythonic/include/builtins/list.hpp"
 #include "pythonic/include/types/tuple.hpp"
+#include "pythonic/include/utils/functor.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -12,7 +12,7 @@ namespace builtins
 
   namespace pythran
   {
-    types::empty_list static_list(std::tuple<> const &other)
+    inline types::empty_list static_list(std::tuple<> const &other)
     {
       return {};
     }
@@ -37,8 +37,8 @@ namespace builtins
     }
 
     DEFINE_FUNCTOR(pythonic::builtins::pythran, static_list);
-  }
-}
+  } // namespace pythran
+} // namespace builtins
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/include/numpy/size.hpp
+++ b/pythran/pythonic/include/numpy/size.hpp
@@ -1,22 +1,24 @@
 #ifndef PYTHONIC_INCLUDE_NUMPY_SIZE_HPP
 #define PYTHONIC_INCLUDE_NUMPY_SIZE_HPP
 
-#include "pythonic/include/utils/functor.hpp"
 #include "pythonic/include/types/ndarray.hpp"
+#include "pythonic/include/utils/functor.hpp"
 
 PYTHONIC_NS_BEGIN
 
 namespace numpy
 {
 
-
   template <class E>
   auto size(E const &e) -> decltype(e.flat_size());
 
-  long size(...) { return 1; }
+  inline long size(...)
+  {
+    return 1;
+  }
 
   DEFINE_FUNCTOR(pythonic::numpy, size)
-}
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/include/types/NoneType.hpp
+++ b/pythran/pythonic/include/types/NoneType.hpp
@@ -1,8 +1,8 @@
 #ifndef PYTHONIC_INCLUDE_TYPES_NONE_HPP
 #define PYTHONIC_INCLUDE_TYPES_NONE_HPP
 
-#include "pythonic/include/types/assignable.hpp"
 #include "pythonic/include/operator_/mod.hpp"
+#include "pythonic/include/types/assignable.hpp"
 #include <ostream>
 
 PYTHONIC_NS_BEGIN
@@ -17,7 +17,7 @@ namespace types
     intptr_t id() const;
   };
 
-  std::ostream &operator<<(std::ostream &os, none_type const &)
+  inline std::ostream &operator<<(std::ostream &os, none_type const &)
   {
     return os << "None";
   }
@@ -44,8 +44,7 @@ namespace types
     {
     }
     template <class OT>
-    none(OT const &arg)
-        : none(T(arg))
+    none(OT const &arg) : none(T(arg))
     {
     }
 
@@ -68,7 +67,7 @@ namespace types
   };
 
   /* specialization of none for integral types we cannot derive from
-  */
+   */
   template <class P, class T>
   struct none_data {
     explicit operator bool() const
@@ -251,7 +250,7 @@ namespace types
   struct is_none<none<T>> {
     static const bool value = true;
   };
-}
+} // namespace types
 
 template <class T>
 struct assignable<types::none<T>> {
@@ -270,7 +269,7 @@ namespace std
   struct tuple_element<I, pythonic::types::none<T0>> {
     using type = typename std::tuple_element<I, T0>::type;
   };
-}
+} // namespace std
 
 /* type inference stuff { */
 #include "pythonic/include/types/combined.hpp"

--- a/pythran/pythonic/include/types/ndarray.hpp
+++ b/pythran/pythonic/include/types/ndarray.hpp
@@ -2,54 +2,54 @@
 #define PYTHONIC_INCLUDE_TYPES_NDARRAY_HPP
 
 #include "pythonic/include/types/assignable.hpp"
-#include "pythonic/include/types/empty_iterator.hpp"
 #include "pythonic/include/types/attr.hpp"
+#include "pythonic/include/types/empty_iterator.hpp"
 
-#include "pythonic/include/utils/nested_container.hpp"
-#include "pythonic/include/utils/shared_ref.hpp"
-#include "pythonic/include/utils/reserve.hpp"
-#include "pythonic/include/utils/int_.hpp"
 #include "pythonic/include/utils/broadcast_copy.hpp"
+#include "pythonic/include/utils/int_.hpp"
+#include "pythonic/include/utils/nested_container.hpp"
+#include "pythonic/include/utils/reserve.hpp"
+#include "pythonic/include/utils/shared_ref.hpp"
 
-#include "pythonic/include/types/slice.hpp"
-#include "pythonic/include/types/tuple.hpp"
 #include "pythonic/include/types/list.hpp"
 #include "pythonic/include/types/raw_array.hpp"
+#include "pythonic/include/types/slice.hpp"
+#include "pythonic/include/types/tuple.hpp"
 
 #include "pythonic/include/numpy/bool_.hpp"
-#include "pythonic/include/numpy/uint8.hpp"
-#include "pythonic/include/numpy/int8.hpp"
-#include "pythonic/include/numpy/uint16.hpp"
-#include "pythonic/include/numpy/int16.hpp"
-#include "pythonic/include/numpy/uint32.hpp"
-#include "pythonic/include/numpy/int32.hpp"
-#include "pythonic/include/numpy/uint64.hpp"
-#include "pythonic/include/numpy/int64.hpp"
+#include "pythonic/include/numpy/complex128.hpp"
+#include "pythonic/include/numpy/complex64.hpp"
 #include "pythonic/include/numpy/float32.hpp"
 #include "pythonic/include/numpy/float64.hpp"
-#include "pythonic/include/numpy/complex64.hpp"
-#include "pythonic/include/numpy/complex128.hpp"
+#include "pythonic/include/numpy/int16.hpp"
+#include "pythonic/include/numpy/int32.hpp"
+#include "pythonic/include/numpy/int64.hpp"
+#include "pythonic/include/numpy/int8.hpp"
+#include "pythonic/include/numpy/uint16.hpp"
+#include "pythonic/include/numpy/uint32.hpp"
+#include "pythonic/include/numpy/uint64.hpp"
+#include "pythonic/include/numpy/uint8.hpp"
 
 #include "pythonic/include/types/dynamic_tuple.hpp"
-#include "pythonic/include/types/vectorizable_type.hpp"
-#include "pythonic/include/types/numpy_op_helper.hpp"
 #include "pythonic/include/types/numpy_expr.hpp"
-#include "pythonic/include/types/numpy_texpr.hpp"
-#include "pythonic/include/types/numpy_iexpr.hpp"
 #include "pythonic/include/types/numpy_gexpr.hpp"
+#include "pythonic/include/types/numpy_iexpr.hpp"
+#include "pythonic/include/types/numpy_op_helper.hpp"
+#include "pythonic/include/types/numpy_texpr.hpp"
 #include "pythonic/include/types/numpy_vexpr.hpp"
-#include "pythonic/include/utils/numpy_traits.hpp"
-#include "pythonic/include/utils/array_helper.hpp"
 #include "pythonic/include/types/pointer.hpp"
+#include "pythonic/include/types/vectorizable_type.hpp"
+#include "pythonic/include/utils/array_helper.hpp"
+#include "pythonic/include/utils/numpy_traits.hpp"
 
 #include "pythonic/include/builtins/len.hpp"
 
-#include <cassert>
-#include <ostream>
-#include <iterator>
 #include <array>
+#include <cassert>
 #include <initializer_list>
+#include <iterator>
 #include <numeric>
+#include <ostream>
 
 #ifdef ENABLE_PYTHON_MODULE
 // Cython still uses the deprecated API, so we can't set this macro in this
@@ -367,14 +367,14 @@ namespace types
     /* element indexing
      * differentiate const from non const, && r-value from l-value
      * */
-    auto fast(long i) const
-        & -> decltype(type_helper<ndarray const &>::get(*this, i))
+    auto fast(
+        long i) const & -> decltype(type_helper<ndarray const &>::get(*this, i))
     {
       return type_helper<ndarray const &>::get(*this, i);
     }
 
-    auto fast(long i) &&
-        -> decltype(type_helper<ndarray>::get(std::move(*this), i))
+    auto fast(long i) && -> decltype(type_helper<ndarray>::get(std::move(*this),
+                                                               i))
     {
       return type_helper<ndarray>::get(std::move(*this), i);
     }
@@ -393,10 +393,10 @@ namespace types
                                                             indices))>::type;
 
     template <class Ty, size_t M>
-        auto fast(array<Ty, M> const &indices) &&
-        -> typename std::enable_if<std::is_integral<Ty>::value,
-                                   decltype(nget<M - 1>().fast(std::move(*this),
-                                                               indices))>::type;
+    auto fast(array<Ty, M> const &indices) && ->
+        typename std::enable_if<std::is_integral<Ty>::value,
+                                decltype(nget<M - 1>().fast(std::move(*this),
+                                                            indices))>::type;
 
 #ifdef USE_XSIMD
     using simd_iterator = const_simd_nditerator<ndarray>;
@@ -432,10 +432,9 @@ namespace types
     operator[](S const &s) const &;
 
     template <class S>
-        typename std::enable_if<is_slice<S>::value,
-                                numpy_gexpr<ndarray, normalize_t<S>>>::type
-        operator[](S const &s) &&
-        ;
+    typename std::enable_if<is_slice<S>::value,
+                            numpy_gexpr<ndarray, normalize_t<S>>>::type
+    operator[](S const &s) &&;
 
     long size() const;
 
@@ -449,19 +448,17 @@ namespace types
     }
 
     template <class S0, class... S>
-    auto operator()(S0 const &s0, S const &... s) const & -> decltype(
+    auto operator()(S0 const &s0, S const &...s) const & -> decltype(
         extended_slice<count_new_axis<S0, S...>::value>{}((*this), s0, s...));
 
     template <class S0, class... S>
-        auto operator()(S0 const &s0, S const &... s) &
-        -> decltype(extended_slice<count_new_axis<S0, S...>::value>{}((*this),
-                                                                      s0,
-                                                                      s...));
+    auto operator()(S0 const &s0, S const &...s) & -> decltype(
+        extended_slice<count_new_axis<S0, S...>::value>{}((*this), s0, s...));
 
     template <class S0, class... S>
-        auto operator()(S0 const &s0, S const &... s) &&
-        -> decltype(extended_slice<count_new_axis<S0, S...>::value>{}(
-            std::move(*this), s0, s...));
+    auto operator()(S0 const &s0, S const &...s) && -> decltype(
+        extended_slice<count_new_axis<S0, S...>::value>{}(std::move(*this), s0,
+                                                          s...));
 
     /* element filtering */
     template <class F> // indexing through an array of boolean -- a mask
@@ -542,10 +539,10 @@ namespace types
                                 decltype(nget<M - 1>()(*this, indices))>::type;
 
     template <class Ty, size_t M>
-        auto operator[](array<Ty, M> const &indices) &&
-        -> typename std::enable_if<std::is_integral<Ty>::value,
-                                   decltype(nget<M - 1>()(std::move(*this),
-                                                          indices))>::type;
+    auto operator[](array<Ty, M> const &indices) && ->
+        typename std::enable_if<std::is_integral<Ty>::value,
+                                decltype(nget<M - 1>()(std::move(*this),
+                                                       indices))>::type;
 
     template <class... Tys, size_t... Is>
     auto _fwdlongindex(std::tuple<Tys...> const &indices,
@@ -597,16 +594,16 @@ namespace types
     }
 
     template <class Slices, size_t... Is>
-    auto _fwdindex(Slices const &indices, utils::index_sequence<Is...>) const
-        & -> decltype((*this)(std::get<Is>(indices)...))
+    auto _fwdindex(Slices const &indices, utils::index_sequence<Is...>)
+        const & -> decltype((*this)(std::get<Is>(indices)...))
     {
       return (*this)(std::get<Is>(indices)...);
     }
 
     template <class S, size_t... Is>
     auto _fwdindex(dynamic_tuple<S> const &indices,
-                   utils::index_sequence<Is...>) const
-        & -> decltype((*this)(std::get<Is>(indices)...))
+                   utils::index_sequence<Is...>)
+        const & -> decltype((*this)(std::get<Is>(indices)...))
     {
       return (*this)((indices.size() > Is ? std::get<Is>(indices)
                                           : contiguous_slice())...);
@@ -621,8 +618,9 @@ namespace types
                                     indices, utils::make_index_sequence<
                                                  2 + sizeof...(Tys)>()))>::type;
 
-    template <class Ty, size_t M, class _ = typename std::enable_if<
-                                      !std::is_integral<Ty>::value, void>::type>
+    template <class Ty, size_t M,
+              class _ = typename std::enable_if<!std::is_integral<Ty>::value,
+                                                void>::type>
     auto operator[](array<Ty, M> const &indices) const
         & -> decltype(this->_fwdindex(indices, utils::make_index_sequence<M>()))
     {
@@ -654,8 +652,7 @@ namespace types
     template <class qS>
     ndarray<T, qS> reshape(qS const &shape) const &;
     template <class qS>
-        ndarray<T, qS> reshape(qS const &shape) &&
-        ;
+    ndarray<T, qS> reshape(qS const &shape) &&;
 
     explicit operator bool() const;
 
@@ -688,7 +685,7 @@ namespace types
   typename std::enable_if<is_array<E>::value, std::ostream &>::type
   operator<<(std::ostream &os, E const &e);
   /* } */
-}
+} // namespace types
 PYTHONIC_NS_END
 
 /* std::get overloads */
@@ -726,7 +723,7 @@ namespace std
     using type =
         decltype(std::declval<pythonic::types::numpy_gexpr<E, S...>>()[0]);
   };
-}
+} // namespace std
 
 /* pythran attribute system { */
 #include "pythonic/include/numpy/transpose.hpp"
@@ -751,11 +748,9 @@ namespace types
     struct dtype_helper {
       using table = typename std::conditional<std::is_signed<T>::value,
                                               dtype_table, dtype_utable>::type;
-      using type = typename std::tuple_element <
-                           (sizeof(T) < std::tuple_size<table>::value)
-                       ? sizeof(T)
-                       : 0,
-            table > ::type;
+      using type = typename std::tuple_element<
+          (sizeof(T) < std::tuple_size<table>::value) ? sizeof(T) : 0,
+          table>::type;
     };
 
     template <>
@@ -783,10 +778,10 @@ namespace types
     struct dtype_helper<std::complex<long double>> {
       using type = pythonic::numpy::functor::complex256;
     };
-  }
+  } // namespace details
   template <class T>
   using dtype_t = typename details::dtype_helper<T>::type;
-}
+} // namespace types
 namespace builtins
 {
   namespace details
@@ -794,7 +789,7 @@ namespace builtins
     template <size_t N>
     struct _build_gexpr {
       template <class E, class... S>
-      auto operator()(E const &a, S const &... slices)
+      auto operator()(E const &a, S const &...slices)
           -> decltype(_build_gexpr<N - 1>{}(a, types::contiguous_slice(),
                                             slices...));
     };
@@ -803,7 +798,7 @@ namespace builtins
     struct _build_gexpr<1> {
       template <class E, class... S>
       types::numpy_gexpr<E, types::normalize_t<S>...>
-      operator()(E const &a, S const &... slices);
+      operator()(E const &a, S const &...slices);
     };
 
     template <class E>
@@ -837,12 +832,15 @@ namespace builtins
     {
       return std::forward<T>(expr)(std::get<Is>(indices)...);
     }
-  }
+  } // namespace details
 
   template <class E>
   types::array<long, E::value> getattr(types::attr::SHAPE, E const &a);
 
-  types::pshape<> getattr(types::attr::SHAPE, ...) { return {}; }
+  inline types::pshape<> getattr(types::attr::SHAPE, ...)
+  {
+    return {};
+  }
 
   template <class E>
   constexpr decltype(long(E::value)) getattr(types::attr::NDIM, E const &a);
@@ -851,12 +849,18 @@ namespace builtins
   std::integral_constant<long, E::value> getattr(types::attr::NDIM,
                                                  E *const &a);
 
-  long getattr(types::attr::NDIM, ...) { return 0; }
+  inline long getattr(types::attr::NDIM, ...)
+  {
+    return 0;
+  }
 
   template <class E>
   types::array<long, E::value> getattr(types::attr::STRIDES, E const &a);
 
-  std::tuple<> getattr(types::attr::STRIDES, ...) { return {}; }
+  inline std::tuple<> getattr(types::attr::STRIDES, ...)
+  {
+    return {};
+  }
 
   template <class E>
   long getattr(types::attr::SIZE, E const &a);
@@ -881,8 +885,9 @@ namespace builtins
   }
 
   template <class T, class pS>
-  auto getattr(types::attr::REAL, types::ndarray<T, pS> const &a) -> decltype(
-      details::_make_real(a, utils::int_<types::is_complex<T>::value>{}));
+  auto getattr(types::attr::REAL, types::ndarray<T, pS> const &a)
+      -> decltype(details::_make_real(
+          a, utils::int_<types::is_complex<T>::value>{}));
 
   template <class Op, class... Args>
   auto getattr(types::attr::REAL, types::numpy_expr<Op, Args...> const &a)
@@ -904,20 +909,20 @@ namespace builtins
   }
 
   template <class T, class F>
-  auto getattr(types::attr::REAL, types::numpy_vexpr<T, F> const &a)
-      -> decltype(
-          types::numpy_vexpr<decltype(getattr(types::attr::REAL{}, a.data_)),
-                             F>{getattr(types::attr::REAL{}, a.data_), a.view_})
+  auto
+  getattr(types::attr::REAL, types::numpy_vexpr<T, F> const &a) -> decltype(
+      types::numpy_vexpr<decltype(getattr(types::attr::REAL{}, a.data_)), F>{
+          getattr(types::attr::REAL{}, a.data_), a.view_})
   {
     return {getattr(types::attr::REAL{}, a.data_), a.view_};
   }
 
   template <class E, class... S>
   auto getattr(types::attr::REAL, types::numpy_gexpr<E, S...> const &a)
-      -> decltype(
-          details::real_get(getattr(types::attr::REAL{}, a.arg), a.slices,
-                            utils::make_index_sequence<
-                                std::tuple_size<decltype(a.slices)>::value>()))
+      -> decltype(details::real_get(
+          getattr(types::attr::REAL{}, a.arg), a.slices,
+          utils::make_index_sequence<
+              std::tuple_size<decltype(a.slices)>::value>()))
   {
     return details::real_get(getattr(types::attr::REAL{}, a.arg), a.slices,
                              utils::make_index_sequence<
@@ -925,8 +930,9 @@ namespace builtins
   }
 
   template <class T, class pS>
-  auto getattr(types::attr::IMAG, types::ndarray<T, pS> const &a) -> decltype(
-      details::_make_imag(a, utils::int_<types::is_complex<T>::value>{}));
+  auto getattr(types::attr::IMAG, types::ndarray<T, pS> const &a)
+      -> decltype(details::_make_imag(
+          a, utils::int_<types::is_complex<T>::value>{}));
 
   template <class Op, class... Args>
   auto getattr(types::attr::IMAG, types::numpy_expr<Op, Args...> const &a)
@@ -948,20 +954,20 @@ namespace builtins
   }
 
   template <class T, class F>
-  auto getattr(types::attr::IMAG, types::numpy_vexpr<T, F> const &a)
-      -> decltype(
-          types::numpy_vexpr<decltype(getattr(types::attr::IMAG{}, a.data_)),
-                             F>{getattr(types::attr::IMAG{}, a.data_), a.view_})
+  auto
+  getattr(types::attr::IMAG, types::numpy_vexpr<T, F> const &a) -> decltype(
+      types::numpy_vexpr<decltype(getattr(types::attr::IMAG{}, a.data_)), F>{
+          getattr(types::attr::IMAG{}, a.data_), a.view_})
   {
     return {getattr(types::attr::IMAG{}, a.data_), a.view_};
   }
 
   template <class E, class... S>
   auto getattr(types::attr::IMAG, types::numpy_gexpr<E, S...> const &a)
-      -> decltype(
-          details::imag_get(getattr(types::attr::IMAG{}, a.arg), a.slices,
-                            utils::make_index_sequence<
-                                std::tuple_size<decltype(a.slices)>::value>()))
+      -> decltype(details::imag_get(
+          getattr(types::attr::IMAG{}, a.arg), a.slices,
+          utils::make_index_sequence<
+              std::tuple_size<decltype(a.slices)>::value>()))
   {
     return details::imag_get(getattr(types::attr::IMAG{}, a.arg), a.slices,
                              utils::make_index_sequence<
@@ -971,7 +977,7 @@ namespace builtins
   template <class E>
   types::dtype_t<typename types::dtype_of<E>::type> getattr(types::attr::DTYPE,
                                                             E const &);
-}
+} // namespace builtins
 PYTHONIC_NS_END
 
 /* } */
@@ -1110,9 +1116,11 @@ namespace std
   template <class T, class pS>
   typename pythonic::types::nditerator<pythonic::types::ndarray<T, pS>> copy(
       typename pythonic::types::const_nditerator<
-          pythonic::types::ndarray<T, pS>> begin,
+          pythonic::types::ndarray<T, pS>>
+          begin,
       typename pythonic::types::const_nditerator<
-          pythonic::types::ndarray<T, pS>> end,
+          pythonic::types::ndarray<T, pS>>
+          end,
       typename pythonic::types::nditerator<pythonic::types::ndarray<T, pS>> out)
   {
     const long offset = pythonic::sutils::prod_tail(begin.data);
@@ -1121,7 +1129,7 @@ namespace std
               out.data.buffer + out.index * offset);
     return out + (end - begin);
   }
-}
+} // namespace std
 
 #endif
 

--- a/pythran/pythonic/include/types/str.hpp
+++ b/pythran/pythonic/include/types/str.hpp
@@ -5,15 +5,15 @@
 #include "pythonic/include/types/tuple.hpp"
 
 #include "pythonic/include/types/assignable.hpp"
-#include "pythonic/include/utils/shared_ref.hpp"
 #include "pythonic/include/utils/functor.hpp"
 #include "pythonic/include/utils/int_.hpp"
+#include "pythonic/include/utils/shared_ref.hpp"
 
 #include <cassert>
-#include <string>
 #include <cstring>
 #include <sstream>
 #include <stdexcept>
+#include <string>
 
 PYTHONIC_NS_BEGIN
 
@@ -149,7 +149,7 @@ namespace types
     explicit str(char c);
     str(const char *s);
     template <size_t N>
-    str(const char(&s)[N]);
+    str(const char (&s)[N]);
     str(const char *s, size_t n);
     template <class S>
     str(sliced_str<S> const &other);
@@ -295,25 +295,23 @@ namespace types
     long operator-(const_sliced_str_iterator const &other) const;
   };
 
-  size_t hash_value(str const &x);
-
   str operator+(str const &self, str const &other);
   str operator+(chr const &self, chr const &other);
   str operator+(chr const &self, str const &other);
   str operator+(chr const &self, str const &other);
 
   template <size_t N>
-  str operator+(str const &self, char const(&other)[N]);
+  str operator+(str const &self, char const (&other)[N]);
   template <size_t N>
-  str operator+(chr const &self, char const(&other)[N]);
+  str operator+(chr const &self, char const (&other)[N]);
 
   template <size_t N>
-  str operator+(char const(&self)[N], str const &other);
+  str operator+(char const (&self)[N], str const &other);
   template <size_t N>
-  str operator+(char const(&self)[N], chr const &other);
+  str operator+(char const (&self)[N], chr const &other);
 
   template <size_t N>
-  bool operator==(char const(&self)[N], str const &other);
+  bool operator==(char const (&self)[N], str const &other);
 
   bool operator==(chr self, str const &other);
 
@@ -324,20 +322,20 @@ namespace types
   str operator*(long t, str const &s);
   str operator*(chr const &s, long n);
   str operator*(long t, chr const &s);
-}
+} // namespace types
 
 namespace operator_
 {
 
   template <size_t N, class Arg>
-  auto mod(const char(&fmt)[N], Arg &&arg)
+  auto mod(const char (&fmt)[N], Arg &&arg)
       -> decltype(pythonic::types::str(fmt) % std::forward<Arg>(arg));
 
   pythonic::types::str add(char const *self, char const *other);
 
   pythonic::types::str mul(char const *self, long other);
   pythonic::types::str mul(long self, char const *other);
-}
+} // namespace operator_
 
 template <>
 struct assignable<types::chr> {
@@ -357,9 +355,7 @@ struct assignable<char[N]> {
   using type = types::str;
 };
 template <size_t N>
-struct assignable<char const[N]> {
-  using type = types::str;
-};
+struct assignable<char const [N]> { using type = types::str; };
 PYTHONIC_NS_END
 
 namespace std
@@ -387,7 +383,7 @@ namespace std
   struct tuple_element<I, pythonic::types::sliced_str<S>> {
     using type = pythonic::types::str;
   };
-}
+} // namespace std
 
 /* type inference stuff  {*/
 #include "pythonic/include/types/combined.hpp"

--- a/pythran/pythonic/include/types/tuple.hpp
+++ b/pythran/pythonic/include/types/tuple.hpp
@@ -2,14 +2,14 @@
 #define PYTHONIC_INCLUDE_TYPES_TUPLE_HPP
 
 #include "pythonic/include/types/assignable.hpp"
-#include "pythonic/include/types/traits.hpp"
 #include "pythonic/include/types/nditerator.hpp"
+#include "pythonic/include/types/traits.hpp"
 #include "pythonic/include/utils/int_.hpp"
-#include "pythonic/include/utils/seq.hpp"
 #include "pythonic/include/utils/nested_container.hpp"
+#include "pythonic/include/utils/seq.hpp"
 
-#include <tuple>
 #include <algorithm>
+#include <tuple>
 
 #if !defined(HAVE_SSIZE_T) || !HAVE_SSIZE_T
 #if defined(_MSC_VER)
@@ -26,7 +26,7 @@ namespace std
 
   template <class F0, class S0, class F1, class S1>
   bool operator==(pair<const F0, S0> const &self, tuple<F1, S1> const &other);
-}
+} // namespace std
 
 // Tuple concatenation with operator+
 template <class... Types0, class... Types1>
@@ -112,12 +112,13 @@ namespace types
   template <class S, class... Stail>
   auto tuple_pop(std::tuple<S, Stail...> const &t)
       -> decltype(make_tuple_tail<count_trailing_long<Stail...>::value>(
-          t, utils::make_index_sequence<
-                 sizeof...(Stail)-count_trailing_long<Stail...>::value>{}))
+          t,
+          utils::make_index_sequence<sizeof...(Stail) -
+                                     count_trailing_long<Stail...>::value>{}))
   {
     return make_tuple_tail<count_trailing_long<Stail...>::value>(
-        t, utils::make_index_sequence<sizeof...(
-               Stail)-count_trailing_long<Stail...>::value>{});
+        t, utils::make_index_sequence<sizeof...(Stail) -
+                                      count_trailing_long<Stail...>::value>{});
   }
 
   template <class A, size_t... I, class... Types>
@@ -140,7 +141,7 @@ namespace types
   {
     return N;
   }
-  long check_type(long, long value)
+  inline long check_type(long, long value)
   {
     return value;
   }
@@ -304,7 +305,7 @@ namespace types
     {
       return extract_shape(e[0], utils::int_<L - 1>{});
     }
-  }
+  } // namespace details
 
   /* inspired by std::array implementation */
   template <typename T, size_t N, typename Version>
@@ -546,9 +547,10 @@ namespace types
           alike<T, typename std::remove_cv<typename std::remove_reference<
                        Types>::type>::type...>::value;
       using type = typename std::conditional<
-          value, typename alike<
-                     T, typename std::remove_cv<typename std::remove_reference<
-                            Types>::type>::type...>::type,
+          value,
+          typename alike<T,
+                         typename std::remove_cv<typename std::remove_reference<
+                             Types>::type>::type...>::type,
           void>::type;
     };
 
@@ -563,7 +565,7 @@ namespace types
                                 alike<T, typename alike<Types...>::type>::value;
       using type = typename alike<T, typename alike<Types...>::type>::type;
     };
-  }
+  } // namespace details
 
   template <class... Types>
   struct alike : details::alike<typename std::remove_cv<
@@ -574,7 +576,7 @@ namespace types
   // (static array for sames types || real tuple otherwise)
   template <bool Same, class... Types>
   struct _make_tuple {
-    auto operator()(Types &&... types)
+    auto operator()(Types &&...types)
         -> decltype(std::make_tuple(std::forward<Types>(types)...))
     {
       return std::make_tuple(std::forward<Types>(types)...);
@@ -584,14 +586,14 @@ namespace types
   template <class... Types>
   struct _make_tuple<true, Types...> {
     types::array<typename alike<Types...>::type, sizeof...(Types)>
-    operator()(Types &&... types)
+    operator()(Types &&...types)
     {
       return {{std::forward<Types>(types)...}};
     }
   };
 
   template <class... Types>
-  auto make_tuple(Types &&... types)
+  auto make_tuple(Types &&...types)
 #if !_MSC_VER || __clang__
       -> decltype(_make_tuple<alike<Types...>::value, Types...>()(
           std::forward<Types>(types)...))
@@ -627,7 +629,7 @@ namespace types
   auto operator+(types::array_base<T, N, V> const &lt,
                  std::tuple<Types...> const &t)
       -> decltype(std::tuple_cat(lt.to_tuple(), t));
-}
+} // namespace types
 
 template <class... Types>
 struct assignable<std::tuple<Types...>> {
@@ -677,7 +679,7 @@ namespace std
   struct tuple_size<pythonic::types::array_base<T, N, V>> {
     static const size_t value = N;
   };
-}
+} // namespace std
 
 /* hashable tuples, as proposed in
  * http://stackoverflow.com/questions/7110301/generic-hash-for-tuples-in-unordered-map-unordered-set
@@ -695,7 +697,7 @@ namespace
   struct hash_impl<0, types...> {
     size_t operator()(size_t a, const std::tuple<types...> &t) const;
   };
-}
+} // namespace
 
 /* specialize std::hash */
 namespace std
@@ -709,7 +711,7 @@ namespace std
   struct hash<pythonic::types::array_base<T, N, V>> {
     size_t operator()(pythonic::types::array_base<T, N, V> const &l) const;
   };
-}
+} // namespace std
 
 /* type inference stuff  {*/
 #include "pythonic/include/types/combined.hpp"
@@ -818,7 +820,7 @@ namespace details
   struct pick_combined<T, P, false> {
     using type = P;
   };
-}
+} // namespace details
 PYTHONIC_NS_END
 
 template <long I, class t, class... t0>
@@ -829,8 +831,8 @@ struct __combined<std::tuple<t0...>,
   static std::tuple<typename pythonic::details::pick_combined<
       t, typename std::tuple_element<Is, holder>::type, I == Is>::type...>
       make_type(pythonic::utils::index_sequence<Is...>);
-  static auto make_type() -> decltype(
-      make_type(pythonic::utils::make_index_sequence<sizeof...(t0)>()));
+  static auto make_type() -> decltype(make_type(
+      pythonic::utils::make_index_sequence<sizeof...(t0)>()));
   using type = decltype(make_type());
 };
 
@@ -892,7 +894,7 @@ namespace types
   struct len_of<std::tuple<Types...>> {
     static constexpr long value = sizeof...(Types);
   };
-}
+} // namespace types
 PYTHONIC_NS_END
 
 namespace std
@@ -927,10 +929,10 @@ namespace std
 
   template <size_t I, class... Tys>
   struct tuple_element<I, pythonic::types::pshape<Tys...>> {
-    using type = typename std::tuple_element < I < sizeof...(Tys) ? I : 0,
-          std::tuple<Tys...>> ::type;
+    using type = typename std::tuple_element <
+                 I<sizeof...(Tys) ? I : 0, std::tuple<Tys...>>::type;
   };
-}
+} // namespace std
 PYTHONIC_NS_BEGIN
 namespace sutils
 {
@@ -1017,8 +1019,9 @@ namespace sutils
   struct shape_commonifier<std::integral_constant<long, N0>,
                            std::integral_constant<long, N1>, Ss...> {
     using type = typename std::conditional<
-        N0 == N1, typename shape_commonifier<std::integral_constant<long, N0>,
-                                             Ss...>::type,
+        N0 == N1,
+        typename shape_commonifier<std::integral_constant<long, N0>,
+                                   Ss...>::type,
         long>::type;
   };
 
@@ -1173,7 +1176,10 @@ namespace sutils
     return getshape(e, utils::make_index_sequence<E::value>());
   }
 
-  inline std::tuple<> getshape(...) { return {};}
+  inline std::tuple<> getshape(...)
+  {
+    return {};
+  }
 
   template <class pS0, class pS1>
   struct concat;
@@ -1225,8 +1231,9 @@ namespace sutils
   }
 
   template <class S>
-  long find(S &s, long v, long start = S::value,
-            bool comp(long, long) = [](long a, long b) { return (a == b); })
+  long find(
+      S &s, long v, long start = S::value,
+      bool comp(long, long) = [](long a, long b) { return (a == b); })
   {
     return find(s, v, std::integral_constant<size_t, S::value - 1>(), start,
                 comp);
@@ -1248,8 +1255,9 @@ namespace sutils
   }
 
   template <class S>
-  long sfind(S &s, long v, long start = std::tuple_size<S>::value,
-             bool comp(long, long) = [](long a, long b) { return (a == b); })
+  long sfind(
+      S &s, long v, long start = std::tuple_size<S>::value,
+      bool comp(long, long) = [](long a, long b) { return (a == b); })
   {
     return sfind(
         s, v, std::integral_constant<size_t, std::tuple_size<S>::value - 1>(),
@@ -1480,8 +1488,8 @@ namespace sutils
             decltype(copy_new_axis_helper<I - 1>{}.doit(
                 sutils::push_front_t<S0, typename std::tuple_element<
                                              J, typename S1::shape_t>::type>(),
-                shape, new_axis, std::integral_constant < size_t,
-                J == 0 ? J : J - 1 > ()))>::type
+                shape, new_axis,
+                std::integral_constant<size_t, J == 0 ? J : J - 1>()))>::type
     {
       return copy_new_axis_helper<I - 1>{}.doit(
           sutils::push_front_t<
@@ -1500,8 +1508,8 @@ namespace sutils
             decltype(copy_new_axis_helper<I - 1>{}.doit(
                 sutils::push_front_t<S0, typename std::tuple_element<
                                              J, typename S1::shape_t>::type>(),
-                shape, new_axis, std::integral_constant < size_t,
-                J == 0 ? J : J - 1 > ()))>::type
+                shape, new_axis,
+                std::integral_constant<size_t, J == 0 ? J : J - 1>()))>::type
     {
       return copy_new_axis_helper<I - 1>{}.doit(
           sutils::push_front_t<
@@ -1523,7 +1531,7 @@ namespace sutils
         types::pshape<>(), shape, new_axis,
         std::integral_constant<size_t, S1::value - 1>());
   }
-}
+} // namespace sutils
 
 namespace types
 {
@@ -1540,7 +1548,7 @@ namespace types
       sutils::assign(std::get<std::tuple_size<S>::value - L>(res), e.size());
       init_shape(res, e[0], utils::int_<L - 1>{});
     }
-  }
+  } // namespace details
   template <class T, class... Tys>
   bool operator==(T const &self, pshape<Tys...> const &other)
   {
@@ -1571,14 +1579,14 @@ namespace types
   {
     return !sutils::equals(self, other);
   }
-}
+} // namespace types
 
 PYTHONIC_NS_END
 
 #ifdef ENABLE_PYTHON_MODULE
 
-#include "pythonic/include/utils/seq.hpp"
 #include "pythonic/include/utils/fwd.hpp"
+#include "pythonic/include/utils/seq.hpp"
 #include "pythonic/python/core.hpp"
 
 PYTHONIC_NS_BEGIN

--- a/pythran/pythonic/itertools/count.hpp
+++ b/pythran/pythonic/itertools/count.hpp
@@ -63,8 +63,7 @@ namespace itertools
     }
 
     template <class T>
-    count<T>::count(T value, T step)
-        : count_iterator<T>(value, step)
+    count<T>::count(T value, T step) : count_iterator<T>(value, step)
     {
     }
 
@@ -85,7 +84,7 @@ namespace itertools
     {
       return {std::numeric_limits<T>::max(), count_iterator<T>::step};
     }
-  }
+  } // namespace details
 
   template <typename T0, typename T1>
   details::count<typename __combined<T0, T1>::type> count(T0 start, T1 step)
@@ -94,11 +93,11 @@ namespace itertools
     return {static_cast<return_t>(start), static_cast<return_t>(step)};
   }
 
-  details::count<long> count()
+  inline details::count<long> count()
   {
     return {0, 1};
   }
-}
+} // namespace itertools
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/math/log.hpp
+++ b/pythran/pythonic/math/log.hpp
@@ -12,11 +12,11 @@ namespace math
 {
   using std::log;
 
-  double log(double x, double base)
+  inline double log(double x, double base)
   {
     return log(x) / log(base);
   }
-}
+} // namespace math
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/binary_repr.hpp
+++ b/pythran/pythonic/numpy/binary_repr.hpp
@@ -15,7 +15,7 @@ namespace numpy
   namespace details
   {
 
-    char *int2bin(long a, char *buffer, int buf_size)
+    inline char *int2bin(long a, char *buffer, int buf_size)
     {
       buffer += (buf_size - 1);
       buffer[1] = 0;
@@ -25,14 +25,14 @@ namespace numpy
       }
       return buffer;
     }
-  }
+  } // namespace details
 
-  types::str binary_repr(long number, types::none_type width)
+  inline types::str binary_repr(long number, types::none_type width)
   {
     return base_repr(number, 2);
   }
 
-  types::str binary_repr(long number, long width)
+  inline types::str binary_repr(long number, long width)
   {
     types::str out = binary_repr(std::abs(number));
     if (number >= 0)
@@ -44,7 +44,7 @@ namespace numpy
       return res;
     }
   }
-}
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/bitwise_not.hpp
+++ b/pythran/pythonic/numpy/bitwise_not.hpp
@@ -3,9 +3,9 @@
 
 #include "pythonic/include/numpy/bitwise_not.hpp"
 
+#include "pythonic/types/numpy_op_helper.hpp"
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
-#include "pythonic/types/numpy_op_helper.hpp"
 
 PYTHONIC_NS_BEGIN
 namespace numpy
@@ -19,16 +19,16 @@ namespace numpy
       return ~a;
     }
 
-    bool bitwise_not(bool t0)
+    inline bool bitwise_not(bool t0)
     {
       return !t0;
     }
-  }
+  } // namespace wrapper
 
 #define NUMPY_NARY_FUNC_NAME bitwise_not
 #define NUMPY_NARY_FUNC_SYM wrapper::bitwise_not
 #include "pythonic/types/numpy_nary_expr.hpp"
-}
+} // namespace numpy
 PYTHONIC_NS_END
 
 // ndarray have to be include after as bitwise_not is used as a numpy_operator

--- a/pythran/pythonic/numpy/bool_.hpp
+++ b/pythran/pythonic/numpy/bool_.hpp
@@ -3,10 +3,10 @@
 
 #include "pythonic/include/numpy/bool_.hpp"
 
+#include "pythonic/types/numpy_op_helper.hpp"
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/meta.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
-#include "pythonic/types/numpy_op_helper.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -16,7 +16,7 @@ namespace numpy
   namespace details
   {
 
-    bool bool_()
+    inline bool bool_()
     {
       return bool();
     }
@@ -26,12 +26,12 @@ namespace numpy
     {
       return v;
     }
-  }
+  } // namespace details
 
 #define NUMPY_NARY_FUNC_NAME bool_
 #define NUMPY_NARY_FUNC_SYM details::bool_
 #include "pythonic/types/numpy_nary_expr.hpp"
-}
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/byte.hpp
+++ b/pythran/pythonic/numpy/byte.hpp
@@ -3,10 +3,10 @@
 
 #include "pythonic/include/numpy/byte.hpp"
 
+#include "pythonic/types/numpy_op_helper.hpp"
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/meta.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
-#include "pythonic/types/numpy_op_helper.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -16,7 +16,7 @@ namespace numpy
   namespace details
   {
 
-    char byte()
+    inline char byte()
     {
       return {};
     }
@@ -26,12 +26,12 @@ namespace numpy
     {
       return v;
     }
-  }
+  } // namespace details
 
 #define NUMPY_NARY_FUNC_NAME byte
 #define NUMPY_NARY_FUNC_SYM details::byte
 #include "pythonic/types/numpy_nary_expr.hpp"
-}
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/complex.hpp
+++ b/pythran/pythonic/numpy/complex.hpp
@@ -3,8 +3,8 @@
 
 #include "pythonic/include/numpy/complex.hpp"
 
-#include "pythonic/utils/functor.hpp"
 #include "pythonic/types/complex.hpp"
+#include "pythonic/utils/functor.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -13,16 +13,16 @@ namespace numpy
 
   namespace details
   {
-    std::complex<double> complex(double v, double v2)
+    inline std::complex<double> complex(double v, double v2)
     {
       return {v, v2};
     }
-  }
+  } // namespace details
 
 #define NUMPY_NARY_FUNC_NAME complex
 #define NUMPY_NARY_FUNC_SYM details::complex
 #include "pythonic/types/numpy_nary_expr.hpp"
-}
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/complex128.hpp
+++ b/pythran/pythonic/numpy/complex128.hpp
@@ -3,10 +3,10 @@
 
 #include "pythonic/include/numpy/complex128.hpp"
 
+#include "pythonic/types/numpy_op_helper.hpp"
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/meta.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
-#include "pythonic/types/numpy_op_helper.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -15,7 +15,7 @@ namespace numpy
   namespace details
   {
 
-    std::complex<double> complex128()
+    inline std::complex<double> complex128()
     {
       return {};
     }
@@ -25,12 +25,12 @@ namespace numpy
     {
       return v;
     }
-  }
+  } // namespace details
 
 #define NUMPY_NARY_FUNC_NAME complex128
 #define NUMPY_NARY_FUNC_SYM details::complex128
 #include "pythonic/types/numpy_nary_expr.hpp"
-}
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/complex256.hpp
+++ b/pythran/pythonic/numpy/complex256.hpp
@@ -3,10 +3,10 @@
 
 #include "pythonic/include/numpy/complex256.hpp"
 
+#include "pythonic/types/numpy_op_helper.hpp"
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/meta.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
-#include "pythonic/types/numpy_op_helper.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -15,7 +15,7 @@ namespace numpy
   namespace details
   {
 
-    std::complex<long double> complex256()
+    inline std::complex<long double> complex256()
     {
       return {};
     }
@@ -25,12 +25,12 @@ namespace numpy
     {
       return v;
     }
-  }
+  } // namespace details
 
 #define NUMPY_NARY_FUNC_NAME complex256
 #define NUMPY_NARY_FUNC_SYM details::complex256
 #include "pythonic/types/numpy_nary_expr.hpp"
-}
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/complex64.hpp
+++ b/pythran/pythonic/numpy/complex64.hpp
@@ -3,11 +3,11 @@
 
 #include "pythonic/include/numpy/complex64.hpp"
 
+#include "pythonic/types/complex.hpp"
+#include "pythonic/types/numpy_op_helper.hpp"
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/meta.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
-#include "pythonic/types/complex.hpp"
-#include "pythonic/types/numpy_op_helper.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -16,7 +16,7 @@ namespace numpy
   namespace details
   {
 
-    std::complex<float> complex64()
+    inline std::complex<float> complex64()
     {
       return {};
     }
@@ -32,12 +32,12 @@ namespace numpy
     {
       return {(float)v.real(), (float)v.imag()};
     }
-  }
+  } // namespace details
 
 #define NUMPY_NARY_FUNC_NAME complex64
 #define NUMPY_NARY_FUNC_SYM details::complex64
 #include "pythonic/types/numpy_nary_expr.hpp"
-}
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/dot.hpp
+++ b/pythran/pythonic/numpy/dot.hpp
@@ -3,9 +3,9 @@
 
 #include "pythonic/include/numpy/dot.hpp"
 
-#include "pythonic/types/ndarray.hpp"
-#include "pythonic/numpy/sum.hpp"
 #include "pythonic/numpy/multiply.hpp"
+#include "pythonic/numpy/sum.hpp"
+#include "pythonic/types/ndarray.hpp"
 #include "pythonic/types/traits.hpp"
 
 #ifdef PYTHRAN_BLAS_NONE
@@ -126,10 +126,10 @@ namespace numpy
     return out;
   }
 
-/// Matrice / Vector multiplication
+  /// Matrice / Vector multiplication
 
 #define MV_DEF(T, L)                                                           \
-  void mv(int m, int n, T *A, T *B, T *C)                                      \
+  inline void mv(int m, int n, T *A, T *B, T *C)                               \
   {                                                                            \
     cblas_##L##gemv(CblasRowMajor, CblasNoTrans, n, m, 1, A, m, B, 1, 0, C,    \
                     1);                                                        \
@@ -141,7 +141,7 @@ namespace numpy
 #undef MV_DEF
 
 #define TV_DEF(T, L)                                                           \
-  void tv(int m, int n, T *A, T *B, T *C)                                      \
+  inline void tv(int m, int n, T *A, T *B, T *C)                               \
   {                                                                            \
     cblas_##L##gemv(CblasRowMajor, CblasTrans, m, n, 1, A, n, B, 1, 0, C, 1);  \
   }
@@ -152,7 +152,7 @@ namespace numpy
 #undef TV_DEF
 
 #define MV_DEF(T, K, L)                                                        \
-  void mv(int m, int n, T *A, T *B, T *C)                                      \
+  inline void mv(int m, int n, T *A, T *B, T *C)                               \
   {                                                                            \
     T alpha = 1, beta = 0;                                                     \
     cblas_##L##gemv(CblasRowMajor, CblasNoTrans, n, m, (K *)&alpha, (K *)A, m, \
@@ -193,7 +193,7 @@ namespace numpy
 
 // The trick is to not transpose the matrix so that MV become VM
 #define VM_DEF(T, L)                                                           \
-  void vm(int m, int n, T *A, T *B, T *C)                                      \
+  inline void vm(int m, int n, T *A, T *B, T *C)                               \
   {                                                                            \
     cblas_##L##gemv(CblasRowMajor, CblasTrans, n, m, 1, A, m, B, 1, 0, C, 1);  \
   }
@@ -203,7 +203,7 @@ namespace numpy
 
 #undef VM_DEF
 #define VT_DEF(T, L)                                                           \
-  void vt(int m, int n, T *A, T *B, T *C)                                      \
+  inline void vt(int m, int n, T *A, T *B, T *C)                               \
   {                                                                            \
     cblas_##L##gemv(CblasRowMajor, CblasNoTrans, m, n, 1, A, n, B, 1, 0, C,    \
                     1);                                                        \
@@ -214,7 +214,7 @@ namespace numpy
 
 #undef VM_DEF
 #define VM_DEF(T, K, L)                                                        \
-  void vm(int m, int n, T *A, T *B, T *C)                                      \
+  inline void vm(int m, int n, T *A, T *B, T *C)                               \
   {                                                                            \
     T alpha = 1, beta = 0;                                                     \
     cblas_##L##gemv(CblasRowMajor, CblasTrans, n, m, (K *)&alpha, (K *)A, m,   \
@@ -264,8 +264,7 @@ namespace numpy
           is_blas_type<typename E::dtype>::value &&
           is_blas_type<typename F::dtype>::value // With dtype compatible with
                                                  // blas
-          &&
-          E::value == 2 && F::value == 1, // And it is matrix / vect
+          && E::value == 2 && F::value == 1,     // And it is matrix / vect
       types::ndarray<
           typename __combined<typename E::dtype, typename F::dtype>::type,
           types::pshape<long>>>::type
@@ -273,10 +272,12 @@ namespace numpy
   {
     types::ndarray<
         typename __combined<typename E::dtype, typename F::dtype>::type,
-        typename E::shape_t> e_ = e;
+        typename E::shape_t>
+        e_ = e;
     types::ndarray<
         typename __combined<typename E::dtype, typename F::dtype>::type,
-        typename F::shape_t> f_ = f;
+        typename F::shape_t>
+        f_ = f;
     return dot(e_, f_);
   }
 
@@ -291,8 +292,7 @@ namespace numpy
           is_blas_type<typename E::dtype>::value &&
           is_blas_type<typename F::dtype>::value // With dtype compatible with
                                                  // blas
-          &&
-          E::value == 1 && F::value == 2, // And it is vect / matrix
+          && E::value == 1 && F::value == 2,     // And it is vect / matrix
       types::ndarray<
           typename __combined<typename E::dtype, typename F::dtype>::type,
           types::pshape<long>>>::type
@@ -300,10 +300,12 @@ namespace numpy
   {
     types::ndarray<
         typename __combined<typename E::dtype, typename F::dtype>::type,
-        typename E::shape_t> e_ = e;
+        typename E::shape_t>
+        e_ = e;
     types::ndarray<
         typename __combined<typename E::dtype, typename F::dtype>::type,
-        typename F::shape_t> f_ = f;
+        typename F::shape_t>
+        f_ = f;
     return dot(e_, f_);
   }
 
@@ -322,7 +324,7 @@ namespace numpy
     types::ndarray<
         typename __combined<typename E::dtype, typename F::dtype>::type,
         types::pshape<long>>
-    out(types::pshape<long>{f.template shape<1>()}, 0);
+        out(types::pshape<long>{f.template shape<1>()}, 0);
     for (long i = 0; i < out.template shape<0>(); i++)
       for (long j = 0; j < f.template shape<0>(); j++)
         out[i] += e[j] * f[types::array<long, 2>{{j, i}}];
@@ -344,17 +346,17 @@ namespace numpy
     types::ndarray<
         typename __combined<typename E::dtype, typename F::dtype>::type,
         types::pshape<long>>
-    out(types::pshape<long>{e.template shape<0>()}, 0);
+        out(types::pshape<long>{e.template shape<0>()}, 0);
     for (long i = 0; i < out.template shape<0>(); i++)
       for (long j = 0; j < f.template shape<0>(); j++)
         out[i] += e[types::array<long, 2>{{i, j}}] * f[j];
     return out;
   }
 
-/// Matrix / Matrix multiplication
+  /// Matrix / Matrix multiplication
 
 #define MM_DEF(T, L)                                                           \
-  void mm(int m, int n, int k, T *A, T *B, T *C)                               \
+  inline void mm(int m, int n, int k, T *A, T *B, T *C)                        \
   {                                                                            \
     cblas_##L##gemm(CblasRowMajor, CblasNoTrans, CblasNoTrans, m, n, k, 1, A,  \
                     k, B, n, 0, C, n);                                         \
@@ -363,7 +365,7 @@ namespace numpy
   MM_DEF(float, s)
 #undef MM_DEF
 #define MM_DEF(T, K, L)                                                        \
-  void mm(int m, int n, int k, T *A, T *B, T *C)                               \
+  inline void mm(int m, int n, int k, T *A, T *B, T *C)                        \
   {                                                                            \
     T alpha = 1, beta = 0;                                                     \
     cblas_##L##gemm(CblasRowMajor, CblasNoTrans, CblasNoTrans, m, n, k,        \
@@ -405,7 +407,7 @@ namespace numpy
   }
 
 #define TM_DEF(T, L)                                                           \
-  void tm(int m, int n, int k, T *A, T *B, T *C)                               \
+  inline void tm(int m, int n, int k, T *A, T *B, T *C)                        \
   {                                                                            \
     cblas_##L##gemm(CblasRowMajor, CblasTrans, CblasNoTrans, m, n, k, 1, A, m, \
                     B, n, 0, C, n);                                            \
@@ -414,7 +416,7 @@ namespace numpy
   TM_DEF(float, s)
 #undef TM_DEF
 #define TM_DEF(T, K, L)                                                        \
-  void tm(int m, int n, int k, T *A, T *B, T *C)                               \
+  inline void tm(int m, int n, int k, T *A, T *B, T *C)                        \
   {                                                                            \
     T alpha = 1, beta = 0;                                                     \
     cblas_##L##gemm(CblasRowMajor, CblasTrans, CblasNoTrans, m, n, k,          \
@@ -442,7 +444,7 @@ namespace numpy
   }
 
 #define MT_DEF(T, L)                                                           \
-  void mt(int m, int n, int k, T *A, T *B, T *C)                               \
+  inline void mt(int m, int n, int k, T *A, T *B, T *C)                        \
   {                                                                            \
     cblas_##L##gemm(CblasRowMajor, CblasNoTrans, CblasTrans, m, n, k, 1, A, k, \
                     B, k, 0, C, n);                                            \
@@ -451,7 +453,7 @@ namespace numpy
   MT_DEF(float, s)
 #undef MT_DEF
 #define MT_DEF(T, K, L)                                                        \
-  void mt(int m, int n, int k, T *A, T *B, T *C)                               \
+  inline void mt(int m, int n, int k, T *A, T *B, T *C)                        \
   {                                                                            \
     T alpha = 1, beta = 0;                                                     \
     cblas_##L##gemm(CblasRowMajor, CblasNoTrans, CblasTrans, m, n, k,          \
@@ -479,7 +481,7 @@ namespace numpy
   }
 
 #define TT_DEF(T, L)                                                           \
-  void tt(int m, int n, int k, T *A, T *B, T *C)                               \
+  inline void tt(int m, int n, int k, T *A, T *B, T *C)                        \
   {                                                                            \
     cblas_##L##gemm(CblasRowMajor, CblasTrans, CblasTrans, m, n, k, 1, A, m,   \
                     B, k, 0, C, n);                                            \
@@ -488,7 +490,7 @@ namespace numpy
   TT_DEF(float, s)
 #undef TT_DEF
 #define TT_DEF(T, K, L)                                                        \
-  void tt(int m, int n, int k, T *A, T *B, T *C)                               \
+  inline void tt(int m, int n, int k, T *A, T *B, T *C)                        \
   {                                                                            \
     T alpha = 1, beta = 0;                                                     \
     cblas_##L##gemm(CblasRowMajor, CblasTrans, CblasTrans, m, n, k,            \
@@ -526,8 +528,7 @@ namespace numpy
           is_blas_type<typename E::dtype>::value &&
           is_blas_type<typename F::dtype>::value // With dtype compatible with
                                                  // blas
-          &&
-          E::value == 2 && F::value == 2, // And both are matrix
+          && E::value == 2 && F::value == 2,     // And both are matrix
       types::ndarray<
           typename __combined<typename E::dtype, typename F::dtype>::type,
           types::array<long, 2>>>::type
@@ -535,10 +536,12 @@ namespace numpy
   {
     types::ndarray<
         typename __combined<typename E::dtype, typename F::dtype>::type,
-        typename E::shape_t> e_ = e;
+        typename E::shape_t>
+        e_ = e;
     types::ndarray<
         typename __combined<typename E::dtype, typename F::dtype>::type,
-        typename F::shape_t> f_ = f;
+        typename F::shape_t>
+        f_ = f;
     return dot(e_, f_);
   }
 
@@ -557,8 +560,9 @@ namespace numpy
     types::ndarray<
         typename __combined<typename E::dtype, typename F::dtype>::type,
         types::array<long, 2>>
-    out(types::array<long, 2>{{e.template shape<0>(), f.template shape<1>()}},
-        0);
+        out(types::array<long, 2>{{e.template shape<0>(),
+                                   f.template shape<1>()}},
+            0);
     for (long i = 0; i < out.template shape<0>(); i++)
       for (long j = 0; j < out.template shape<1>(); j++)
         for (long k = 0; k < e.template shape<1>(); k++)
@@ -594,7 +598,7 @@ namespace numpy
   {
     static_assert(E::value == 0, "not implemented yet");
   }
-}
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/float128.hpp
+++ b/pythran/pythonic/numpy/float128.hpp
@@ -3,10 +3,10 @@
 
 #include "pythonic/include/numpy/float128.hpp"
 
+#include "pythonic/types/numpy_op_helper.hpp"
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/meta.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
-#include "pythonic/types/numpy_op_helper.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -15,7 +15,7 @@ namespace numpy
   namespace details
   {
 
-    long double float128()
+    inline long double float128()
     {
       return {};
     }
@@ -25,12 +25,12 @@ namespace numpy
     {
       return static_cast<long double>(v);
     }
-  }
+  } // namespace details
 
 #define NUMPY_NARY_FUNC_NAME float128
 #define NUMPY_NARY_FUNC_SYM details::float128
 #include "pythonic/types/numpy_nary_expr.hpp"
-}
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/float32.hpp
+++ b/pythran/pythonic/numpy/float32.hpp
@@ -3,10 +3,10 @@
 
 #include "pythonic/include/numpy/float32.hpp"
 
+#include "pythonic/types/numpy_op_helper.hpp"
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/meta.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
-#include "pythonic/types/numpy_op_helper.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -16,7 +16,7 @@ namespace numpy
   namespace details
   {
 
-    float float32()
+    inline float float32()
     {
       return float();
     }
@@ -26,12 +26,12 @@ namespace numpy
     {
       return static_cast<float>(v);
     }
-  }
+  } // namespace details
 
 #define NUMPY_NARY_FUNC_NAME float32
 #define NUMPY_NARY_FUNC_SYM details::float32
 #include "pythonic/types/numpy_nary_expr.hpp"
-}
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/float64.hpp
+++ b/pythran/pythonic/numpy/float64.hpp
@@ -3,10 +3,10 @@
 
 #include "pythonic/include/numpy/float64.hpp"
 
+#include "pythonic/types/numpy_op_helper.hpp"
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/meta.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
-#include "pythonic/types/numpy_op_helper.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -15,7 +15,7 @@ namespace numpy
   namespace details
   {
 
-    double float64()
+    inline double float64()
     {
       return double();
     }
@@ -25,12 +25,12 @@ namespace numpy
     {
       return static_cast<double>(v);
     }
-  }
+  } // namespace details
 
 #define NUMPY_NARY_FUNC_NAME float64
 #define NUMPY_NARY_FUNC_SYM details::float64
 #include "pythonic/types/numpy_nary_expr.hpp"
-}
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/int16.hpp
+++ b/pythran/pythonic/numpy/int16.hpp
@@ -3,10 +3,10 @@
 
 #include "pythonic/include/numpy/int16.hpp"
 
+#include "pythonic/types/numpy_op_helper.hpp"
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/meta.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
-#include "pythonic/types/numpy_op_helper.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -16,7 +16,7 @@ namespace numpy
   namespace details
   {
 
-    int16_t int16()
+    inline int16_t int16()
     {
       return int16_t();
     }
@@ -26,12 +26,12 @@ namespace numpy
     {
       return v;
     }
-  }
+  } // namespace details
 
 #define NUMPY_NARY_FUNC_NAME int16
 #define NUMPY_NARY_FUNC_SYM details::int16
 #include "pythonic/types/numpy_nary_expr.hpp"
-}
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/int32.hpp
+++ b/pythran/pythonic/numpy/int32.hpp
@@ -3,10 +3,10 @@
 
 #include "pythonic/include/numpy/int32.hpp"
 
+#include "pythonic/types/numpy_op_helper.hpp"
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/meta.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
-#include "pythonic/types/numpy_op_helper.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -16,7 +16,7 @@ namespace numpy
   namespace details
   {
 
-    int32_t int32()
+    inline int32_t int32()
     {
       return int32_t();
     }
@@ -26,12 +26,12 @@ namespace numpy
     {
       return v;
     }
-  }
+  } // namespace details
 
 #define NUMPY_NARY_FUNC_NAME int32
 #define NUMPY_NARY_FUNC_SYM details::int32
 #include "pythonic/types/numpy_nary_expr.hpp"
-}
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/int64.hpp
+++ b/pythran/pythonic/numpy/int64.hpp
@@ -3,10 +3,10 @@
 
 #include "pythonic/include/numpy/int64.hpp"
 
+#include "pythonic/types/numpy_op_helper.hpp"
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/meta.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
-#include "pythonic/types/numpy_op_helper.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -16,7 +16,7 @@ namespace numpy
   namespace details
   {
 
-    int64_t int64()
+    inline int64_t int64()
     {
       return int64_t();
     }
@@ -26,12 +26,12 @@ namespace numpy
     {
       return v;
     }
-  }
+  } // namespace details
 
 #define NUMPY_NARY_FUNC_NAME int64
 #define NUMPY_NARY_FUNC_SYM details::int64
 #include "pythonic/types/numpy_nary_expr.hpp"
-}
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/int8.hpp
+++ b/pythran/pythonic/numpy/int8.hpp
@@ -3,10 +3,10 @@
 
 #include "pythonic/include/numpy/int8.hpp"
 
+#include "pythonic/types/numpy_op_helper.hpp"
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/meta.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
-#include "pythonic/types/numpy_op_helper.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -16,7 +16,7 @@ namespace numpy
   namespace details
   {
 
-    int8_t int8()
+    inline int8_t int8()
     {
       return int8_t();
     }
@@ -26,12 +26,12 @@ namespace numpy
     {
       return v;
     }
-  }
+  } // namespace details
 
 #define NUMPY_NARY_FUNC_NAME int8
 #define NUMPY_NARY_FUNC_SYM details::int8
 #include "pythonic/types/numpy_nary_expr.hpp"
-}
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/int_.hpp
+++ b/pythran/pythonic/numpy/int_.hpp
@@ -3,10 +3,10 @@
 
 #include "pythonic/include/numpy/int_.hpp"
 
+#include "pythonic/types/numpy_op_helper.hpp"
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/meta.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
-#include "pythonic/types/numpy_op_helper.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -16,7 +16,7 @@ namespace numpy
   namespace details
   {
 
-    long int_()
+    inline long int_()
     {
       return {};
     }
@@ -26,12 +26,12 @@ namespace numpy
     {
       return static_cast<long>(v);
     }
-  }
+  } // namespace details
 
 #define NUMPY_NARY_FUNC_NAME int_
 #define NUMPY_NARY_FUNC_SYM details::int_
 #include "pythonic/types/numpy_nary_expr.hpp"
-}
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/intc.hpp
+++ b/pythran/pythonic/numpy/intc.hpp
@@ -3,10 +3,10 @@
 
 #include "pythonic/include/numpy/intc.hpp"
 
+#include "pythonic/types/numpy_op_helper.hpp"
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/meta.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
-#include "pythonic/types/numpy_op_helper.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -16,7 +16,7 @@ namespace numpy
   namespace details
   {
 
-    int intc()
+    inline int intc()
     {
       return {};
     }
@@ -26,12 +26,12 @@ namespace numpy
     {
       return v;
     }
-  }
+  } // namespace details
 
 #define NUMPY_NARY_FUNC_NAME intc
 #define NUMPY_NARY_FUNC_SYM details::intc
 #include "pythonic/types/numpy_nary_expr.hpp"
-}
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/intp.hpp
+++ b/pythran/pythonic/numpy/intp.hpp
@@ -3,10 +3,10 @@
 
 #include "pythonic/include/numpy/intp.hpp"
 
+#include "pythonic/types/numpy_op_helper.hpp"
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/meta.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
-#include "pythonic/types/numpy_op_helper.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -16,7 +16,7 @@ namespace numpy
   namespace details
   {
 
-    intptr_t intp()
+    inline intptr_t intp()
     {
       return intptr_t();
     }
@@ -26,12 +26,12 @@ namespace numpy
     {
       return v;
     }
-  }
+  } // namespace details
 
 #define NUMPY_NARY_FUNC_NAME intp
 #define NUMPY_NARY_FUNC_SYM details::intp
 #include "pythonic/types/numpy_nary_expr.hpp"
-}
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/longlong.hpp
+++ b/pythran/pythonic/numpy/longlong.hpp
@@ -3,10 +3,10 @@
 
 #include "pythonic/include/numpy/longlong.hpp"
 
+#include "pythonic/types/numpy_op_helper.hpp"
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/meta.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
-#include "pythonic/types/numpy_op_helper.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -16,7 +16,7 @@ namespace numpy
   namespace details
   {
 
-    long long longlong()
+    inline long long longlong()
     {
       return {};
     }
@@ -26,12 +26,12 @@ namespace numpy
     {
       return v;
     }
-  }
+  } // namespace details
 
 #define NUMPY_NARY_FUNC_NAME longlong
 #define NUMPY_NARY_FUNC_SYM details::longlong
 #include "pythonic/types/numpy_nary_expr.hpp"
-}
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/random/binomial.hpp
+++ b/pythran/pythonic/numpy/random/binomial.hpp
@@ -24,7 +24,7 @@ namespace numpy
         else if (p > 1)
           throw pythonic::types::ValueError("p > 1");
       }
-    }
+    } // namespace details
 
     template <class pS>
     types::ndarray<long, pS> binomial(double n, double p, pS const &shape)
@@ -37,19 +37,19 @@ namespace numpy
       return result;
     }
 
-    auto binomial(double n, double p, long size)
+    inline auto binomial(double n, double p, long size)
         -> decltype(binomial(n, p, types::array<long, 1>{{size}}))
     {
       return binomial(n, p, types::array<long, 1>{{size}});
     }
 
-    long binomial(double n, double p, types::none_type d)
+    inline long binomial(double n, double p, types::none_type d)
     {
       details::parameters_check(n, p);
       return std::binomial_distribution<long>{(long)n, p}(details::generator);
     }
-  }
-}
+  } // namespace random
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/random/bytes.hpp
+++ b/pythran/pythonic/numpy/random/bytes.hpp
@@ -16,7 +16,7 @@ namespace numpy
   namespace random
   {
 
-    types::str bytes(long length)
+    inline types::str bytes(long length)
     {
       // dummy init + rewrite is faster than reserve && push_back
       types::str result(std::string(length, 0));
@@ -26,8 +26,8 @@ namespace numpy
       });
       return result;
     }
-  }
-}
+  } // namespace random
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/random/chisquare.hpp
+++ b/pythran/pythonic/numpy/random/chisquare.hpp
@@ -1,8 +1,8 @@
 #ifndef PYTHONIC_NUMPY_RANDOM_CHISQUARE_HPP
 #define PYTHONIC_NUMPY_RANDOM_CHISQUARE_HPP
 
-#include "pythonic/include/numpy/random/generator.hpp"
 #include "pythonic/include/numpy/random/chisquare.hpp"
+#include "pythonic/include/numpy/random/generator.hpp"
 
 #include "pythonic/types/NoneType.hpp"
 #include "pythonic/types/ndarray.hpp"
@@ -28,19 +28,19 @@ namespace numpy
       return result;
     }
 
-    auto chisquare(double df, long size)
+    inline auto chisquare(double df, long size)
         -> decltype(chisquare(df, types::array<long, 1>{{size}}))
     {
 
       return chisquare(df, types::array<long, 1>{{size}});
     }
 
-    double chisquare(double df, types::none_type d)
+    inline double chisquare(double df, types::none_type d)
     {
       return std::chi_squared_distribution<double>{df}(details::generator);
     }
-  }
-}
+  } // namespace random
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/random/choice.hpp
+++ b/pythran/pythonic/numpy/random/choice.hpp
@@ -10,8 +10,8 @@
 #include "pythonic/types/tuple.hpp"
 #include "pythonic/utils/functor.hpp"
 
-#include <random>
 #include <algorithm>
+#include <random>
 
 PYTHONIC_NS_BEGIN
 namespace numpy
@@ -52,7 +52,7 @@ namespace numpy
       return randint(0, max, std::forward<T>(size));
     }
 
-    long choice(long max)
+    inline long choice(long max)
     {
       return randint(max);
     }
@@ -116,8 +116,8 @@ namespace numpy
       return choice(std::forward<T>(a), types::pshape<long>{size}, replace,
                     std::forward<P>(p));
     }
-  }
-}
+  } // namespace random
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/random/dirichlet.hpp
+++ b/pythran/pythonic/numpy/random/dirichlet.hpp
@@ -1,8 +1,8 @@
 #ifndef PYTHONIC_NUMPY_RANDOM_DIRICHLET_HPP
 #define PYTHONIC_NUMPY_RANDOM_DIRICHLET_HPP
 
-#include "pythonic/include/numpy/random/generator.hpp"
 #include "pythonic/include/numpy/random/dirichlet.hpp"
+#include "pythonic/include/numpy/random/generator.hpp"
 
 #include "pythonic/types/NoneType.hpp"
 #include "pythonic/types/ndarray.hpp"
@@ -28,19 +28,19 @@ namespace numpy
       return result;
     }
 
-    auto dirichlet(double alpha, long size)
+    inline auto dirichlet(double alpha, long size)
         -> decltype(dirichlet(alpha, types::array<long, 1>{{size}}))
     {
 
       return dirichlet(alpha, types::array<long, 1>{{size}});
     }
 
-    double dirichlet(double alpha, types::none_type d)
+    inline double dirichlet(double alpha, types::none_type d)
     {
       return std::dirichlet_distribution<double>{alpha}(details::generator);
     }
-  }
-}
+  } // namespace random
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/random/exponential.hpp
+++ b/pythran/pythonic/numpy/random/exponential.hpp
@@ -1,8 +1,8 @@
 #ifndef PYTHONIC_NUMPY_RANDOM_EXPONENTIAL_HPP
 #define PYTHONIC_NUMPY_RANDOM_EXPONENTIAL_HPP
 
-#include "pythonic/include/numpy/random/generator.hpp"
 #include "pythonic/include/numpy/random/exponential.hpp"
+#include "pythonic/include/numpy/random/generator.hpp"
 
 #include "pythonic/types/NoneType.hpp"
 #include "pythonic/types/ndarray.hpp"
@@ -28,20 +28,20 @@ namespace numpy
       return result;
     }
 
-    auto exponential(double scale, long size)
+    inline auto exponential(double scale, long size)
         -> decltype(exponential(scale, types::array<long, 1>{{size}}))
     {
 
       return exponential(scale, types::array<long, 1>{{size}});
     }
 
-    double exponential(double scale, types::none_type d)
+    inline double exponential(double scale, types::none_type d)
     {
       return std::exponential_distribution<double>{1 /
                                                    scale}(details::generator);
     }
-  }
-}
+  } // namespace random
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/random/f.hpp
+++ b/pythran/pythonic/numpy/random/f.hpp
@@ -4,13 +4,13 @@
 #include "pythonic/include/numpy/random/f.hpp"
 #include "pythonic/include/numpy/random/generator.hpp"
 
-#include "pythonic/types/ndarray.hpp"
 #include "pythonic/types/NoneType.hpp"
+#include "pythonic/types/ndarray.hpp"
 #include "pythonic/types/tuple.hpp"
 #include "pythonic/utils/functor.hpp"
 
-#include <random>
 #include <algorithm>
+#include <random>
 
 PYTHONIC_NS_BEGIN
 namespace numpy
@@ -31,21 +31,21 @@ namespace numpy
       return result;
     }
 
-    auto f(double dfnum, double dfden, long size)
+    inline auto f(double dfnum, double dfden, long size)
         -> decltype(f(dfnum, dfden, types::array<long, 1>{{size}}))
     {
       return f(dfnum, dfden, types::array<long, 1>{{size}});
     }
 
-    double f(double dfnum, double dfden, types::none_type d)
+    inline double f(double dfnum, double dfden, types::none_type d)
     {
-      return (std::chi_squared_distribution<double>{dfnum}(details::generator) *
-              dfden) /
-             (std::chi_squared_distribution<double>{dfden}(details::generator) *
-              dfnum);
+      return (std::chi_squared_distribution<double>{dfnum}(
+                 details::generator)*dfden) /
+             (std::chi_squared_distribution<double>{dfden}(
+                 details::generator)*dfnum);
     }
-  }
-}
+  } // namespace random
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/random/gamma.hpp
+++ b/pythran/pythonic/numpy/random/gamma.hpp
@@ -4,13 +4,13 @@
 #include "pythonic/include/numpy/random/gamma.hpp"
 #include "pythonic/include/numpy/random/generator.hpp"
 
-#include "pythonic/types/ndarray.hpp"
 #include "pythonic/types/NoneType.hpp"
+#include "pythonic/types/ndarray.hpp"
 #include "pythonic/types/tuple.hpp"
 #include "pythonic/utils/functor.hpp"
 
-#include <random>
 #include <algorithm>
+#include <random>
 
 PYTHONIC_NS_BEGIN
 namespace numpy
@@ -29,18 +29,18 @@ namespace numpy
       return result;
     }
 
-    auto gamma(double shape, double scale, long size)
+    inline auto gamma(double shape, double scale, long size)
         -> decltype(gamma(shape, scale, types::array<long, 1>{{size}}))
     {
       return gamma(shape, scale, types::array<long, 1>{{size}});
     }
 
-    double gamma(double shape, double scale, types::none_type d)
+    inline double gamma(double shape, double scale, types::none_type d)
     {
       return std::gamma_distribution<double>{shape, scale}(details::generator);
     }
-  }
-}
+  } // namespace random
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/random/geometric.hpp
+++ b/pythran/pythonic/numpy/random/geometric.hpp
@@ -28,18 +28,18 @@ namespace numpy
       return result;
     }
 
-    auto geometric(double p, long size)
+    inline auto geometric(double p, long size)
         -> decltype(geometric(p, types::array<long, 1>{{size}}))
     {
       return geometric(p, types::array<long, 1>{{size}});
     }
 
-    double geometric(double p, types::none_type d)
+    inline double geometric(double p, types::none_type d)
     {
       return std::geometric_distribution<int>{p}(details::generator);
     }
-  }
-}
+  } // namespace random
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/random/gumbel.hpp
+++ b/pythran/pythonic/numpy/random/gumbel.hpp
@@ -1,16 +1,16 @@
 #ifndef PYTHONIC_NUMPY_RANDOM_GUMBEL_HPP
 #define PYTHONIC_NUMPY_RANDOM_GUMBEL_HPP
 
-#include "pythonic/include/numpy/random/gumbel.hpp"
 #include "pythonic/include/numpy/random/generator.hpp"
+#include "pythonic/include/numpy/random/gumbel.hpp"
 
-#include "pythonic/types/ndarray.hpp"
 #include "pythonic/types/NoneType.hpp"
+#include "pythonic/types/ndarray.hpp"
 #include "pythonic/types/tuple.hpp"
 #include "pythonic/utils/functor.hpp"
 
-#include <random>
 #include <algorithm>
+#include <random>
 
 PYTHONIC_NS_BEGIN
 namespace numpy
@@ -27,13 +27,13 @@ namespace numpy
       return result;
     }
 
-    auto gumbel(double loc, double scale, long size)
+    inline auto gumbel(double loc, double scale, long size)
         -> decltype(gumbel(loc, scale, types::array<long, 1>{{size}}))
     {
       return gumbel(loc, scale, types::array<long, 1>{{size}});
     }
 
-    double gumbel(double loc, double scale, types::none_type d)
+    inline double gumbel(double loc, double scale, types::none_type d)
     {
       double U =
           std::uniform_real_distribution<double>{0., 1.}(details::generator);
@@ -42,8 +42,8 @@ namespace numpy
       }
       return gumbel(loc, scale);
     }
-  }
-}
+  } // namespace random
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/random/laplace.hpp
+++ b/pythran/pythonic/numpy/random/laplace.hpp
@@ -1,16 +1,16 @@
 #ifndef PYTHONIC_NUMPY_RANDOM_LAPLACE_HPP
 #define PYTHONIC_NUMPY_RANDOM_LAPLACE_HPP
 
-#include "pythonic/include/numpy/random/laplace.hpp"
 #include "pythonic/include/numpy/random/generator.hpp"
+#include "pythonic/include/numpy/random/laplace.hpp"
 
-#include "pythonic/types/ndarray.hpp"
 #include "pythonic/types/NoneType.hpp"
+#include "pythonic/types/ndarray.hpp"
 #include "pythonic/types/tuple.hpp"
 #include "pythonic/utils/functor.hpp"
 
-#include <random>
 #include <algorithm>
+#include <random>
 
 PYTHONIC_NS_BEGIN
 namespace numpy
@@ -28,13 +28,13 @@ namespace numpy
       return result;
     }
 
-    auto laplace(double loc, double scale, long size)
+    inline auto laplace(double loc, double scale, long size)
         -> decltype(laplace(loc, scale, types::array<long, 1>{{size}}))
     {
       return laplace(loc, scale, types::array<long, 1>{{size}});
     }
 
-    double laplace(double loc, double scale, types::none_type d)
+    inline double laplace(double loc, double scale, types::none_type d)
     {
       double U =
           std::uniform_real_distribution<double>{0., 1.}(details::generator);
@@ -47,8 +47,8 @@ namespace numpy
       }
       return U;
     }
-  }
-}
+  } // namespace random
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/random/logistic.hpp
+++ b/pythran/pythonic/numpy/random/logistic.hpp
@@ -1,16 +1,16 @@
 #ifndef PYTHONIC_NUMPY_RANDOM_LOGISTIC_HPP
 #define PYTHONIC_NUMPY_RANDOM_LOGISTIC_HPP
 
-#include "pythonic/include/numpy/random/logistic.hpp"
 #include "pythonic/include/numpy/random/generator.hpp"
+#include "pythonic/include/numpy/random/logistic.hpp"
 
-#include "pythonic/types/ndarray.hpp"
 #include "pythonic/types/NoneType.hpp"
+#include "pythonic/types/ndarray.hpp"
 #include "pythonic/types/tuple.hpp"
 #include "pythonic/utils/functor.hpp"
 
-#include <random>
 #include <algorithm>
+#include <random>
 
 PYTHONIC_NS_BEGIN
 namespace numpy
@@ -28,13 +28,13 @@ namespace numpy
       return result;
     }
 
-    auto logistic(double loc, double scale, long size)
+    inline auto logistic(double loc, double scale, long size)
         -> decltype(logistic(loc, scale, types::array<long, 1>{{size}}))
     {
       return logistic(loc, scale, types::array<long, 1>{{size}});
     }
 
-    double logistic(double loc, double scale, types::none_type d)
+    inline double logistic(double loc, double scale, types::none_type d)
     {
       double U =
           std::uniform_real_distribution<double>{0., 1.}(details::generator);
@@ -43,8 +43,8 @@ namespace numpy
       }
       return logistic(loc, scale);
     }
-  }
-}
+  } // namespace random
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/random/lognormal.hpp
+++ b/pythran/pythonic/numpy/random/lognormal.hpp
@@ -1,16 +1,16 @@
 #ifndef PYTHONIC_NUMPY_RANDOM_LOGNORMAL_HPP
 #define PYTHONIC_NUMPY_RANDOM_LOGNORMAL_HPP
 
-#include "pythonic/include/numpy/random/lognormal.hpp"
 #include "pythonic/include/numpy/random/generator.hpp"
+#include "pythonic/include/numpy/random/lognormal.hpp"
 
-#include "pythonic/types/ndarray.hpp"
 #include "pythonic/types/NoneType.hpp"
+#include "pythonic/types/ndarray.hpp"
 #include "pythonic/types/tuple.hpp"
 #include "pythonic/utils/functor.hpp"
 
-#include <random>
 #include <algorithm>
+#include <random>
 
 PYTHONIC_NS_BEGIN
 namespace numpy
@@ -29,19 +29,19 @@ namespace numpy
       return result;
     }
 
-    auto lognormal(double mean, double sigma, long size)
+    inline auto lognormal(double mean, double sigma, long size)
         -> decltype(lognormal(mean, sigma, types::array<long, 1>{{size}}))
     {
       return lognormal(mean, sigma, types::array<long, 1>{{size}});
     }
 
-    double lognormal(double mean, double sigma, types::none_type d)
+    inline double lognormal(double mean, double sigma, types::none_type d)
     {
       return std::lognormal_distribution<double>{mean,
                                                  sigma}(details::generator);
     }
-  }
-}
+  } // namespace random
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/random/logseries.hpp
+++ b/pythran/pythonic/numpy/random/logseries.hpp
@@ -1,17 +1,17 @@
 #ifndef PYTHONIC_NUMPY_RANDOM_LOGSERIES_HPP
 #define PYTHONIC_NUMPY_RANDOM_LOGSERIES_HPP
 
-#include "pythonic/include/numpy/random/logseries.hpp"
 #include "pythonic/include/numpy/random/generator.hpp"
+#include "pythonic/include/numpy/random/logseries.hpp"
 
-#include "pythonic/types/ndarray.hpp"
 #include "pythonic/types/NoneType.hpp"
+#include "pythonic/types/ndarray.hpp"
 #include "pythonic/types/tuple.hpp"
 #include "pythonic/utils/functor.hpp"
 #include <math.h>
 
-#include <random>
 #include <algorithm>
+#include <random>
 
 PYTHONIC_NS_BEGIN
 namespace numpy
@@ -28,13 +28,13 @@ namespace numpy
       return result;
     }
 
-    auto logseries(double p, long size)
+    inline auto logseries(double p, long size)
         -> decltype(logseries(p, types::array<long, 1>{{size}}))
     {
       return logseries(p, types::array<long, 1>{{size}});
     }
 
-    double logseries(double p, types::none_type d)
+    inline double logseries(double p, types::none_type d)
     {
       double q, r, U, V;
       double result;
@@ -62,8 +62,8 @@ namespace numpy
         return 2;
       }
     }
-  }
-}
+  } // namespace random
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/random/negative_binomial.hpp
+++ b/pythran/pythonic/numpy/random/negative_binomial.hpp
@@ -29,13 +29,13 @@ namespace numpy
       return result;
     }
 
-    auto negative_binomial(long n, double p, long size)
+    inline auto negative_binomial(long n, double p, long size)
         -> decltype(negative_binomial(n, p, types::array<long, 1>{{size}}))
     {
       return negative_binomial(n, p, types::array<long, 1>{{size}});
     }
 
-    long negative_binomial(long n, double p, types::none_type d)
+    inline long negative_binomial(long n, double p, types::none_type d)
     {
       std::negative_binomial_distribution<long> distribution{n, p};
       return distribution(details::generator);

--- a/pythran/pythonic/numpy/random/normal.hpp
+++ b/pythran/pythonic/numpy/random/normal.hpp
@@ -1,16 +1,16 @@
 #ifndef PYTHONIC_NUMPY_RANDOM_NORMAL_HPP
 #define PYTHONIC_NUMPY_RANDOM_NORMAL_HPP
 
-#include "pythonic/include/numpy/random/normal.hpp"
 #include "pythonic/include/numpy/random/generator.hpp"
+#include "pythonic/include/numpy/random/normal.hpp"
 
-#include "pythonic/types/ndarray.hpp"
 #include "pythonic/types/NoneType.hpp"
+#include "pythonic/types/ndarray.hpp"
 #include "pythonic/types/tuple.hpp"
 #include "pythonic/utils/functor.hpp"
 
-#include <random>
 #include <algorithm>
+#include <random>
 
 PYTHONIC_NS_BEGIN
 namespace numpy
@@ -28,18 +28,18 @@ namespace numpy
       return result;
     }
 
-    auto normal(double loc, double scale, long size)
+    inline auto normal(double loc, double scale, long size)
         -> decltype(normal(loc, scale, types::array<long, 1>{{size}}))
     {
       return normal(loc, scale, types::array<long, 1>{{size}});
     }
 
-    double normal(double loc, double scale, types::none_type d)
+    inline double normal(double loc, double scale, types::none_type d)
     {
       return std::normal_distribution<double>{loc, scale}(details::generator);
     }
-  }
-}
+  } // namespace random
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/random/pareto.hpp
+++ b/pythran/pythonic/numpy/random/pareto.hpp
@@ -29,20 +29,20 @@ namespace numpy
       return result;
     }
 
-    auto pareto(double a, long size)
+    inline auto pareto(double a, long size)
         -> decltype(pareto(a, types::array<long, 1>{{size}}))
     {
 
       return pareto(a, types::array<long, 1>{{size}});
     }
 
-    double pareto(double a, types::none_type d)
+    inline double pareto(double a, types::none_type d)
     {
       return expm1(std::exponential_distribution<double>{}(details::generator) /
                    a);
     }
-  }
-}
+  } // namespace random
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/random/poisson.hpp
+++ b/pythran/pythonic/numpy/random/poisson.hpp
@@ -28,18 +28,18 @@ namespace numpy
       return result;
     }
 
-    auto poisson(double lam, long size)
+    inline auto poisson(double lam, long size)
         -> decltype(poisson(lam, types::array<long, 1>{{size}}))
     {
       return poisson(lam, types::array<long, 1>{{size}});
     }
 
-    double poisson(double lam, types::none_type d)
+    inline double poisson(double lam, types::none_type d)
     {
       return std::poisson_distribution<long>{lam}(details::generator);
     }
-  }
-}
+  } // namespace random
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/random/power.hpp
+++ b/pythran/pythonic/numpy/random/power.hpp
@@ -1,17 +1,17 @@
 #ifndef PYTHONIC_NUMPY_RANDOM_POWER_HPP
 #define PYTHONIC_NUMPY_RANDOM_POWER_HPP
 
-#include "pythonic/include/numpy/random/power.hpp"
 #include "pythonic/include/numpy/random/generator.hpp"
+#include "pythonic/include/numpy/random/power.hpp"
 
-#include "pythonic/types/ndarray.hpp"
 #include "pythonic/types/NoneType.hpp"
+#include "pythonic/types/ndarray.hpp"
 #include "pythonic/types/tuple.hpp"
 #include "pythonic/utils/functor.hpp"
 #include <math.h>
 
-#include <random>
 #include <algorithm>
+#include <random>
 
 PYTHONIC_NS_BEGIN
 namespace numpy
@@ -28,20 +28,20 @@ namespace numpy
       return result;
     }
 
-    auto power(double a, long size)
+    inline auto power(double a, long size)
         -> decltype(power(a, types::array<long, 1>{{size}}))
     {
       return power(a, types::array<long, 1>{{size}});
     }
 
-    double power(double a, types::none_type d)
+    inline double power(double a, types::none_type d)
     {
       return pow(
           -expm1(-std::exponential_distribution<double>{}(details::generator)),
           1. / a);
     }
-  }
-}
+  } // namespace random
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/random/rand.hpp
+++ b/pythran/pythonic/numpy/random/rand.hpp
@@ -20,12 +20,12 @@ namespace numpy
       return random(types::array<long, sizeof...(T)>{{shape...}});
     }
 
-    double rand()
+    inline double rand()
     {
       return random();
     }
-  }
-}
+  } // namespace random
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/random/randint.hpp
+++ b/pythran/pythonic/numpy/random/randint.hpp
@@ -1,8 +1,8 @@
 #ifndef PYTHONIC_NUMPY_RANDOM_RANDINT_HPP
 #define PYTHONIC_NUMPY_RANDOM_RANDINT_HPP
 
-#include "pythonic/include/numpy/random/randint.hpp"
 #include "pythonic/include/numpy/random/generator.hpp"
+#include "pythonic/include/numpy/random/randint.hpp"
 
 #include "pythonic/types/ndarray.hpp"
 #include "pythonic/types/tuple.hpp"
@@ -43,25 +43,25 @@ namespace numpy
       return randint(0, max, shape);
     }
 
-    auto randint(long min, long max, long size)
+    inline auto randint(long min, long max, long size)
         -> decltype(randint(min, max, types::array<long, 1>{{size}}))
     {
       return randint(min, max, types::array<long, 1>{{size}});
     }
 
-    long randint(long max, types::none_type)
+    inline long randint(long max, types::none_type)
     {
       return std::uniform_int_distribution<long>{0,
                                                  max - 1}(details::generator);
     }
 
-    long randint(long min, long max)
+    inline long randint(long min, long max)
     {
       return std::uniform_int_distribution<long>{min,
                                                  max - 1}(details::generator);
     }
-  }
-}
+  } // namespace random
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/random/randn.hpp
+++ b/pythran/pythonic/numpy/random/randn.hpp
@@ -20,12 +20,12 @@ namespace numpy
       return standard_normal(types::array<long, sizeof...(T)>{{shape...}});
     }
 
-    double randn()
+    inline double randn()
     {
       return standard_normal();
     }
-  }
-}
+  } // namespace random
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/random/random.hpp
+++ b/pythran/pythonic/numpy/random/random.hpp
@@ -1,16 +1,16 @@
 #ifndef PYTHONIC_NUMPY_RANDOM_RANDOM_HPP
 #define PYTHONIC_NUMPY_RANDOM_RANDOM_HPP
 
-#include "pythonic/include/numpy/random/random.hpp"
 #include "pythonic/include/numpy/random/generator.hpp"
+#include "pythonic/include/numpy/random/random.hpp"
 
-#include "pythonic/types/ndarray.hpp"
 #include "pythonic/types/NoneType.hpp"
+#include "pythonic/types/ndarray.hpp"
 #include "pythonic/types/tuple.hpp"
 #include "pythonic/utils/functor.hpp"
 
-#include <random>
 #include <algorithm>
+#include <random>
 
 PYTHONIC_NS_BEGIN
 namespace numpy
@@ -28,17 +28,18 @@ namespace numpy
       return result;
     }
 
-    auto random(long size) -> decltype(random(types::array<long, 1>{{size}}))
+    inline auto random(long size)
+        -> decltype(random(types::array<long, 1>{{size}}))
     {
       return random(types::array<long, 1>{{size}});
     }
 
-    double random(types::none_type d)
+    inline double random(types::none_type d)
     {
       return std::uniform_real_distribution<double>{0., 1.}(details::generator);
     }
-  }
-}
+  } // namespace random
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/random/random_integers.hpp
+++ b/pythran/pythonic/numpy/random/random_integers.hpp
@@ -18,17 +18,17 @@ namespace numpy
       return randint(min, max + 1, std::forward<T>(size));
     }
 
-    long random_integers(long max)
+    inline long random_integers(long max)
     {
       return randint(1, max + 1);
     }
 
-    long random_integers(long min, long max)
+    inline long random_integers(long min, long max)
     {
       return randint(min, max + 1);
     }
-  }
-}
+  } // namespace random
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/random/rayleigh.hpp
+++ b/pythran/pythonic/numpy/random/rayleigh.hpp
@@ -1,17 +1,17 @@
 #ifndef PYTHONIC_NUMPY_RANDOM_RAYLEIGH_HPP
 #define PYTHONIC_NUMPY_RANDOM_RAYLEIGH_HPP
 
-#include "pythonic/include/numpy/random/rayleigh.hpp"
 #include "pythonic/include/numpy/random/generator.hpp"
+#include "pythonic/include/numpy/random/rayleigh.hpp"
 
-#include "pythonic/types/ndarray.hpp"
 #include "pythonic/types/NoneType.hpp"
+#include "pythonic/types/ndarray.hpp"
 #include "pythonic/types/tuple.hpp"
 #include "pythonic/utils/functor.hpp"
 #include <math.h>
 
-#include <random>
 #include <algorithm>
+#include <random>
 
 PYTHONIC_NS_BEGIN
 namespace numpy
@@ -28,20 +28,20 @@ namespace numpy
       return result;
     }
 
-    auto rayleigh(double scale, long size)
+    inline auto rayleigh(double scale, long size)
         -> decltype(rayleigh(scale, types::array<long, 1>{{size}}))
     {
       return rayleigh(scale, types::array<long, 1>{{size}});
     }
 
-    double rayleigh(double scale, types::none_type d)
+    inline double rayleigh(double scale, types::none_type d)
     {
       return scale *
              sqrt(-2.0 * log(1.0 - std::uniform_real_distribution<double>{
                                        0., 1.}(details::generator)));
     }
-  }
-}
+  } // namespace random
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/random/seed.hpp
+++ b/pythran/pythonic/numpy/random/seed.hpp
@@ -1,8 +1,8 @@
 #ifndef PYTHONIC_NUMPY_RANDOM_SEED_HPP
 #define PYTHONIC_NUMPY_RANDOM_SEED_HPP
 
-#include "pythonic/include/numpy/random/seed.hpp"
 #include "pythonic/builtins/None.hpp"
+#include "pythonic/include/numpy/random/seed.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -11,19 +11,19 @@ namespace numpy
   namespace random
   {
 
-    types::none_type seed(long s)
+    inline types::none_type seed(long s)
     {
       details::generator.seed(s);
       return builtins::None;
     }
 
-    types::none_type seed(types::none_type)
+    inline types::none_type seed(types::none_type)
     {
       details::generator.seed();
       return builtins::None;
     }
-  }
-}
+  } // namespace random
+} // namespace numpy
 
 PYTHONIC_NS_END
 

--- a/pythran/pythonic/numpy/random/standard_exponential.hpp
+++ b/pythran/pythonic/numpy/random/standard_exponential.hpp
@@ -1,17 +1,17 @@
 #ifndef PYTHONIC_NUMPY_RANDOM_STANDARD_EXPONENTIAL_HPP
 #define PYTHONIC_NUMPY_RANDOM_STANDARD_EXPONENTIAL_HPP
 
-#include "pythonic/include/numpy/random/standard_exponential.hpp"
 #include "pythonic/include/numpy/random/generator.hpp"
+#include "pythonic/include/numpy/random/standard_exponential.hpp"
 
-#include "pythonic/types/ndarray.hpp"
+#include "pythonic/numpy/random/exponential.hpp"
 #include "pythonic/types/NoneType.hpp"
+#include "pythonic/types/ndarray.hpp"
 #include "pythonic/types/tuple.hpp"
 #include "pythonic/utils/functor.hpp"
-#include "pythonic/numpy/random/exponential.hpp"
 
-#include <random>
 #include <algorithm>
+#include <random>
 
 PYTHONIC_NS_BEGIN
 namespace numpy
@@ -25,18 +25,18 @@ namespace numpy
       return exponential(1., shape);
     }
 
-    auto standard_exponential(long size)
+    inline auto standard_exponential(long size)
         -> decltype(standard_exponential(types::array<long, 1>{{size}}))
     {
       return standard_exponential(types::array<long, 1>{{size}});
     }
 
-    double standard_exponential(types::none_type d)
+    inline double standard_exponential(types::none_type d)
     {
       return exponential(1., d);
     }
-  }
-}
+  } // namespace random
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/random/standard_gamma.hpp
+++ b/pythran/pythonic/numpy/random/standard_gamma.hpp
@@ -1,17 +1,17 @@
 #ifndef PYTHONIC_NUMPY_RANDOM_STANDARD_GAMMA_HPP
 #define PYTHONIC_NUMPY_RANDOM_STANDARD_GAMMA_HPP
 
-#include "pythonic/include/numpy/random/standard_gamma.hpp"
 #include "pythonic/include/numpy/random/generator.hpp"
+#include "pythonic/include/numpy/random/standard_gamma.hpp"
 
-#include "pythonic/types/ndarray.hpp"
+#include "pythonic/numpy/random/gamma.hpp"
 #include "pythonic/types/NoneType.hpp"
+#include "pythonic/types/ndarray.hpp"
 #include "pythonic/types/tuple.hpp"
 #include "pythonic/utils/functor.hpp"
-#include "pythonic/numpy/random/gamma.hpp"
 
-#include <random>
 #include <algorithm>
+#include <random>
 
 PYTHONIC_NS_BEGIN
 namespace numpy
@@ -25,18 +25,18 @@ namespace numpy
       return gamma(s, 1., shape);
     }
 
-    auto standard_gamma(double s, long size)
+    inline auto standard_gamma(double s, long size)
         -> decltype(standard_gamma(s, types::array<long, 1>{{size}}))
     {
       return standard_gamma(s, types::array<long, 1>{{size}});
     }
 
-    double standard_gamma(double s, types::none_type d)
+    inline double standard_gamma(double s, types::none_type d)
     {
       return gamma(s, 1., d);
     }
-  }
-}
+  } // namespace random
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/random/standard_normal.hpp
+++ b/pythran/pythonic/numpy/random/standard_normal.hpp
@@ -1,17 +1,17 @@
 #ifndef PYTHONIC_NUMPY_RANDOM_STANDARD_NORMAL_HPP
 #define PYTHONIC_NUMPY_RANDOM_STANDARD_NORMAL_HPP
 
-#include "pythonic/include/numpy/random/standard_normal.hpp"
 #include "pythonic/include/numpy/random/generator.hpp"
+#include "pythonic/include/numpy/random/standard_normal.hpp"
 
-#include "pythonic/types/ndarray.hpp"
+#include "pythonic/numpy/random/normal.hpp"
 #include "pythonic/types/NoneType.hpp"
+#include "pythonic/types/ndarray.hpp"
 #include "pythonic/types/tuple.hpp"
 #include "pythonic/utils/functor.hpp"
-#include "pythonic/numpy/random/normal.hpp"
 
-#include <random>
 #include <algorithm>
+#include <random>
 
 PYTHONIC_NS_BEGIN
 namespace numpy
@@ -25,18 +25,18 @@ namespace numpy
       return normal(0., 1., shape);
     }
 
-    auto standard_normal(long size)
+    inline auto standard_normal(long size)
         -> decltype(standard_normal(types::array<long, 1>{{size}}))
     {
       return standard_normal(types::array<long, 1>{{size}});
     }
 
-    double standard_normal(types::none_type d)
+    inline double standard_normal(types::none_type d)
     {
       return normal(0., 1., d);
     }
-  }
-}
+  } // namespace random
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/random/uniform.hpp
+++ b/pythran/pythonic/numpy/random/uniform.hpp
@@ -29,13 +29,13 @@ namespace numpy
       return result;
     }
 
-    auto uniform(double low, double high, long size)
+    inline auto uniform(double low, double high, long size)
         -> decltype(uniform(low, high, types::array<long, 1>{{size}}))
     {
       return uniform(low, high, types::array<long, 1>{{size}});
     }
 
-    double uniform(double low, double high, types::none_type d)
+    inline double uniform(double low, double high, types::none_type d)
     {
       return std::uniform_real_distribution<double>{low,
                                                     high}(details::generator);

--- a/pythran/pythonic/numpy/random/weibull.hpp
+++ b/pythran/pythonic/numpy/random/weibull.hpp
@@ -28,19 +28,19 @@ namespace numpy
       return result;
     }
 
-    auto weibull(double a, long size)
+    inline auto weibull(double a, long size)
         -> decltype(weibull(a, types::array<long, 1>{{size}}))
     {
 
       return weibull(a, types::array<long, 1>{{size}});
     }
 
-    double weibull(double a, types::none_type d)
+    inline double weibull(double a, types::none_type d)
     {
       return std::weibull_distribution<double>{a}(details::generator);
     }
-  }
-}
+  } // namespace random
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/short_.hpp
+++ b/pythran/pythonic/numpy/short_.hpp
@@ -3,10 +3,10 @@
 
 #include "pythonic/include/numpy/short_.hpp"
 
+#include "pythonic/types/numpy_op_helper.hpp"
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/meta.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
-#include "pythonic/types/numpy_op_helper.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -16,7 +16,7 @@ namespace numpy
   namespace details
   {
 
-    short short_()
+    inline short short_()
     {
       return {};
     }
@@ -26,12 +26,12 @@ namespace numpy
     {
       return v;
     }
-  }
+  } // namespace details
 
 #define NUMPY_NARY_FUNC_NAME short_
 #define NUMPY_NARY_FUNC_SYM details::short_
 #include "pythonic/types/numpy_nary_expr.hpp"
-}
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/ubyte.hpp
+++ b/pythran/pythonic/numpy/ubyte.hpp
@@ -3,10 +3,10 @@
 
 #include "pythonic/include/numpy/ubyte.hpp"
 
+#include "pythonic/types/numpy_op_helper.hpp"
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/meta.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
-#include "pythonic/types/numpy_op_helper.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -16,7 +16,7 @@ namespace numpy
   namespace details
   {
 
-    unsigned char ubyte()
+    inline unsigned char ubyte()
     {
       return {};
     }
@@ -26,12 +26,12 @@ namespace numpy
     {
       return v;
     }
-  }
+  } // namespace details
 
 #define NUMPY_NARY_FUNC_NAME ubyte
 #define NUMPY_NARY_FUNC_SYM details::ubyte
 #include "pythonic/types/numpy_nary_expr.hpp"
-}
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/uint.hpp
+++ b/pythran/pythonic/numpy/uint.hpp
@@ -3,10 +3,10 @@
 
 #include "pythonic/include/numpy/uint.hpp"
 
+#include "pythonic/types/numpy_op_helper.hpp"
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/meta.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
-#include "pythonic/types/numpy_op_helper.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -16,7 +16,7 @@ namespace numpy
   namespace details
   {
 
-    unsigned long uint()
+    inline unsigned long uint()
     {
       return {};
     }
@@ -26,12 +26,12 @@ namespace numpy
     {
       return v;
     }
-  }
+  } // namespace details
 
 #define NUMPY_NARY_FUNC_NAME uint
 #define NUMPY_NARY_FUNC_SYM details::uint
 #include "pythonic/types/numpy_nary_expr.hpp"
-}
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/uint16.hpp
+++ b/pythran/pythonic/numpy/uint16.hpp
@@ -3,10 +3,10 @@
 
 #include "pythonic/include/numpy/uint16.hpp"
 
+#include "pythonic/types/numpy_op_helper.hpp"
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/meta.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
-#include "pythonic/types/numpy_op_helper.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -16,7 +16,7 @@ namespace numpy
   namespace details
   {
 
-    uint16_t uint16()
+    inline uint16_t uint16()
     {
       return uint16_t();
     }
@@ -26,12 +26,12 @@ namespace numpy
     {
       return v;
     }
-  }
+  } // namespace details
 
 #define NUMPY_NARY_FUNC_NAME uint16
 #define NUMPY_NARY_FUNC_SYM details::uint16
 #include "pythonic/types/numpy_nary_expr.hpp"
-}
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/uint32.hpp
+++ b/pythran/pythonic/numpy/uint32.hpp
@@ -3,9 +3,9 @@
 
 #include "pythonic/include/numpy/uint32.hpp"
 
+#include "pythonic/types/numpy_op_helper.hpp"
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
-#include "pythonic/types/numpy_op_helper.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -15,7 +15,7 @@ namespace numpy
   namespace details
   {
 
-    uint32_t uint32()
+    inline uint32_t uint32()
     {
       return uint32_t();
     }
@@ -25,12 +25,12 @@ namespace numpy
     {
       return v;
     }
-  }
+  } // namespace details
 
 #define NUMPY_NARY_FUNC_NAME uint32
 #define NUMPY_NARY_FUNC_SYM details::uint32
 #include "pythonic/types/numpy_nary_expr.hpp"
-}
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/uint64.hpp
+++ b/pythran/pythonic/numpy/uint64.hpp
@@ -3,9 +3,9 @@
 
 #include "pythonic/include/numpy/uint64.hpp"
 
+#include "pythonic/types/numpy_op_helper.hpp"
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
-#include "pythonic/types/numpy_op_helper.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -15,7 +15,7 @@ namespace numpy
   namespace details
   {
 
-    uint64_t uint64()
+    inline uint64_t uint64()
     {
       return uint64_t();
     }
@@ -25,12 +25,12 @@ namespace numpy
     {
       return v;
     }
-  }
+  } // namespace details
 
 #define NUMPY_NARY_FUNC_NAME uint64
 #define NUMPY_NARY_FUNC_SYM details::uint64
 #include "pythonic/types/numpy_nary_expr.hpp"
-}
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/uint8.hpp
+++ b/pythran/pythonic/numpy/uint8.hpp
@@ -3,10 +3,10 @@
 
 #include "pythonic/include/numpy/uint8.hpp"
 
+#include "pythonic/types/numpy_op_helper.hpp"
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/meta.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
-#include "pythonic/types/numpy_op_helper.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -16,7 +16,7 @@ namespace numpy
   namespace details
   {
 
-    uint8_t uint8()
+    inline uint8_t uint8()
     {
       return uint8_t();
     }
@@ -26,12 +26,12 @@ namespace numpy
     {
       return v;
     }
-  }
+  } // namespace details
 
 #define NUMPY_NARY_FUNC_NAME uint8
 #define NUMPY_NARY_FUNC_SYM details::uint8
 #include "pythonic/types/numpy_nary_expr.hpp"
-}
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/uintc.hpp
+++ b/pythran/pythonic/numpy/uintc.hpp
@@ -3,10 +3,10 @@
 
 #include "pythonic/include/numpy/uintc.hpp"
 
+#include "pythonic/types/numpy_op_helper.hpp"
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/meta.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
-#include "pythonic/types/numpy_op_helper.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -16,7 +16,7 @@ namespace numpy
   namespace details
   {
 
-    unsigned uintc()
+    inline unsigned uintc()
     {
       return {};
     }
@@ -26,12 +26,12 @@ namespace numpy
     {
       return v;
     }
-  }
+  } // namespace details
 
 #define NUMPY_NARY_FUNC_NAME uintc
 #define NUMPY_NARY_FUNC_SYM details::uintc
 #include "pythonic/types/numpy_nary_expr.hpp"
-}
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/uintp.hpp
+++ b/pythran/pythonic/numpy/uintp.hpp
@@ -3,10 +3,10 @@
 
 #include "pythonic/include/numpy/uintp.hpp"
 
+#include "pythonic/types/numpy_op_helper.hpp"
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/meta.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
-#include "pythonic/types/numpy_op_helper.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -16,7 +16,7 @@ namespace numpy
   namespace details
   {
 
-    uintptr_t uintp()
+    inline uintptr_t uintp()
     {
       return uintptr_t();
     }
@@ -26,12 +26,12 @@ namespace numpy
     {
       return v;
     }
-  }
+  } // namespace details
 
 #define NUMPY_NARY_FUNC_NAME uintp
 #define NUMPY_NARY_FUNC_SYM details::uintp
 #include "pythonic/types/numpy_nary_expr.hpp"
-}
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/ulonglong.hpp
+++ b/pythran/pythonic/numpy/ulonglong.hpp
@@ -3,10 +3,10 @@
 
 #include "pythonic/include/numpy/ulonglong.hpp"
 
+#include "pythonic/types/numpy_op_helper.hpp"
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/meta.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
-#include "pythonic/types/numpy_op_helper.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -16,7 +16,7 @@ namespace numpy
   namespace details
   {
 
-    unsigned long long ulonglong()
+    inline unsigned long long ulonglong()
     {
       return {};
     }
@@ -26,12 +26,12 @@ namespace numpy
     {
       return v;
     }
-  }
+  } // namespace details
 
 #define NUMPY_NARY_FUNC_NAME ulonglong
 #define NUMPY_NARY_FUNC_SYM details::ulonglong
 #include "pythonic/types/numpy_nary_expr.hpp"
-}
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/ushort.hpp
+++ b/pythran/pythonic/numpy/ushort.hpp
@@ -3,10 +3,10 @@
 
 #include "pythonic/include/numpy/ushort.hpp"
 
+#include "pythonic/types/numpy_op_helper.hpp"
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/meta.hpp"
 #include "pythonic/utils/numpy_traits.hpp"
-#include "pythonic/types/numpy_op_helper.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -16,7 +16,7 @@ namespace numpy
   namespace details
   {
 
-    unsigned short ushort()
+    inline unsigned short ushort()
     {
       return {};
     }
@@ -26,12 +26,12 @@ namespace numpy
     {
       return v;
     }
-  }
+  } // namespace details
 
 #define NUMPY_NARY_FUNC_NAME ushort
 #define NUMPY_NARY_FUNC_SYM details::ushort
 #include "pythonic/types/numpy_nary_expr.hpp"
-}
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/operator_/div.hpp
+++ b/pythran/pythonic/operator_/div.hpp
@@ -3,8 +3,8 @@
 
 #include "pythonic/include/operator_/div.hpp"
 
-#include "pythonic/utils/functor.hpp"
 #include "pythonic/operator_/overloads.hpp"
+#include "pythonic/utils/functor.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -21,12 +21,12 @@ namespace operator_
     return std::forward<A>(a) / std::forward<B>(b);
   }
 
-  double div(double a, double b)
+  inline double div(double a, double b)
   {
     assert(b != 0 && "divide by zero");
     return a / b;
   }
-}
+} // namespace operator_
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/operator_/eq.hpp
+++ b/pythran/pythonic/operator_/eq.hpp
@@ -15,11 +15,11 @@ namespace operator_
     return std::forward<A>(a) == std::forward<B>(b);
   }
 
-  bool eq(char const *a, char const *b)
+  inline bool eq(char const *a, char const *b)
   {
     return strcmp(a, b) == 0;
   }
-}
+} // namespace operator_
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/operator_/ge.hpp
+++ b/pythran/pythonic/operator_/ge.hpp
@@ -17,11 +17,11 @@ namespace operator_
     return std::forward<A>(a) >= std::forward<B>(b);
   }
 
-  bool ge(char const *self, char const *other)
+  inline bool ge(char const *self, char const *other)
   {
     return strcmp(self, other) >= 0;
   }
-}
+} // namespace operator_
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/operator_/gt.hpp
+++ b/pythran/pythonic/operator_/gt.hpp
@@ -17,11 +17,11 @@ namespace operator_
     return std::forward<A>(a) > std::forward<B>(b);
   }
 
-  bool gt(char const *self, char const *other)
+  inline bool gt(char const *self, char const *other)
   {
     return strcmp(self, other) > 0;
   }
-}
+} // namespace operator_
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/operator_/itemgetter.hpp
+++ b/pythran/pythonic/operator_/itemgetter.hpp
@@ -3,8 +3,8 @@
 
 #include "pythonic/include/operator_/itemgetter.hpp"
 
-#include "pythonic/utils/functor.hpp"
 #include "pythonic/types/tuple.hpp"
+#include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/int_.hpp"
 
 PYTHONIC_NS_BEGIN
@@ -12,7 +12,7 @@ PYTHONIC_NS_BEGIN
 namespace operator_
 {
 
-  itemgetter_return::itemgetter_return(long const &item) : i(item)
+  inline itemgetter_return::itemgetter_return(long const &item) : i(item)
   {
   }
 
@@ -22,7 +22,7 @@ namespace operator_
     return a[i];
   }
 
-  itemgetter_return itemgetter(long item)
+  inline itemgetter_return itemgetter(long item)
   {
     return itemgetter_return(item);
   }
@@ -61,9 +61,10 @@ namespace operator_
       -> std::tuple<typename std::remove_cv<typename std::remove_reference<
           decltype(a[std::declval<Types>()])>::type>::type...>
   {
-    std::tuple<typename std::remove_cv<typename std::remove_reference<decltype(
-        a[std::declval<Types>()])>::type>::type...> t;
-    helper(t, a, utils::int_<sizeof...(Types)-1>());
+    std::tuple<typename std::remove_cv<typename std::remove_reference<
+        decltype(a[std::declval<Types>()])>::type>::type...>
+        t;
+    helper(t, a, utils::int_<sizeof...(Types) - 1>());
     return t;
   }
 
@@ -73,7 +74,7 @@ namespace operator_
   {
     return {item1, item2, items...};
   }
-}
+} // namespace operator_
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/operator_/le.hpp
+++ b/pythran/pythonic/operator_/le.hpp
@@ -15,11 +15,11 @@ namespace operator_
   {
     return std::forward<A>(a) <= std::forward<B>(b);
   }
-  bool le(char const *self, char const *other)
+  inline bool le(char const *self, char const *other)
   {
     return strcmp(self, other) <= 0;
   }
-}
+} // namespace operator_
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/operator_/lshift.hpp
+++ b/pythran/pythonic/operator_/lshift.hpp
@@ -18,9 +18,16 @@ namespace operator_
     return std::forward<A>(a) << std::forward<B>(b);
   }
 
-  DEFINE_ALL_OPERATOR_OVERLOADS_IMPL(
+  // Just here for the sake of completeness, and has a specific definition to
+  // avoid some warnings.
+  inline bool lshift(bool a, bool b)
+  {
+    return b ? false : a;
+  }
+
+  DEFINE_ALL_OPERATOR_OVERLOADS_NO_BOOL_IMPL(
       lshift, <<, (a <= (std::numeric_limits<decltype(b)>::max() >> b)))
-}
+} // namespace operator_
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/operator_/lt.hpp
+++ b/pythran/pythonic/operator_/lt.hpp
@@ -16,11 +16,11 @@ namespace operator_
   {
     return std::forward<A>(a) < std::forward<B>(b);
   }
-  bool lt(char const *self, char const *other)
+  inline bool lt(char const *self, char const *other)
   {
     return strcmp(self, other) < 0;
   }
-}
+} // namespace operator_
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/operator_/mul.hpp
+++ b/pythran/pythonic/operator_/mul.hpp
@@ -3,8 +3,8 @@
 
 #include "pythonic/include/operator_/mul.hpp"
 
-#include "pythonic/utils/functor.hpp"
 #include "pythonic/operator_/overloads.hpp"
+#include "pythonic/utils/functor.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -17,14 +17,21 @@ namespace operator_
     return std::forward<A>(a) * std::forward<B>(b);
   }
 
-  DEFINE_ALL_OPERATOR_OVERLOADS_IMPL(
+  // Just here for the sake of completeness, and has a specific definition to
+  // avoid some warnings.
+  inline bool mul(bool a, bool b)
+  {
+    return a & b;
+  }
+
+  DEFINE_ALL_OPERATOR_OVERLOADS_NO_BOOL_IMPL(
       mul, *,
       (b == 0 ||
        (a * b >= 0 &&
         std::abs(a) <= std::numeric_limits<decltype(b)>::max() / std::abs(b)) ||
        (a * b <= 0 &&
         std::abs(a) >= std::numeric_limits<decltype(b)>::min() / std::abs(b))))
-}
+} // namespace operator_
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/operator_/ne.hpp
+++ b/pythran/pythonic/operator_/ne.hpp
@@ -16,11 +16,11 @@ namespace operator_
     return std::forward<A>(a) != std::forward<B>(b);
   }
 
-  bool ne(char const *a, char const *b)
+  inline bool ne(char const *a, char const *b)
   {
     return strcmp(a, b) != 0;
   }
-}
+} // namespace operator_
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/operator_/overloads.hpp
+++ b/pythran/pythonic/operator_/overloads.hpp
@@ -5,7 +5,7 @@
 #include <limits>
 
 #define PYTHONIC_OPERATOR_OVERLOAD_IMPL(type, opname, op, overflow_check)      \
-  type opname(type a, type b)                                                  \
+  inline type opname(type a, type b)                                           \
   {                                                                            \
     assert((overflow_check) && "overflow check");                              \
     return a op b;                                                             \
@@ -13,9 +13,9 @@
 
 // workaround the fact that char and short computations are done using int in C,
 // while they are done at their respective type in numpy
-#define DEFINE_ALL_OPERATOR_OVERLOADS_IMPL(opname, op, overflow_check)         \
-  PYTHONIC_OPERATOR_OVERLOAD_IMPL(bool, opname, op, true)                      \
+#define DEFINE_ALL_OPERATOR_OVERLOADS_NO_BOOL_IMPL(opname, op, overflow_check) \
   PYTHONIC_OPERATOR_OVERLOAD_IMPL(unsigned char, opname, op, true)             \
+  PYTHONIC_OPERATOR_OVERLOAD_IMPL(char, opname, op, true)                      \
   PYTHONIC_OPERATOR_OVERLOAD_IMPL(signed char, opname, op, overflow_check)     \
   PYTHONIC_OPERATOR_OVERLOAD_IMPL(unsigned short, opname, op, true)            \
   PYTHONIC_OPERATOR_OVERLOAD_IMPL(signed short, opname, op, overflow_check)    \
@@ -25,5 +25,9 @@
   PYTHONIC_OPERATOR_OVERLOAD_IMPL(signed long, opname, op, overflow_check)     \
   PYTHONIC_OPERATOR_OVERLOAD_IMPL(unsigned long long, opname, op, true)        \
   PYTHONIC_OPERATOR_OVERLOAD_IMPL(signed long long, opname, op, overflow_check)
+
+#define DEFINE_ALL_OPERATOR_OVERLOADS_IMPL(opname, op, overflow_check)         \
+  PYTHONIC_OPERATOR_OVERLOAD_IMPL(bool, opname, op, true)                      \
+  DEFINE_ALL_OPERATOR_OVERLOADS_NO_BOOL_IMPL(opname, op, overflow_check)
 
 #endif

--- a/pythran/pythonic/operator_/truth.hpp
+++ b/pythran/pythonic/operator_/truth.hpp
@@ -9,11 +9,11 @@ PYTHONIC_NS_BEGIN
 
 namespace operator_
 {
-  bool truth(bool const &a)
+  inline bool truth(bool const &a)
   {
     return a;
   }
-}
+} // namespace operator_
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/os/path/join.hpp
+++ b/pythran/pythonic/os/path/join.hpp
@@ -25,17 +25,17 @@ namespace os
       }
 
       template <class T, class... Types>
-      size_t sizeof_string(T const &s, Types &&... tail)
+      size_t sizeof_string(T const &s, Types &&...tail)
       {
         return s.size() + sizeof_string(std::forward<Types>(tail)...);
       }
 
-      void _join(types::str &buffer)
+      inline void _join(types::str &buffer)
       {
       }
 
       template <class T, class... Types>
-      void _join(types::str &buffer, T &&head, Types &&... tail)
+      void _join(types::str &buffer, T &&head, Types &&...tail)
       {
         if (((types::str)head)[0] == "/")
           buffer = std::forward<T>(head);
@@ -48,7 +48,7 @@ namespace os
         }
         _join(buffer, std::forward<Types>(tail)...);
       }
-    }
+    } // namespace
 
     template <class T>
     T join(T &&head)
@@ -57,15 +57,15 @@ namespace os
     }
 
     template <class T, class... Types>
-    types::str join(T &&head, Types &&... tail)
+    types::str join(T &&head, Types &&...tail)
     {
       types::str p = head;
       p.reserve(sizeof_string(tail...));
       _join(p, std::forward<Types>(tail)...);
       return p;
     }
-  }
-}
+  } // namespace path
+} // namespace os
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/python/core.hpp
+++ b/pythran/pythonic/python/core.hpp
@@ -7,9 +7,9 @@
 // Python defines this for windows, and it's not needed in C++
 #undef copysign
 
+#include <sstream>
 #include <type_traits>
 #include <utility>
-#include <sstream>
 
 // Cython still uses the deprecated API, so we can't set this macro in this
 // case!
@@ -27,9 +27,10 @@ struct from_python;
 PYTHONIC_NS_END
 
 template <class T>
-auto to_python(T &&value) -> decltype(pythonic::to_python<
-    typename std::remove_cv<typename std::remove_reference<T>::type>::type>::
-                                          convert(std::forward<T>(value)))
+auto to_python(T &&value)
+    -> decltype(pythonic::to_python<typename std::remove_cv<
+                    typename std::remove_reference<T>::type>::type>::
+                    convert(std::forward<T>(value)))
 {
   return pythonic::to_python<
       typename std::remove_cv<typename std::remove_reference<T>::type>::type>::
@@ -52,10 +53,10 @@ namespace python
 {
 
 #ifndef PyString_AS_STRING
-#define PyString_AS_STRING (char *) _PyUnicode_COMPACT_DATA
+#define PyString_AS_STRING (char *)_PyUnicode_COMPACT_DATA
 #endif
 
-  void PyObject_TypePrettyPrinter(std::ostream &oss, PyObject *obj)
+  inline void PyObject_TypePrettyPrinter(std::ostream &oss, PyObject *obj)
   {
     if (PyTuple_Check(obj)) {
       oss << '(';
@@ -135,9 +136,9 @@ namespace python
     }
   }
 
-  std::nullptr_t raise_invalid_argument(char const name[],
-                                        char const alternatives[],
-                                        PyObject *args, PyObject *kwargs)
+  inline std::nullptr_t raise_invalid_argument(char const name[],
+                                               char const alternatives[],
+                                               PyObject *args, PyObject *kwargs)
   {
     std::ostringstream oss;
     oss << "Invalid call to pythranized function `" << name << '(';
@@ -166,7 +167,7 @@ namespace python
     PyErr_SetString(PyExc_TypeError, oss.str().c_str());
     return nullptr;
   }
-}
+} // namespace python
 
 PYTHONIC_NS_END
 

--- a/pythran/pythonic/random/expovariate.hpp
+++ b/pythran/pythonic/random/expovariate.hpp
@@ -3,18 +3,18 @@
 
 #include "pythonic/include/random/expovariate.hpp"
 
-#include "pythonic/utils/functor.hpp"
 #include "pythonic/random/random.hpp"
+#include "pythonic/utils/functor.hpp"
 
 PYTHONIC_NS_BEGIN
 
 namespace random
 {
-  double expovariate(double l)
+  inline double expovariate(double l)
   {
     return std::exponential_distribution<>(l)(__random_generator);
   }
-}
+} // namespace random
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/random/gauss.hpp
+++ b/pythran/pythonic/random/gauss.hpp
@@ -3,19 +3,19 @@
 
 #include "pythonic/include/random/gauss.hpp"
 
-#include "pythonic/utils/functor.hpp"
 #include "pythonic/random/random.hpp"
+#include "pythonic/utils/functor.hpp"
 
 PYTHONIC_NS_BEGIN
 
 namespace random
 {
 
-  double gauss(double mu, double sigma)
+  inline double gauss(double mu, double sigma)
   {
     return std::normal_distribution<>(mu, sigma)(__random_generator);
   }
-}
+} // namespace random
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/random/randint.hpp
+++ b/pythran/pythonic/random/randint.hpp
@@ -3,20 +3,20 @@
 
 #include "pythonic/include/random/randint.hpp"
 
-#include "pythonic/utils/functor.hpp"
 #include "pythonic/random/randrange.hpp"
+#include "pythonic/utils/functor.hpp"
 
 PYTHONIC_NS_BEGIN
 
 namespace random
 {
 
-  long randint(long a, long b)
+  inline long randint(long a, long b)
   {
     // TODO: It should be implemented with an uniform_int_distribution
     return randrange(a, b + 1);
   }
-}
+} // namespace random
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/random/random.hpp
+++ b/pythran/pythonic/random/random.hpp
@@ -10,13 +10,12 @@ PYTHONIC_NS_BEGIN
 
 namespace random
 {
-
-  double random()
+  inline double random()
   {
     static std::uniform_real_distribution<> uniform_distrib(0.0, 1.0);
     return uniform_distrib(__random_generator);
   }
-}
+} // namespace random
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/random/randrange.hpp
+++ b/pythran/pythonic/random/randrange.hpp
@@ -3,8 +3,8 @@
 
 #include "pythonic/include/random/randrange.hpp"
 
-#include "pythonic/utils/functor.hpp"
 #include "pythonic/random/random.hpp"
+#include "pythonic/utils/functor.hpp"
 
 #include <cmath>
 
@@ -12,21 +12,21 @@ PYTHONIC_NS_BEGIN
 
 namespace random
 {
-  long randrange(long stop)
+  inline long randrange(long stop)
   {
     return long(random() * stop);
   }
 
-  long randrange(long start, long stop)
+  inline long randrange(long start, long stop)
   {
     return start + long(random() * (stop - start));
   }
 
-  long randrange(long start, long stop, long step)
+  inline long randrange(long start, long stop, long step)
   {
     return start + step * long((random() * (stop - start)) / std::abs(step));
   }
-}
+} // namespace random
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/random/seed.hpp
+++ b/pythran/pythonic/random/seed.hpp
@@ -3,9 +3,9 @@
 
 #include "pythonic/include/random/seed.hpp"
 
-#include "pythonic/utils/functor.hpp"
 #include "pythonic/builtins/None.hpp"
 #include "pythonic/random/random.hpp"
+#include "pythonic/utils/functor.hpp"
 
 #include <ctime>
 
@@ -13,18 +13,18 @@ PYTHONIC_NS_BEGIN
 
 namespace random
 {
-  types::none_type seed(long s)
+  inline types::none_type seed(long s)
   {
     __random_generator.seed(s);
     return builtins::None;
   }
 
-  types::none_type seed()
+  inline types::none_type seed()
   {
     __random_generator.seed(time(nullptr));
     return builtins::None;
   }
-}
+} // namespace random
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/random/uniform.hpp
+++ b/pythran/pythonic/random/uniform.hpp
@@ -3,18 +3,18 @@
 
 #include "pythonic/include/random/uniform.hpp"
 
-#include "pythonic/utils/functor.hpp"
 #include "pythonic/random/random.hpp"
+#include "pythonic/utils/functor.hpp"
 
 PYTHONIC_NS_BEGIN
 
 namespace random
 {
-  double uniform(double a, double b)
+  inline double uniform(double a, double b)
   {
     return a + (b - a) * random();
   }
-}
+} // namespace random
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/types/NoneType.hpp
+++ b/pythran/pythonic/types/NoneType.hpp
@@ -3,10 +3,10 @@
 
 #include "pythonic/include/types/NoneType.hpp"
 
-#include "pythonic/types/assignable.hpp"
-#include "pythonic/builtins/id.hpp"
 #include "pythonic/builtins/bool_.hpp"
+#include "pythonic/builtins/id.hpp"
 #include "pythonic/operator_/mod.hpp"
+#include "pythonic/types/assignable.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -18,7 +18,7 @@ namespace types
   {
   }
 
-  intptr_t none_type::id() const
+  inline intptr_t none_type::id() const
   {
     return NONE_ID;
   }
@@ -29,8 +29,7 @@ namespace types
    * see http://en.wikipedia.org/wiki/Option_type
    */
   template <class T>
-  none<T, false>::none(none_type const &)
-      : T(), is_none(true)
+  none<T, false>::none(none_type const &) : T(), is_none(true)
   {
   }
 
@@ -83,20 +82,17 @@ namespace types
 
   /* specialization of none for integral types we cannot derive from */
   template <class T>
-  none<T, true>::none()
-      : data(), is_none(false)
+  none<T, true>::none() : data(), is_none(false)
   {
   }
 
   template <class T>
-  none<T, true>::none(none_type const &)
-      : data(), is_none(true)
+  none<T, true>::none(none_type const &) : data(), is_none(true)
   {
   }
 
   template <class T>
-  none<T, true>::none(T const &data)
-      : data(data), is_none(false)
+  none<T, true>::none(T const &data) : data(data), is_none(false)
   {
   }
 
@@ -375,24 +371,24 @@ namespace types
     else
       return os << v.data;
   }
-}
+} // namespace types
 PYTHONIC_NS_END
 
 #ifdef ENABLE_PYTHON_MODULE
 
 PYTHONIC_NS_BEGIN
 
-bool from_python<types::none_type>::is_convertible(PyObject *obj)
+inline bool from_python<types::none_type>::is_convertible(PyObject *obj)
 {
   return obj == Py_None;
 }
 
-types::none_type from_python<types::none_type>::convert(PyObject *obj)
+inline types::none_type from_python<types::none_type>::convert(PyObject *obj)
 {
   return {};
 }
 
-PyObject *to_python<types::none_type>::convert(types::none_type)
+inline PyObject *to_python<types::none_type>::convert(types::none_type)
 {
   Py_RETURN_NONE;
 }

--- a/pythran/pythonic/types/bool.hpp
+++ b/pythran/pythonic/types/bool.hpp
@@ -6,7 +6,7 @@
 #ifdef ENABLE_PYTHON_MODULE
 
 PYTHONIC_NS_BEGIN
-PyObject *to_python<bool>::convert(bool b)
+inline PyObject *to_python<bool>::convert(bool b)
 {
   if (b)
     Py_RETURN_TRUE;
@@ -14,11 +14,11 @@ PyObject *to_python<bool>::convert(bool b)
     Py_RETURN_FALSE;
 }
 
-bool from_python<bool>::is_convertible(PyObject *obj)
+inline bool from_python<bool>::is_convertible(PyObject *obj)
 {
   return obj == Py_True || obj == Py_False;
 }
-bool from_python<bool>::convert(PyObject *obj)
+inline bool from_python<bool>::convert(PyObject *obj)
 {
   return obj == Py_True;
 }

--- a/pythran/pythonic/types/complex.hpp
+++ b/pythran/pythonic/types/complex.hpp
@@ -2,9 +2,9 @@
 #define PYTHONIC_TYPES_COMPLEX_HPP
 
 #include "pythonic/include/types/complex.hpp"
-#include "pythonic/numpy/complex64.hpp"
 #include "pythonic/numpy/complex128.hpp"
 #include "pythonic/numpy/complex256.hpp"
+#include "pythonic/numpy/complex64.hpp"
 
 #include "pythonic/types/attr.hpp"
 
@@ -139,7 +139,7 @@ namespace std
   {
     return std::hash<T>{}(x.real()) ^ std::hash<T>{}(x.imag());
   };
-}
+} // namespace std
 
 PYTHONIC_NS_BEGIN
 
@@ -156,33 +156,33 @@ namespace builtins
   {
     return std::imag(self);
   }
-  numpy::functor::complex64 getattr(types::attr::DTYPE,
-                                    std::complex<float> const &self)
+  inline numpy::functor::complex64 getattr(types::attr::DTYPE,
+                                           std::complex<float> const &self)
   {
     return {};
   }
-  numpy::functor::complex128 getattr(types::attr::DTYPE,
-                                     std::complex<double> const &self)
+  inline numpy::functor::complex128 getattr(types::attr::DTYPE,
+                                            std::complex<double> const &self)
   {
     return {};
   }
-  numpy::functor::complex256 getattr(types::attr::DTYPE,
-                                     std::complex<long double> const &self)
+  inline numpy::functor::complex256
+  getattr(types::attr::DTYPE, std::complex<long double> const &self)
   {
     return {};
   }
-}
+} // namespace builtins
 PYTHONIC_NS_END
 
 #ifdef ENABLE_PYTHON_MODULE
 
-#include "pythonic/python/core.hpp"
 #include "numpy/arrayscalars.h"
+#include "pythonic/python/core.hpp"
 
 PYTHONIC_NS_BEGIN
 
 template <>
-PyObject *to_python<std::complex<long double>>::convert(
+inline PyObject *to_python<std::complex<long double>>::convert(
     std::complex<long double> const &c)
 {
   return PyArray_Scalar(const_cast<std::complex<long double> *>(&c),
@@ -190,39 +190,41 @@ PyObject *to_python<std::complex<long double>>::convert(
 }
 
 template <>
-PyObject *
+inline PyObject *
 to_python<std::complex<double>>::convert(std::complex<double> const &c)
 {
   return PyComplex_FromDoubles(c.real(), c.imag());
 }
 
 template <>
-PyObject *to_python<std::complex<float>>::convert(std::complex<float> const &c)
+inline PyObject *
+to_python<std::complex<float>>::convert(std::complex<float> const &c)
 {
   return PyArray_Scalar(const_cast<std::complex<float> *>(&c),
                         PyArray_DescrFromType(NPY_CFLOAT), nullptr);
 }
 
 template <>
-bool from_python<std::complex<long double>>::is_convertible(PyObject *obj)
+inline bool
+from_python<std::complex<long double>>::is_convertible(PyObject *obj)
 {
   return PyArray_IsScalar(obj, CLongDouble);
 }
 
 template <>
-bool from_python<std::complex<double>>::is_convertible(PyObject *obj)
+inline bool from_python<std::complex<double>>::is_convertible(PyObject *obj)
 {
   return PyComplex_Check(obj);
 }
 
 template <>
-bool from_python<std::complex<float>>::is_convertible(PyObject *obj)
+inline bool from_python<std::complex<float>>::is_convertible(PyObject *obj)
 {
   return PyArray_IsScalar(obj, CFloat);
 }
 
 template <>
-std::complex<long double>
+inline std::complex<long double>
 from_python<std::complex<long double>>::convert(PyObject *obj)
 {
   auto val = PyArrayScalar_VAL(obj, CLongDouble);
@@ -230,13 +232,15 @@ from_python<std::complex<long double>>::convert(PyObject *obj)
 }
 
 template <>
-std::complex<double> from_python<std::complex<double>>::convert(PyObject *obj)
+inline std::complex<double>
+from_python<std::complex<double>>::convert(PyObject *obj)
 {
   return {PyComplex_RealAsDouble(obj), PyComplex_ImagAsDouble(obj)};
 }
 
 template <>
-std::complex<float> from_python<std::complex<float>>::convert(PyObject *obj)
+inline std::complex<float>
+from_python<std::complex<float>>::convert(PyObject *obj)
 {
   auto val = PyArrayScalar_VAL(obj, CFloat);
   return {val.real, val.imag};

--- a/pythran/pythonic/types/dict.hpp
+++ b/pythran/pythonic/types/dict.hpp
@@ -494,22 +494,22 @@ namespace types
     return s;
   }
 
-  empty_dict empty_dict::operator+(empty_dict const &)
+  inline empty_dict empty_dict::operator+(empty_dict const &)
   {
     return empty_dict();
   }
 
-  empty_dict::operator bool() const
+  inline empty_dict::operator bool() const
   {
     return false;
   }
 
-  typename empty_dict::iterator empty_dict::begin() const
+  inline typename empty_dict::iterator empty_dict::begin() const
   {
     return empty_iterator();
   }
 
-  typename empty_dict::iterator empty_dict::end() const
+  inline typename empty_dict::iterator empty_dict::end() const
   {
     return empty_iterator();
   }
@@ -527,7 +527,7 @@ namespace types
   }
 } // namespace types
 
-std::ostream &operator<<(std::ostream &os, types::empty_dict const &)
+inline std::ostream &operator<<(std::ostream &os, types::empty_dict const &)
 {
   return os << "{}";
 }
@@ -591,7 +591,7 @@ PyObject *to_python<types::dict<K, V>>::convert(types::dict<K, V> const &v)
   return ret;
 }
 
-PyObject *to_python<types::empty_dict>::convert(types::empty_dict)
+inline PyObject *to_python<types::empty_dict>::convert(types::empty_dict)
 {
   return PyDict_New();
 }

--- a/pythran/pythonic/types/empty_iterator.hpp
+++ b/pythran/pythonic/types/empty_iterator.hpp
@@ -16,41 +16,41 @@ namespace types
   {
   }
 
-  bool empty_iterator::operator==(empty_iterator const &) const
+  inline bool empty_iterator::operator==(empty_iterator const &) const
   {
     return true;
   }
 
-  bool empty_iterator::operator!=(empty_iterator const &) const
+  inline bool empty_iterator::operator!=(empty_iterator const &) const
   {
     return false;
   }
 
-  bool empty_iterator::operator<(empty_iterator const &) const
+  inline bool empty_iterator::operator<(empty_iterator const &) const
   {
     return false;
   }
 
-  empty_iterator &empty_iterator::operator++()
+  inline empty_iterator &empty_iterator::operator++()
   {
     return *this;
   }
 
-  empty_iterator &empty_iterator::operator++(int)
+  inline empty_iterator &empty_iterator::operator++(int)
   {
     return *this;
   }
 
-  double empty_iterator::operator*() const
+  inline double empty_iterator::operator*() const
   {
     return {};
   }
 
-  void empty_iterator::operator->() const
+  inline void empty_iterator::operator->() const
   {
     return;
   }
-}
+} // namespace types
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/types/exceptions.hpp
+++ b/pythran/pythonic/types/exceptions.hpp
@@ -3,11 +3,11 @@
 
 #include "pythonic/include/types/exceptions.hpp"
 
-#include "pythonic/types/str.hpp"
-#include "pythonic/types/dynamic_tuple.hpp"
-#include "pythonic/types/attr.hpp"
 #include "pythonic/builtins/None.hpp"
 #include "pythonic/builtins/str.hpp"
+#include "pythonic/types/attr.hpp"
+#include "pythonic/types/dynamic_tuple.hpp"
+#include "pythonic/types/str.hpp"
 
 #include <stdexcept>
 
@@ -17,7 +17,7 @@ namespace types
 {
 
   template <typename... Types>
-  BaseException::BaseException(Types const &... types)
+  BaseException::BaseException(Types const &...types)
       : args({builtins::functor::str{}(types)...})
   {
   }
@@ -72,13 +72,13 @@ namespace types
   CLASS_EXCEPTION_IMPL(IndentationError, SyntaxError);
   CLASS_EXCEPTION_IMPL(TabError, IndentationError);
   CLASS_EXCEPTION_IMPL(UnicodeError, ValueError);
-}
+} // namespace types
 PYTHONIC_NS_END
 
 #include "pythonic/utils/functor.hpp"
 #define PYTHONIC_EXCEPTION_IMPL(name)                                          \
   template <typename... Types>                                                 \
-  types::name name(Types const &... args)                                      \
+  types::name name(Types const &...args)                                       \
   {                                                                            \
     return types::name(args...);                                               \
   }
@@ -88,7 +88,7 @@ PYTHONIC_NS_END
   PYTHONIC_NS_BEGIN                                                            \
   namespace builtins                                                           \
   {                                                                            \
-    types::none<types::dynamic_tuple<types::str>>                              \
+    inline types::none<types::dynamic_tuple<types::str>>                       \
     getattr(types::attr::ARGS, types::name const &f)                           \
     {                                                                          \
       return f.args;                                                           \
@@ -100,7 +100,7 @@ PYTHONIC_NS_END
   PYTHONIC_NS_BEGIN                                                            \
   namespace builtins                                                           \
   {                                                                            \
-    types::none<types::dynamic_tuple<types::str>>                              \
+    inline types::none<types::dynamic_tuple<types::str>>                       \
     getattr(types::attr::ARGS, types::name const &e)                           \
     {                                                                          \
       if (e.args.size() > 3 || e.args.size() < 2)                              \
@@ -109,23 +109,24 @@ PYTHONIC_NS_END
         return types::dynamic_tuple<types::str>(e.args.begin(),                \
                                                 e.args.begin() + 2);           \
     }                                                                          \
-    types::none<types::str> getattr(types::attr::ERRNO, types::name const &e)  \
+    inline types::none<types::str> getattr(types::attr::ERRNO,                 \
+                                           types::name const &e)               \
     {                                                                          \
       if (e.args.size() > 3 || e.args.size() < 2)                              \
         return builtins::None;                                                 \
       else                                                                     \
         return e.args[0];                                                      \
     }                                                                          \
-    types::none<types::str> getattr(types::attr::STRERROR,                     \
-                                    types::name const &e)                      \
+    inline types::none<types::str> getattr(types::attr::STRERROR,              \
+                                           types::name const &e)               \
     {                                                                          \
       if (e.args.size() > 3 || e.args.size() < 2)                              \
         return builtins::None;                                                 \
       else                                                                     \
         return e.args[1];                                                      \
     }                                                                          \
-    types::none<types::str> getattr(types::attr::FILENAME,                     \
-                                    types::name const &e)                      \
+    inline types::none<types::str> getattr(types::attr::FILENAME,              \
+                                           types::name const &e)               \
     {                                                                          \
       if (e.args.size() != 3)                                                  \
         return builtins::None;                                                 \
@@ -187,7 +188,7 @@ PYTHONIC_NS_BEGIN
 namespace types
 {
 
-  std::ostream &operator<<(std::ostream &o, BaseException const &e)
+  inline std::ostream &operator<<(std::ostream &o, BaseException const &e)
   {
     return o << e.args;
   }
@@ -203,7 +204,7 @@ namespace types
    * - four || more args, the "tuple" used to construct the exception
    *
    */
-  std::ostream &operator<<(std::ostream &o, EnvironmentError const &e)
+  inline std::ostream &operator<<(std::ostream &o, EnvironmentError const &e)
   {
     if (e.args.size() == 1)
       return o << e.args[0];
@@ -224,7 +225,7 @@ namespace types
       return o;
     }
   }
-}
+} // namespace types
 PYTHONIC_NS_END
 
 /* } */

--- a/pythran/pythonic/types/file.hpp
+++ b/pythran/pythonic/types/file.hpp
@@ -3,23 +3,23 @@
 
 #include "pythonic/include/types/file.hpp"
 
-#include "pythonic/types/assignable.hpp"
-#include "pythonic/utils/shared_ref.hpp"
-#include "pythonic/types/str.hpp"
-#include "pythonic/types/list.hpp"
-#include "pythonic/types/NoneType.hpp"
-#include "pythonic/types/attr.hpp"
 #include "pythonic/builtins/IOError.hpp"
-#include "pythonic/builtins/ValueError.hpp"
 #include "pythonic/builtins/RuntimeError.hpp"
 #include "pythonic/builtins/StopIteration.hpp"
+#include "pythonic/builtins/ValueError.hpp"
+#include "pythonic/types/NoneType.hpp"
+#include "pythonic/types/assignable.hpp"
+#include "pythonic/types/attr.hpp"
+#include "pythonic/types/list.hpp"
+#include "pythonic/types/str.hpp"
+#include "pythonic/utils/shared_ref.hpp"
 
+#include <cstdio>
+#include <cstring>
 #include <fstream>
 #include <iterator>
-#include <cstring>
-#include <string>
-#include <cstdio>
 #include <memory>
+#include <string>
 
 #ifdef _WIN32
 #include <io.h>
@@ -34,22 +34,22 @@ namespace types
 
   /// _file implementation
 
-  _file::_file() : f(nullptr)
+  inline _file::_file() : f(nullptr)
   {
   }
 
   // TODO : no check on file existance?
-  _file::_file(types::str const &filename, types::str const &strmode)
+  inline _file::_file(types::str const &filename, types::str const &strmode)
       : f(fopen(filename.c_str(), strmode.c_str()))
   {
   }
 
-  FILE *_file::operator*() const
+  inline FILE *_file::operator*() const
   {
     return f;
   }
 
-  _file::~_file()
+  inline _file::~_file()
   {
     if (f)
       fclose(f);
@@ -58,11 +58,11 @@ namespace types
   /// file implementation
 
   // Constructors
-  file::file() : file_iterator(), data(utils::no_memory())
+  inline file::file() : file_iterator(), data(utils::no_memory())
   {
   }
 
-  file::file(types::str const &filename, types::str const &strmode)
+  inline file::file(types::str const &filename, types::str const &strmode)
       : file_iterator(), data(utils::no_memory()), mode(strmode),
         name(filename), newlines('\n')
   {
@@ -72,18 +72,18 @@ namespace types
   }
 
   // Iterators
-  file::iterator file::begin()
+  inline file::iterator file::begin()
   {
     return *this;
   }
 
-  file::iterator file::end()
+  inline file::iterator file::end()
   {
     return {};
   }
 
   // Modifiers
-  void file::open(types::str const &filename, types::str const &strmode)
+  inline void file::open(types::str const &filename, types::str const &strmode)
   {
     const char *smode = strmode.c_str();
     // Python enforces that the mode, after stripping 'U', begins with 'r',
@@ -98,61 +98,61 @@ namespace types
     is_open = true;
   }
 
-  void file::close()
+  inline void file::close()
   {
     fclose(**data);
     data->f = nullptr;
     is_open = false;
   }
 
-  bool file::closed() const
+  inline bool file::closed() const
   {
     return !is_open;
   }
 
-  types::str const &file::getmode() const
+  inline types::str const &file::getmode() const
   {
     return mode;
   }
 
-  types::str const &file::getname() const
+  inline types::str const &file::getname() const
   {
     return name;
   }
 
-  types::str const &file::getnewlines() const
+  inline types::str const &file::getnewlines() const
   {
     // Python seems to always return none... Doing the same here
     return newlines;
   }
 
-  bool file::eof()
+  inline bool file::eof()
   {
     return ::feof(**data);
   }
 
-  void file::flush()
+  inline void file::flush()
   {
     if (!is_open)
       throw ValueError("I/O operation on closed file");
     fflush(**data);
   }
 
-  long file::fileno() const
+  inline long file::fileno() const
   {
     if (!is_open)
       throw ValueError("I/O operation on closed file");
     return ::fileno(**data);
   }
 
-  bool file::isatty() const
+  inline bool file::isatty() const
   {
     if (!is_open)
       throw ValueError("I/O operation on closed file");
     return ::isatty(this->fileno());
   }
 
-  types::str file::read(long size)
+  inline types::str file::read(long size)
   {
     if (!is_open)
       throw ValueError("I/O operation on closed file");
@@ -172,7 +172,7 @@ namespace types
     return res;
   }
 
-  types::str file::readline(long size)
+  inline types::str file::readline(long size)
   {
     if (!is_open)
       throw ValueError("I/O operation on closed file");
@@ -192,7 +192,7 @@ namespace types
     return res;
   }
 
-  types::list<types::str> file::readlines(long sizehint)
+  inline types::list<types::str> file::readlines(long sizehint)
   {
     // Official python doc specifies that sizehint is used as a max of chars
     // But it has not been implemented in the standard python interpreter...
@@ -203,7 +203,7 @@ namespace types
     return lst;
   }
 
-  void file::seek(long offset, long whence)
+  inline void file::seek(long offset, long whence)
   {
     if (!is_open)
       throw ValueError("I/O operation on closed file");
@@ -212,14 +212,14 @@ namespace types
     fseek(**data, offset, whence);
   }
 
-  long file::tell() const
+  inline long file::tell() const
   {
     if (!is_open)
       throw ValueError("I/O operation on closed file");
     return ftell(**data);
   }
 
-  void file::truncate(long size)
+  inline void file::truncate(long size)
   {
     if (!is_open)
       throw ValueError("I/O operation on closed file");
@@ -236,7 +236,7 @@ namespace types
       throw RuntimeError(strerror(errno));
   }
 
-  long file::write(types::str const &str)
+  inline long file::write(types::str const &str)
   {
     if (!is_open)
       throw ValueError("I/O operation on closed file");
@@ -258,33 +258,33 @@ namespace types
   // Like in :
   // for line in open("myfile"):
   //     print line
-  file_iterator::file_iterator(file &ref)
+  inline file_iterator::file_iterator(file &ref)
       : f(&ref), set(false), curr(), position(ref.tell())
   {
   }
 
-  file_iterator::file_iterator()
+  inline file_iterator::file_iterator()
       : f(nullptr), set(false), curr(),
         position(std::numeric_limits<long>::max()){};
 
-  bool file_iterator::operator==(file_iterator const &f2) const
+  inline bool file_iterator::operator==(file_iterator const &f2) const
   {
     return position == f2.position;
   }
 
-  bool file_iterator::operator!=(file_iterator const &f2) const
+  inline bool file_iterator::operator!=(file_iterator const &f2) const
   {
     return position != f2.position;
   }
 
-  bool file_iterator::operator<(file_iterator const &f2) const
+  inline bool file_iterator::operator<(file_iterator const &f2) const
   {
     // Not really elegant...
     // Equivalent to 'return *this != f2;'
     return position < f2.position;
   }
 
-  file_iterator &file_iterator::operator++()
+  inline file_iterator &file_iterator::operator++()
   {
     if (f->eof())
       return *this;
@@ -295,7 +295,7 @@ namespace types
     return *this;
   }
 
-  types::str file_iterator::operator*() const
+  inline types::str file_iterator::operator*() const
   {
     if (!set) {
       curr = f->readline();
@@ -303,7 +303,7 @@ namespace types
     }
     return curr.chars(); // to make a copy
   }
-}
+} // namespace types
 PYTHONIC_NS_END
 
 /* pythran attribute system { */
@@ -311,27 +311,27 @@ PYTHONIC_NS_BEGIN
 
 namespace builtins
 {
-  bool getattr(types::attr::CLOSED, types::file const &f)
+  inline bool getattr(types::attr::CLOSED, types::file const &f)
   {
     return f.closed();
   }
 
-  types::str const &getattr(types::attr::MODE, types::file const &f)
+  inline types::str const &getattr(types::attr::MODE, types::file const &f)
   {
     return f.getmode();
   }
 
-  types::str const &getattr(types::attr::NAME, types::file const &f)
+  inline types::str const &getattr(types::attr::NAME, types::file const &f)
   {
     return f.getname();
   }
 
   // Python seems to always return none... Doing the same.
-  types::none_type getattr(types::attr::NEWLINES, types::file const &f)
+  inline types::none_type getattr(types::attr::NEWLINES, types::file const &f)
   {
     return builtins::None;
   }
-}
+} // namespace builtins
 PYTHONIC_NS_END
 
 /* } */

--- a/pythran/pythonic/types/float.hpp
+++ b/pythran/pythonic/types/float.hpp
@@ -8,50 +8,50 @@
 
 #ifdef ENABLE_PYTHON_MODULE
 
-#include "pythonic/python/core.hpp"
 #include "numpy/arrayscalars.h"
+#include "pythonic/python/core.hpp"
 #include <iostream>
 
 PYTHONIC_NS_BEGIN
 
-PyObject *to_python<long double>::convert(long double d)
+inline PyObject *to_python<long double>::convert(long double d)
 {
   return PyArray_Scalar(&d, PyArray_DescrFromType(NPY_LONGDOUBLE), nullptr);
 }
 
-PyObject *to_python<double>::convert(double d)
+inline PyObject *to_python<double>::convert(double d)
 {
   return PyFloat_FromDouble(d);
 }
-PyObject *to_python<float>::convert(float d)
+inline PyObject *to_python<float>::convert(float d)
 {
   return PyArray_Scalar(&d, PyArray_DescrFromType(NPY_FLOAT), nullptr);
 }
 
-bool from_python<long double>::is_convertible(PyObject *obj)
+inline bool from_python<long double>::is_convertible(PyObject *obj)
 {
   return PyArray_IsScalar(obj, LongDouble);
 }
 
-long double from_python<long double>::convert(PyObject *obj)
+inline long double from_python<long double>::convert(PyObject *obj)
 {
   return PyArrayScalar_VAL(obj, LongDouble);
 }
 
-bool from_python<double>::is_convertible(PyObject *obj)
+inline bool from_python<double>::is_convertible(PyObject *obj)
 {
   return PyFloat_Check(obj);
 }
-double from_python<double>::convert(PyObject *obj)
+inline double from_python<double>::convert(PyObject *obj)
 {
   return PyFloat_AsDouble(obj);
 }
 
-bool from_python<float>::is_convertible(PyObject *obj)
+inline bool from_python<float>::is_convertible(PyObject *obj)
 {
   return PyArray_IsScalar(obj, Float);
 }
-float from_python<float>::convert(PyObject *obj)
+inline float from_python<float>::convert(PyObject *obj)
 {
   return PyArrayScalar_VAL(obj, Float);
 }

--- a/pythran/pythonic/types/int.hpp
+++ b/pythran/pythonic/types/int.hpp
@@ -20,13 +20,13 @@ namespace builtins
   {
     return T(0);
   }
-}
+} // namespace builtins
 PYTHONIC_NS_END
 
 #ifdef ENABLE_PYTHON_MODULE
 
-#include "pythonic/python/core.hpp"
 #include "numpy/arrayobject.h"
+#include "pythonic/python/core.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -132,7 +132,7 @@ struct c_type_to_numpy_type<bool> : std::integral_constant<int, NPY_BOOL> {
 #endif
 
 #define PYTHONIC_INT_TO_PYTHON(TYPE)                                           \
-  PyObject *to_python<TYPE>::convert(TYPE l)                                   \
+  inline PyObject *to_python<TYPE>::convert(TYPE l)                            \
   {                                                                            \
     return PyArray_Scalar(                                                     \
         &l, PyArray_DescrFromType(c_type_to_numpy_type<TYPE>::value),          \
@@ -157,12 +157,12 @@ PYTHONIC_INT_TO_PYTHON(signed long long)
 #undef PYTHONIC_INT_TO_PYTHON
 
 #define PYTHONIC_INT_FROM_PYTHON(TYPE, NTYPE)                                  \
-  bool from_python<TYPE>::is_convertible(PyObject *obj)                        \
+  inline bool from_python<TYPE>::is_convertible(PyObject *obj)                 \
   {                                                                            \
     return PyInt_CheckExact(obj) ||                                            \
            PyObject_TypeCheck(obj, &Py##NTYPE##ArrType_Type);                  \
   }                                                                            \
-  TYPE from_python<TYPE>::convert(PyObject *obj)                               \
+  inline TYPE from_python<TYPE>::convert(PyObject *obj)                        \
   {                                                                            \
     return PyInt_AsLong(obj);                                                  \
   }

--- a/pythran/pythonic/types/list.hpp
+++ b/pythran/pythonic/types/list.hpp
@@ -5,14 +5,14 @@
 #include "pythonic/types/nditerator.hpp"
 
 #include "pythonic/builtins/len.hpp"
+#include "pythonic/types/bool.hpp"
 #include "pythonic/types/slice.hpp"
 #include "pythonic/types/tuple.hpp"
-#include "pythonic/types/bool.hpp"
-#include "pythonic/utils/shared_ref.hpp"
 #include "pythonic/utils/reserve.hpp"
+#include "pythonic/utils/shared_ref.hpp"
 
-#include <cassert>
 #include <algorithm>
+#include <cassert>
 
 PYTHONIC_NS_BEGIN
 
@@ -23,8 +23,7 @@ namespace types
 
   // Constructors
   template <class T, class S>
-  sliced_list<T, S>::sliced_list()
-      : data(utils::no_memory())
+  sliced_list<T, S>::sliced_list() : data(utils::no_memory())
   {
   }
   template <class T, class S>
@@ -90,8 +89,8 @@ namespace types
     return (*data)[index];
   }
   template <class T, class S>
-  typename sliced_list<T, S>::const_reference sliced_list<T, S>::
-  operator[](long i) const
+  typename sliced_list<T, S>::const_reference
+  sliced_list<T, S>::operator[](long i) const
   {
     assert(i < size());
     auto const index = slicing.get(i);
@@ -112,8 +111,7 @@ namespace types
   typename std::enable_if<
       is_slice<Sp>::value,
       sliced_list<T, decltype(std::declval<S>() * std::declval<Sp>())>>::type
-      sliced_list<T, S>::
-      operator[](Sp s) const
+  sliced_list<T, S>::operator[](Sp s) const
   {
     return {data, slicing * s.normalize(this->size())};
   }
@@ -149,8 +147,8 @@ namespace types
     return size() == 0;
   }
   template <class T, class S>
-  inline sliced_list<T, S> &sliced_list<T, S>::
-  operator=(sliced_list<T, S> const &s)
+  inline sliced_list<T, S> &
+  sliced_list<T, S>::operator=(sliced_list<T, S> const &s)
   {
     if (slicing.step == 1) {
       // inserting before erasing in case of self-copy
@@ -192,8 +190,8 @@ namespace types
   }
   template <class T, class S>
   template <class Tp, class Sp>
-  list<typename __combined<T, Tp>::type> sliced_list<T, S>::
-  operator+(sliced_list<Tp, Sp> const &s) const
+  list<typename __combined<T, Tp>::type>
+  sliced_list<T, S>::operator+(sliced_list<Tp, Sp> const &s) const
   {
     list<typename __combined<T, Tp>::type> out(size() + s.size());
     std::copy(s.begin(), s.end(), std::copy(begin(), end(), out.begin()));
@@ -208,7 +206,7 @@ namespace types
   template <class T, class S>
   template <class vectorizer>
   typename sliced_list<T, S>::simd_iterator
-      sliced_list<T, S>::vbegin(vectorizer) const
+  sliced_list<T, S>::vbegin(vectorizer) const
   {
     return {data->data() + slicing.lower};
   }
@@ -216,7 +214,7 @@ namespace types
   template <class T, class S>
   template <class vectorizer>
   typename sliced_list<T, S>::simd_iterator
-      sliced_list<T, S>::vend(vectorizer) const
+  sliced_list<T, S>::vend(vectorizer) const
   {
     using vector_type = typename xsimd::batch<dtype>;
     static const std::size_t vector_size = vector_type::size;
@@ -250,14 +248,12 @@ namespace types
 
   // constructors
   template <class T>
-  list<T>::list()
-      : data(utils::no_memory())
+  list<T>::list() : data(utils::no_memory())
   {
   }
   template <class T>
   template <class InputIterator>
-  list<T>::list(InputIterator start, InputIterator stop)
-      : data()
+  list<T>::list(InputIterator start, InputIterator stop) : data()
   {
     if (std::is_same<
             typename std::iterator_traits<InputIterator>::iterator_category,
@@ -268,39 +264,32 @@ namespace types
     std::copy(start, stop, std::back_inserter(*data));
   }
   template <class T>
-  list<T>::list(empty_list const &)
-      : data(0)
+  list<T>::list(empty_list const &) : data(0)
   {
   }
   template <class T>
-  list<T>::list(size_type sz)
-      : data(sz)
+  list<T>::list(size_type sz) : data(sz)
   {
   }
   template <class T>
-  list<T>::list(T const &value, single_value, size_type sz)
-      : data(sz, value)
+  list<T>::list(T const &value, single_value, size_type sz) : data(sz, value)
   {
   }
   template <class T>
-  list<T>::list(std::initializer_list<T> l)
-      : data(std::move(l))
+  list<T>::list(std::initializer_list<T> l) : data(std::move(l))
   {
   }
   template <class T>
-  list<T>::list(list<T> &&other)
-      : data(std::move(other.data))
+  list<T>::list(list<T> &&other) : data(std::move(other.data))
   {
   }
   template <class T>
-  list<T>::list(list<T> const &other)
-      : data(other.data)
+  list<T>::list(list<T> const &other) : data(other.data)
   {
   }
   template <class T>
   template <class F>
-  list<T>::list(list<F> const &other)
-      : data(other.size())
+  list<T>::list(list<F> const &other) : data(other.size())
   {
     std::copy(other.begin(), other.end(), begin());
   }
@@ -542,8 +531,7 @@ namespace types
   template <class T>
   template <class Sp>
   typename std::enable_if<is_slice<Sp>::value, sliced_list<T, Sp>>::type
-      list<T>::
-      operator[](Sp const &s) const
+  list<T>::operator[](Sp const &s) const
   {
     return {*this, s};
   }
@@ -615,8 +603,8 @@ namespace types
 
   template <class T>
   template <class F>
-  list<typename __combined<T, F>::type> list<T>::
-  operator+(list<F> const &s) const
+  list<typename __combined<T, F>::type>
+  list<T>::operator+(list<F> const &s) const
   {
     list<typename __combined<T, F>::type> clone(size() + s.size());
     std::copy(s.begin(), s.end(), std::copy(begin(), end(), clone.begin()));
@@ -627,7 +615,7 @@ namespace types
   template <class F, class S>
   list<decltype(std::declval<T>() +
                 std::declval<typename sliced_list<F, S>::value_type>())>
-      list<T>::operator+(sliced_list<F, S> const &s) const
+  list<T>::operator+(sliced_list<F, S> const &s) const
   {
     list<decltype(std::declval<T>() +
                   std::declval<typename sliced_list<F, S>::value_type>())>
@@ -739,18 +727,18 @@ namespace types
   {
     return s.template to_array<list_version>();
   }
-  empty_list empty_list::operator+(empty_list const &) const
+  inline empty_list empty_list::operator+(empty_list const &) const
   {
     return empty_list();
   }
   template <class F>
   typename std::enable_if<!is_numexpr_arg<F>::value,
-                          list<typename F::value_type>>::type empty_list::
-  operator+(F s) const
+                          list<typename F::value_type>>::type
+  empty_list::operator+(F s) const
   {
     return {s.begin(), s.end()};
   }
-  empty_list::operator bool() const
+  inline empty_list::operator bool() const
   {
     return false;
   }
@@ -761,16 +749,16 @@ namespace types
     return list<T>(0);
   }
 
-  constexpr long empty_list::size()
+  inline constexpr long empty_list::size()
   {
     return 0;
   }
 
-  std::ostream &operator<<(std::ostream &os, empty_list const &)
+  inline std::ostream &operator<<(std::ostream &os, empty_list const &)
   {
     return os << "[]";
   }
-}
+} // namespace types
 
 namespace utils
 {
@@ -781,7 +769,7 @@ namespace utils
   {
     l.reserve(builtins::len(f));
   }
-}
+} // namespace utils
 PYTHONIC_NS_END
 
 /* overload std::get */
@@ -827,19 +815,19 @@ namespace std
   {
     return std::move(t)[I];
   }
-}
+} // namespace std
 
 #ifdef ENABLE_PYTHON_MODULE
 
 PYTHONIC_NS_BEGIN
 
-PyObject *to_python<typename std::vector<bool>::reference>::convert(
+inline PyObject *to_python<typename std::vector<bool>::reference>::convert(
     typename std::vector<bool>::reference const &v)
 {
   return ::to_python((bool)v);
 }
 
-PyObject *to_python<typename std::conditional<
+inline PyObject *to_python<typename std::conditional<
     std::is_same<bool, typename std::vector<bool>::const_reference>::value,
     phantom_type, typename std::vector<bool>::const_reference>::type>::
     convert(typename std::vector<bool>::const_reference const &v)
@@ -867,7 +855,8 @@ to_python<types::sliced_list<T, S>>::convert(types::sliced_list<T, S> const &v)
   return ret;
 }
 
-PyObject *to_python<types::empty_list>::convert(types::empty_list const &)
+inline PyObject *
+to_python<types::empty_list>::convert(types::empty_list const &)
 {
   return PyList_New(0);
 }

--- a/pythran/pythonic/types/ndarray.hpp
+++ b/pythran/pythonic/types/ndarray.hpp
@@ -4,45 +4,45 @@
 #include "pythonic/include/types/ndarray.hpp"
 
 #include "pythonic/types/assignable.hpp"
-#include "pythonic/types/empty_iterator.hpp"
 #include "pythonic/types/attr.hpp"
+#include "pythonic/types/empty_iterator.hpp"
 
 #include "pythonic/builtins/ValueError.hpp"
 
-#include "pythonic/utils/nested_container.hpp"
-#include "pythonic/utils/shared_ref.hpp"
-#include "pythonic/utils/reserve.hpp"
-#include "pythonic/utils/int_.hpp"
 #include "pythonic/utils/broadcast_copy.hpp"
+#include "pythonic/utils/int_.hpp"
+#include "pythonic/utils/nested_container.hpp"
+#include "pythonic/utils/reserve.hpp"
+#include "pythonic/utils/shared_ref.hpp"
 
-#include "pythonic/types/slice.hpp"
-#include "pythonic/types/tuple.hpp"
 #include "pythonic/types/list.hpp"
 #include "pythonic/types/raw_array.hpp"
+#include "pythonic/types/slice.hpp"
+#include "pythonic/types/tuple.hpp"
 
 #include "pythonic/numpy/bool_.hpp"
-#include "pythonic/numpy/uint8.hpp"
-#include "pythonic/numpy/int8.hpp"
-#include "pythonic/numpy/uint16.hpp"
-#include "pythonic/numpy/int16.hpp"
-#include "pythonic/numpy/uint32.hpp"
-#include "pythonic/numpy/int32.hpp"
-#include "pythonic/numpy/uint64.hpp"
-#include "pythonic/numpy/int64.hpp"
+#include "pythonic/numpy/complex128.hpp"
+#include "pythonic/numpy/complex64.hpp"
 #include "pythonic/numpy/float32.hpp"
 #include "pythonic/numpy/float64.hpp"
-#include "pythonic/numpy/complex64.hpp"
-#include "pythonic/numpy/complex128.hpp"
+#include "pythonic/numpy/int16.hpp"
+#include "pythonic/numpy/int32.hpp"
+#include "pythonic/numpy/int64.hpp"
+#include "pythonic/numpy/int8.hpp"
+#include "pythonic/numpy/uint16.hpp"
+#include "pythonic/numpy/uint32.hpp"
+#include "pythonic/numpy/uint64.hpp"
+#include "pythonic/numpy/uint8.hpp"
 
-#include "pythonic/types/vectorizable_type.hpp"
-#include "pythonic/types/numpy_op_helper.hpp"
 #include "pythonic/types/numpy_expr.hpp"
-#include "pythonic/types/numpy_texpr.hpp"
-#include "pythonic/types/numpy_iexpr.hpp"
 #include "pythonic/types/numpy_gexpr.hpp"
+#include "pythonic/types/numpy_iexpr.hpp"
+#include "pythonic/types/numpy_op_helper.hpp"
+#include "pythonic/types/numpy_texpr.hpp"
 #include "pythonic/types/numpy_vexpr.hpp"
-#include "pythonic/utils/numpy_traits.hpp"
+#include "pythonic/types/vectorizable_type.hpp"
 #include "pythonic/utils/array_helper.hpp"
+#include "pythonic/utils/numpy_traits.hpp"
 
 #include "pythonic/builtins/len.hpp"
 #include "pythonic/operator_/iadd.hpp"
@@ -50,14 +50,14 @@
 #include "pythonic/operator_/idiv.hpp"
 #include "pythonic/operator_/imul.hpp"
 #include "pythonic/operator_/ior.hpp"
-#include "pythonic/operator_/ixor.hpp"
 #include "pythonic/operator_/isub.hpp"
+#include "pythonic/operator_/ixor.hpp"
 
+#include <array>
 #include <cassert>
+#include <initializer_list>
 #include <iostream>
 #include <iterator>
-#include <array>
-#include <initializer_list>
 #include <numeric>
 
 #if !defined(HAVE_SSIZE_T) || !HAVE_SSIZE_T
@@ -146,8 +146,8 @@ namespace types
         std::get<std::tuple_size<S>::value - std::tuple_size<pS>::value>(shape),
         iter.size());
     for (auto content : iter)
-      from = type_helper<ndarray<T, sutils::pop_tail_t<pS>> const &>::
-          initialize_from_iterable(shape, from, content);
+      from = type_helper<ndarray<T, sutils::pop_tail_t<pS>> const
+                             &>::initialize_from_iterable(shape, from, content);
     return from;
   }
 
@@ -226,16 +226,16 @@ namespace types
 
   template <class T, class pS>
   typename type_helper<ndarray<T, array<pS, 1>>>::iterator
-      type_helper<ndarray<T, array<pS, 1>>>::make_iterator(
-          ndarray<T, array<pS, 1>> &n, long i)
+  type_helper<ndarray<T, array<pS, 1>>>::make_iterator(
+      ndarray<T, array<pS, 1>> &n, long i)
   {
     return n.buffer + i;
   }
 
   template <class T, class pS>
   typename type_helper<ndarray<T, array<pS, 1>>>::const_iterator
-      type_helper<ndarray<T, array<pS, 1>>>::make_iterator(
-          ndarray<T, array<pS, 1>> const &n, long i)
+  type_helper<ndarray<T, array<pS, 1>>>::make_iterator(
+      ndarray<T, array<pS, 1>> const &n, long i)
   {
     return n.buffer + i;
   }
@@ -251,23 +251,23 @@ namespace types
 
   template <class T, class pS>
   typename type_helper<ndarray<T, array<pS, 1>>>::type
-      type_helper<ndarray<T, array<pS, 1>>>::get(
-          ndarray<T, array<pS, 1>> &&self, long i)
+  type_helper<ndarray<T, array<pS, 1>>>::get(ndarray<T, array<pS, 1>> &&self,
+                                             long i)
   {
     return self.buffer[i];
   }
 
   template <class T, class pS>
   typename type_helper<ndarray<T, array<pS, 1>> const &>::iterator
-      type_helper<ndarray<T, array<pS, 1>> const &>::make_iterator(
-          ndarray<T, array<pS, 1>> &n, long i)
+  type_helper<ndarray<T, array<pS, 1>> const &>::make_iterator(
+      ndarray<T, array<pS, 1>> &n, long i)
   {
     return n.buffer + i;
   }
 
   template <class T, class pS>
   typename type_helper<ndarray<T, array<pS, 1>> const &>::const_iterator
-      make_iterator(ndarray<T, array<pS, 1>> const &n, long i)
+  make_iterator(ndarray<T, array<pS, 1>> const &n, long i)
   {
     return n.buffer + i;
   }
@@ -283,8 +283,8 @@ namespace types
 
   template <class T, class pS>
   typename type_helper<ndarray<T, array<pS, 1>> const &>::type &
-      type_helper<ndarray<T, array<pS, 1>> const &>::get(
-          ndarray<T, array<pS, 1>> const &self, long i)
+  type_helper<ndarray<T, array<pS, 1>> const &>::get(
+      ndarray<T, array<pS, 1>> const &self, long i)
   {
     return self.buffer[i];
   }
@@ -294,7 +294,7 @@ namespace types
   {
     return index;
   }
-  long patch_index(long index, std::integral_constant<long, 1> const &)
+  inline long patch_index(long index, std::integral_constant<long, 1> const &)
   {
     return 0;
   }
@@ -408,8 +408,7 @@ namespace types
   }
 
   template <class T, class pS>
-  ndarray<T, pS>::ndarray(pS const &shape, T init)
-      : ndarray(shape, none_type())
+  ndarray<T, pS>::ndarray(pS const &shape, T init) : ndarray(shape, none_type())
   {
     std::fill(fbegin(), fend(), init);
   }
@@ -629,11 +628,11 @@ namespace types
   }
 
   template <class T, class pS>
-      template <class Ty, size_t M>
-      auto ndarray<T, pS>::fast(array<Ty, M> const &indices) &&
-      -> typename std::enable_if<std::is_integral<Ty>::value,
-                                 decltype(nget<M - 1>().fast(std::move(*this),
-                                                             indices))>::type
+  template <class Ty, size_t M>
+  auto ndarray<T, pS>::fast(array<Ty, M> const &indices) && ->
+      typename std::enable_if<std::is_integral<Ty>::value,
+                              decltype(nget<M - 1>().fast(std::move(*this),
+                                                          indices))>::type
   {
     return nget<M - 1>().fast(std::move(*this), indices);
   }
@@ -641,8 +640,7 @@ namespace types
   template <class T, class pS>
   template <class Ty>
   typename std::enable_if<std::is_integral<Ty>::value, T const &>::type
-      ndarray<T, pS>::
-      operator[](array<Ty, value> const &indices) const
+  ndarray<T, pS>::operator[](array<Ty, value> const &indices) const
   {
     return *(buffer +
              noffset<std::tuple_size<pS>::value>{}(*this, indices, _shape));
@@ -651,8 +649,7 @@ namespace types
   template <class T, class pS>
   template <class Ty>
   typename std::enable_if<std::is_integral<Ty>::value, T &>::type
-      ndarray<T, pS>::
-      operator[](array<Ty, value> const &indices)
+  ndarray<T, pS>::operator[](array<Ty, value> const &indices)
   {
     return *(buffer +
              noffset<std::tuple_size<pS>::value>{}(*this, indices, _shape));
@@ -668,11 +665,11 @@ namespace types
   }
 
   template <class T, class pS>
-      template <class Ty, size_t M>
-      auto ndarray<T, pS>::operator[](array<Ty, M> const &indices) &&
-      -> typename std::enable_if<std::is_integral<Ty>::value,
-                                 decltype(nget<M - 1>()(std::move(*this),
-                                                        indices))>::type
+  template <class Ty, size_t M>
+  auto ndarray<T, pS>::operator[](array<Ty, M> const &indices) && ->
+      typename std::enable_if<std::is_integral<Ty>::value,
+                              decltype(nget<M - 1>()(std::move(*this),
+                                                     indices))>::type
   {
     return nget<M - 1>()(std::move(*this), indices);
   }
@@ -681,7 +678,7 @@ namespace types
   template <class T, class pS>
   template <class vectorizer>
   typename ndarray<T, pS>::simd_iterator
-      ndarray<T, pS>::vbegin(vectorizer) const
+  ndarray<T, pS>::vbegin(vectorizer) const
   {
     return {buffer};
   }
@@ -700,7 +697,7 @@ namespace types
   /* slice indexing */
   template <class T, class pS>
   ndarray<T, sutils::push_front_t<pS, std::integral_constant<long, 1>>>
-      ndarray<T, pS>::operator[](none_type) const
+  ndarray<T, pS>::operator[](none_type) const
   {
     sutils::push_front_t<pS, std::integral_constant<long, 1>> new_shape;
     sutils::copy_shape<1, -1>(
@@ -714,8 +711,7 @@ namespace types
   typename std::enable_if<
       is_slice<S>::value,
       numpy_gexpr<ndarray<T, pS> const &, normalize_t<S>>>::type
-      ndarray<T, pS>::
-      operator[](S const &s) const &
+  ndarray<T, pS>::operator[](S const &s) const &
   {
     return make_gexpr(*this, s);
   }
@@ -724,8 +720,7 @@ namespace types
   template <class S>
   typename std::enable_if<is_slice<S>::value,
                           numpy_gexpr<ndarray<T, pS>, normalize_t<S>>>::type
-      ndarray<T, pS>::
-      operator[](S const &s) &&
+  ndarray<T, pS>::operator[](S const &s) &&
   {
     return make_gexpr(std::move(*this), s);
   }
@@ -739,27 +734,26 @@ namespace types
   /* extended slice indexing */
   template <class T, class pS>
   template <class S0, class... S>
-  auto ndarray<T, pS>::operator()(S0 const &s0, S const &... s) const
-      & -> decltype(extended_slice<count_new_axis<S0, S...>::value>{}((*this),
-                                                                      s0, s...))
+  auto
+  ndarray<T, pS>::operator()(S0 const &s0, S const &...s) const & -> decltype(
+      extended_slice<count_new_axis<S0, S...>::value>{}((*this), s0, s...))
   {
     return extended_slice<count_new_axis<S0, S...>::value>{}((*this), s0, s...);
   }
 
   template <class T, class pS>
-      template <class S0, class... S>
-      auto ndarray<T, pS>::operator()(S0 const &s0, S const &... s) &
-      -> decltype(extended_slice<count_new_axis<S0, S...>::value>{}((*this), s0,
-                                                                    s...))
+  template <class S0, class... S>
+  auto ndarray<T, pS>::operator()(S0 const &s0, S const &...s) & -> decltype(
+      extended_slice<count_new_axis<S0, S...>::value>{}((*this), s0, s...))
   {
     return extended_slice<count_new_axis<S0, S...>::value>{}((*this), s0, s...);
   }
 
   template <class T, class pS>
-      template <class S0, class... S>
-      auto ndarray<T, pS>::operator()(S0 const &s0, S const &... s) &&
-      -> decltype(extended_slice<count_new_axis<S0, S...>::value>{}(
-          std::move(*this), s0, s...))
+  template <class S0, class... S>
+  auto ndarray<T, pS>::operator()(S0 const &s0, S const &...s) && -> decltype(
+      extended_slice<count_new_axis<S0, S...>::value>{}(std::move(*this), s0,
+                                                        s...))
   {
     return extended_slice<count_new_axis<S0, S...>::value>{}(std::move(*this),
                                                              s0, s...);
@@ -793,8 +787,7 @@ namespace types
           std::is_same<bool, typename F::dtype>::value && F::value == 1 &&
           !is_pod_array<F>::value,
       numpy_vexpr<ndarray<T, pS>, ndarray<long, pshape<long>>>>::type
-      ndarray<T, pS>::
-      operator[](F const &filter) const
+  ndarray<T, pS>::operator[](F const &filter) const
   {
     return fast(filter);
   }
@@ -818,8 +811,7 @@ namespace types
           std::is_same<bool, typename F::dtype>::value && F::value != 1 &&
           !is_pod_array<F>::value,
       numpy_vexpr<ndarray<T, pshape<long>>, ndarray<long, pshape<long>>>>::type
-      ndarray<T, pS>::
-      operator[](F const &filter) const
+  ndarray<T, pS>::operator[](F const &filter) const
   {
     return fast(filter);
   }
@@ -830,8 +822,8 @@ namespace types
                               !is_array_index<F>::value &&
                               !std::is_same<bool, typename F::dtype>::value &&
                               !is_pod_array<F>::value,
-                          numpy_vexpr<ndarray<T, pS>, F>>::type ndarray<T, pS>::
-  operator[](F const &filter) const
+                          numpy_vexpr<ndarray<T, pS>, F>>::type
+  ndarray<T, pS>::operator[](F const &filter) const
   {
     return {*this, filter};
   }
@@ -850,9 +842,9 @@ namespace types
 
   template <class T, class pS>
   template <class Ty0, class Ty1, class... Tys, class _>
-  auto ndarray<T, pS>::
-  operator[](std::tuple<Ty0, Ty1, Tys...> const &indices) const ->
-      typename std::enable_if<
+  auto
+  ndarray<T, pS>::operator[](std::tuple<Ty0, Ty1, Tys...> const &indices) const
+      -> typename std::enable_if<
           is_numexpr_arg<Ty0>::value,
           decltype(this->_fwdindex(
               indices, utils::make_index_sequence<2 + sizeof...(Tys)>()))>::type
@@ -994,7 +986,7 @@ namespace types
         oss << *e.fbegin();
       return oss.str().length() + 2;
     }
-  }
+  } // namespace impl
 
   template <class T, class pS>
   std::ostream &operator<<(std::ostream &os, ndarray<T, pS> const &e)
@@ -1066,7 +1058,7 @@ namespace types
     data = utils::shared_ref<T>(other.begin(), other.end());
     return *this;
   }
-}
+} // namespace types
 PYTHONIC_NS_END
 
 /* std::get overloads */
@@ -1081,7 +1073,7 @@ namespace std
   {
     return std::forward<E>(a)[I];
   }
-}
+} // namespace std
 
 /* pythran attribute system { */
 #include "pythonic/numpy/transpose.hpp"
@@ -1092,7 +1084,7 @@ namespace builtins
   {
     template <size_t N>
     template <class E, class... S>
-    auto _build_gexpr<N>::operator()(E const &a, S const &... slices)
+    auto _build_gexpr<N>::operator()(E const &a, S const &...slices)
         -> decltype(_build_gexpr<N - 1>{}(a, types::contiguous_slice(),
                                           slices...))
     {
@@ -1101,8 +1093,8 @@ namespace builtins
     }
 
     template <class E, class... S>
-    types::numpy_gexpr<E, types::normalize_t<S>...> _build_gexpr<1>::
-    operator()(E const &a, S const &... slices)
+    types::numpy_gexpr<E, types::normalize_t<S>...>
+    _build_gexpr<1>::operator()(E const &a, S const &...slices)
     {
       return E(a)(slices...);
     }
@@ -1187,7 +1179,7 @@ namespace builtins
       return _build_gexpr<E::value>{}(
           translated, types::slice{1, std::get<E::value - 1>(new_shape), 2});
     }
-  }
+  } // namespace details
 
   template <class E>
   types::array<long, E::value> getattr(types::attr::SHAPE, E const &a)
@@ -1250,8 +1242,9 @@ namespace builtins
   }
 
   template <class T, class pS>
-  auto getattr(types::attr::REAL, types::ndarray<T, pS> const &a) -> decltype(
-      details::_make_real(a, utils::int_<types::is_complex<T>::value>{}))
+  auto getattr(types::attr::REAL, types::ndarray<T, pS> const &a)
+      -> decltype(details::_make_real(
+          a, utils::int_<types::is_complex<T>::value>{}))
   {
     return details::_make_real(a, utils::int_<types::is_complex<T>::value>{});
   }
@@ -1277,8 +1270,9 @@ namespace builtins
   }
 
   template <class T, class pS>
-  auto getattr(types::attr::IMAG, types::ndarray<T, pS> const &a) -> decltype(
-      details::_make_imag(a, utils::int_<types::is_complex<T>::value>{}))
+  auto getattr(types::attr::IMAG, types::ndarray<T, pS> const &a)
+      -> decltype(details::_make_imag(
+          a, utils::int_<types::is_complex<T>::value>{}))
   {
     return details::_make_imag(a, utils::int_<types::is_complex<T>::value>{});
   }
@@ -1309,7 +1303,7 @@ namespace builtins
   {
     return {};
   }
-}
+} // namespace builtins
 PYTHONIC_NS_END
 
 /* } */
@@ -1366,7 +1360,7 @@ struct pyarray_new<npy_intp, N> {
   }
 };
 
-void wrapfree(PyObject *capsule)
+inline void wrapfree(PyObject *capsule)
 {
   void *obj = PyCapsule_GetPointer(capsule, PyCapsule_GetName(capsule));
   free(obj);
@@ -1532,14 +1526,15 @@ namespace impl
   {
   }
 
-  void set_slice(types::contiguous_normalized_slice &cs, long lower, long upper,
-                 long step)
+  inline void set_slice(types::contiguous_normalized_slice &cs, long lower,
+                        long upper, long step)
   {
     cs.lower = lower;
     cs.upper = upper;
     assert(cs.step == step && "consistent steps");
   }
-  void set_slice(types::normalized_slice &s, long lower, long upper, long step)
+  inline void set_slice(types::normalized_slice &s, long lower, long upper,
+                        long step)
   {
     s.lower = lower;
     s.upper = upper;
@@ -1550,14 +1545,12 @@ namespace impl
   void fill_slice(Slice &slice, long const *strides, long const *offsets,
                   S const *dims, utils::int_<N>)
   {
-    set_slice(std::get<std::tuple_size<Slice>::value - N>(slice),
-              *offsets,
-              *offsets + *dims * *strides,
-              *strides);
+    set_slice(std::get<std::tuple_size<Slice>::value - N>(slice), *offsets,
+              *offsets + *dims * *strides, *strides);
     fill_slice<T>(slice, strides + 1, offsets + 1, dims + 1,
                   utils::int_<N - 1>());
   }
-}
+} // namespace impl
 
 template <typename T, class pS>
 bool from_python<types::ndarray<T, pS>>::is_convertible(PyObject *obj)

--- a/pythran/pythonic/types/numpy_expr.hpp
+++ b/pythran/pythonic/types/numpy_expr.hpp
@@ -3,8 +3,8 @@
 
 #include "pythonic/include/types/numpy_expr.hpp"
 
-#include "pythonic/utils/meta.hpp"
 #include "pythonic/types/nditerator.hpp"
+#include "pythonic/utils/meta.hpp"
 
 #include "pythonic/builtins/ValueError.hpp"
 
@@ -16,7 +16,7 @@ namespace types
   namespace details
   {
 
-    long best_of()
+    inline long best_of()
     {
       return 1;
     }
@@ -32,22 +32,22 @@ namespace types
     {
       return best_of(std::get<Is>(args).template shape<I>()...);
     }
-  }
+  } // namespace details
 
   template <class Op, class... Args>
-  numpy_expr<Op, Args...>::numpy_expr(Args const &... args)
-      : args(args...)
+  numpy_expr<Op, Args...>::numpy_expr(Args const &...args) : args(args...)
   {
   }
 
   template <class Op, class... Args>
   template <size_t... I>
   typename numpy_expr<Op, Args...>::const_iterator
-      numpy_expr<Op, Args...>::_begin(utils::index_sequence<I...>) const
+  numpy_expr<Op, Args...>::_begin(utils::index_sequence<I...>) const
   {
-    return {{make_step(size(), std::get<I>(args).template shape<0>())...},
-            const_cast<typename std::decay<Args>::type const &>(
-                std::get<I>(args)).begin()...};
+    return {
+        {make_step(size(), std::get<I>(args).template shape<0>())...},
+        const_cast<typename std::decay<Args>::type const &>(std::get<I>(args))
+            .begin()...};
   }
 
   template <class Op, class... Args>
@@ -60,11 +60,12 @@ namespace types
   template <class Op, class... Args>
   template <size_t... I>
   typename numpy_expr<Op, Args...>::const_iterator
-      numpy_expr<Op, Args...>::_end(utils::index_sequence<I...>) const
+  numpy_expr<Op, Args...>::_end(utils::index_sequence<I...>) const
   {
-    return {{make_step(size(), std::get<I>(args).template shape<0>())...},
-            const_cast<typename std::decay<Args>::type const &>(
-                std::get<I>(args)).end()...};
+    return {
+        {make_step(size(), std::get<I>(args).template shape<0>())...},
+        const_cast<typename std::decay<Args>::type const &>(std::get<I>(args))
+            .end()...};
   }
 
   template <class Op, class... Args>
@@ -76,14 +77,14 @@ namespace types
 
   template <class Op, class... Args>
   typename numpy_expr<Op, Args...>::const_fast_iterator
-      numpy_expr<Op, Args...>::begin(types::fast) const
+  numpy_expr<Op, Args...>::begin(types::fast) const
   {
     return {*this, 0};
   }
 
   template <class Op, class... Args>
   typename numpy_expr<Op, Args...>::const_fast_iterator
-      numpy_expr<Op, Args...>::end(types::fast) const
+  numpy_expr<Op, Args...>::end(types::fast) const
   {
     return {*this, size()};
   }
@@ -107,8 +108,8 @@ namespace types
 
   template <class Op, class... Args>
   template <size_t... I>
-  bool numpy_expr<Op, Args...>::_no_broadcast_ex(
-      utils::index_sequence<I...>) const
+  bool
+  numpy_expr<Op, Args...>::_no_broadcast_ex(utils::index_sequence<I...>) const
   {
     bool child_broadcast = false;
     (void)std::initializer_list<bool>{
@@ -163,7 +164,7 @@ namespace types
   template <class Op, class... Args>
   template <size_t... I>
   typename numpy_expr<Op, Args...>::iterator
-      numpy_expr<Op, Args...>::_begin(utils::index_sequence<I...>)
+  numpy_expr<Op, Args...>::_begin(utils::index_sequence<I...>)
   {
     return {{make_step(size(), std::get<I>(args).template shape<0>())...},
             const_cast<typename std::decay<Args>::type &>(std::get<I>(args))
@@ -179,7 +180,7 @@ namespace types
   template <class Op, class... Args>
   template <size_t... I>
   typename numpy_expr<Op, Args...>::iterator
-      numpy_expr<Op, Args...>::_end(utils::index_sequence<I...>)
+  numpy_expr<Op, Args...>::_end(utils::index_sequence<I...>)
   {
     return {{make_step(size(), std::get<I>(args).template shape<0>())...},
             const_cast<typename std::decay<Args>::type &>(std::get<I>(args))
@@ -201,9 +202,10 @@ namespace types
 
   template <class Op, class... Args>
   template <class... Indices>
-  auto numpy_expr<Op, Args...>::map_fast(Indices... indices) const -> decltype(
-      this->_map_fast(array<long, sizeof...(Indices)>{{indices...}},
-                      utils::make_index_sequence<sizeof...(Args)>{}))
+  auto numpy_expr<Op, Args...>::map_fast(Indices... indices) const
+      -> decltype(this->_map_fast(
+          array<long, sizeof...(Indices)>{{indices...}},
+          utils::make_index_sequence<sizeof...(Args)>{}))
   {
     static_assert(sizeof...(Indices) == sizeof...(Args), "compatible call");
     return _map_fast(array<long, sizeof...(Indices)>{{indices...}},
@@ -223,19 +225,19 @@ namespace types
   template <class Op, class... Args>
   template <size_t... I>
   typename numpy_expr<Op, Args...>::simd_iterator
-      numpy_expr<Op, Args...>::_vbegin(vectorize,
-                                       utils::index_sequence<I...>) const
+  numpy_expr<Op, Args...>::_vbegin(vectorize, utils::index_sequence<I...>) const
   {
-    return {{make_step(size(), std::get<I>(args).template shape<0>())...},
-            std::make_tuple(xsimd::batch<
-                typename std::remove_reference<Args>::type::value_type>(
-                *std::get<I>(args).begin())...),
-            std::get<I>(args).vbegin(vectorize{})...};
+    return {
+        {make_step(size(), std::get<I>(args).template shape<0>())...},
+        std::make_tuple(xsimd::batch<
+                        typename std::remove_reference<Args>::type::value_type>(
+            *std::get<I>(args).begin())...),
+        std::get<I>(args).vbegin(vectorize{})...};
   }
 
   template <class Op, class... Args>
   typename numpy_expr<Op, Args...>::simd_iterator
-      numpy_expr<Op, Args...>::vbegin(vectorize) const
+  numpy_expr<Op, Args...>::vbegin(vectorize) const
   {
     return _vbegin(vectorize{}, utils::make_index_sequence<sizeof...(Args)>{});
   }
@@ -243,8 +245,7 @@ namespace types
   template <class Op, class... Args>
   template <size_t... I>
   typename numpy_expr<Op, Args...>::simd_iterator
-      numpy_expr<Op, Args...>::_vend(vectorize,
-                                     utils::index_sequence<I...>) const
+  numpy_expr<Op, Args...>::_vend(vectorize, utils::index_sequence<I...>) const
   {
     return {{make_step(size(), std::get<I>(args).template shape<0>())...},
             {},
@@ -253,7 +254,7 @@ namespace types
 
   template <class Op, class... Args>
   typename numpy_expr<Op, Args...>::simd_iterator
-      numpy_expr<Op, Args...>::vend(vectorize) const
+  numpy_expr<Op, Args...>::vend(vectorize) const
   {
     return _vend(vectorize{}, utils::make_index_sequence<sizeof...(Args)>{});
   }
@@ -261,15 +262,15 @@ namespace types
   template <class Op, class... Args>
   template <size_t... I>
   typename numpy_expr<Op, Args...>::simd_iterator_nobroadcast
-      numpy_expr<Op, Args...>::_vbegin(vectorize_nobroadcast,
-                                       utils::index_sequence<I...>) const
+  numpy_expr<Op, Args...>::_vbegin(vectorize_nobroadcast,
+                                   utils::index_sequence<I...>) const
   {
     return {std::get<I>(args).vbegin(vectorize_nobroadcast{})...};
   }
 
   template <class Op, class... Args>
   typename numpy_expr<Op, Args...>::simd_iterator_nobroadcast
-      numpy_expr<Op, Args...>::vbegin(vectorize_nobroadcast) const
+  numpy_expr<Op, Args...>::vbegin(vectorize_nobroadcast) const
   {
     return _vbegin(vectorize_nobroadcast{},
                    utils::make_index_sequence<sizeof...(Args)>{});
@@ -278,15 +279,15 @@ namespace types
   template <class Op, class... Args>
   template <size_t... I>
   typename numpy_expr<Op, Args...>::simd_iterator_nobroadcast
-      numpy_expr<Op, Args...>::_vend(vectorize_nobroadcast,
-                                     utils::index_sequence<I...>) const
+  numpy_expr<Op, Args...>::_vend(vectorize_nobroadcast,
+                                 utils::index_sequence<I...>) const
   {
     return {std::get<I>(args).vend(vectorize_nobroadcast{})...};
   }
 
   template <class Op, class... Args>
   typename numpy_expr<Op, Args...>::simd_iterator_nobroadcast
-      numpy_expr<Op, Args...>::vend(vectorize_nobroadcast) const
+  numpy_expr<Op, Args...>::vend(vectorize_nobroadcast) const
   {
     return _vend(vectorize_nobroadcast{},
                  utils::make_index_sequence<sizeof...(Args)>{});
@@ -296,7 +297,7 @@ namespace types
 
   template <class Op, class... Args>
   template <class... S>
-  auto numpy_expr<Op, Args...>::operator()(S const &... s) const
+  auto numpy_expr<Op, Args...>::operator()(S const &...s) const
       -> decltype(this->_get(utils::make_index_sequence<sizeof...(Args)>{},
                              s...))
   {
@@ -331,8 +332,7 @@ namespace types
           std::is_same<bool, typename F::dtype>::value &&
           !is_pod_array<F>::value,
       numpy_vexpr<numpy_expr<Op, Args...>, ndarray<long, pshape<long>>>>::type
-      numpy_expr<Op, Args...>::
-      operator[](F const &filter) const
+  numpy_expr<Op, Args...>::operator[](F const &filter) const
   {
     return fast(filter);
   }
@@ -343,8 +343,7 @@ namespace types
                               !std::is_same<bool, typename F::dtype>::value &&
                               !is_pod_array<F>::value,
                           numpy_vexpr<numpy_expr<Op, Args...>, F>>::type
-      numpy_expr<Op, Args...>::
-      operator[](F const &filter) const
+  numpy_expr<Op, Args...>::operator[](F const &filter) const
   {
     return {*this, filter};
   }
@@ -382,7 +381,7 @@ namespace types
   {
     return this->template shape<0>();
   }
-}
+} // namespace types
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/types/set.hpp
+++ b/pythran/pythonic/types/set.hpp
@@ -13,12 +13,12 @@
 
 #include "pythonic/builtins/in.hpp"
 
-#include <set>
-#include <memory>
-#include <utility>
-#include <limits>
 #include <algorithm>
 #include <iterator>
+#include <limits>
+#include <memory>
+#include <set>
+#include <utility>
 
 PYTHONIC_NS_BEGIN
 
@@ -28,48 +28,41 @@ namespace types
   /// set implementation
   // constructors
   template <class T>
-  set<T>::set()
-      : data(utils::no_memory())
+  set<T>::set() : data(utils::no_memory())
   {
   }
 
   template <class T>
   template <class InputIterator>
-  set<T>::set(InputIterator start, InputIterator stop)
-      : data()
+  set<T>::set(InputIterator start, InputIterator stop) : data()
   {
     std::copy(start, stop, std::back_inserter(*this));
   }
 
   template <class T>
-  set<T>::set(empty_set const &)
-      : data()
+  set<T>::set(empty_set const &) : data()
   {
   }
 
   template <class T>
-  set<T>::set(T const &value, single_value)
-      : data()
+  set<T>::set(T const &value, single_value) : data()
   {
     data->insert(value);
   }
 
   template <class T>
-  set<T>::set(std::initializer_list<value_type> l)
-      : data(std::move(l))
+  set<T>::set(std::initializer_list<value_type> l) : data(std::move(l))
   {
   }
 
   template <class T>
-  set<T>::set(set<T> const &other)
-      : data(other.data)
+  set<T>::set(set<T> const &other) : data(other.data)
   {
   }
 
   template <class T>
   template <class F>
-  set<T>::set(set<F> const &other)
-      : data()
+  set<T>::set(set<F> const &other) : data()
   {
     std::copy(other.begin(), other.end(), std::inserter(*data, data->begin()));
   }
@@ -234,7 +227,7 @@ namespace types
   template <class T>
   template <typename U, typename... Types>
   typename __combined<set<T>, U, Types...>::type
-  set<T>::union_(U &&other, Types &&... others) const
+  set<T>::union_(U &&other, Types &&...others) const
   {
     typename __combined<set<T>, U, Types...>::type tmp =
         union_(std::forward<Types...>(others)...);
@@ -244,7 +237,7 @@ namespace types
 
   template <class T>
   template <typename... Types>
-  none_type set<T>::update(Types &&... others)
+  none_type set<T>::update(Types &&...others)
   {
     *this = union_(std::forward<Types>(others)...);
     return {};
@@ -259,7 +252,7 @@ namespace types
   template <class T>
   template <typename U, typename... Types>
   typename __combined<set<T>, U, Types...>::type
-  set<T>::intersection(U const &other, Types const &... others) const
+  set<T>::intersection(U const &other, Types const &...others) const
   {
     // Return a new set with elements common to the set && all others.
     typename __combined<set<T>, U, Types...>::type tmp =
@@ -274,7 +267,7 @@ namespace types
 
   template <class T>
   template <typename... Types>
-  void set<T>::intersection_update(Types const &... others)
+  void set<T>::intersection_update(Types const &...others)
   {
     *this = intersection(others...);
   }
@@ -287,7 +280,7 @@ namespace types
 
   template <class T>
   template <typename U, typename... Types>
-  set<T> set<T>::difference(U const &other, Types const &... others) const
+  set<T> set<T>::difference(U const &other, Types const &...others) const
   {
     // Return a new set with elements in the set that are ! in the others.
     set<T> tmp = difference(others...);
@@ -314,7 +307,7 @@ namespace types
 
   template <class T>
   template <typename... Types>
-  void set<T>::difference_update(Types const &... others)
+  void set<T>::difference_update(Types const &...others)
   {
     *this = difference(others...);
   }
@@ -395,8 +388,8 @@ namespace types
 
   template <class T>
   template <class U>
-  set<typename __combined<T, U>::type> set<T>::
-  operator|(set<U> const &other) const
+  set<typename __combined<T, U>::type>
+  set<T>::operator|(set<U> const &other) const
   {
     return union_(other);
   }
@@ -410,8 +403,8 @@ namespace types
 
   template <class T>
   template <class U>
-  set<typename __combined<U, T>::type> set<T>::
-  operator&(set<U> const &other) const
+  set<typename __combined<U, T>::type>
+  set<T>::operator&(set<U> const &other) const
   {
     return intersection(other);
   }
@@ -439,8 +432,8 @@ namespace types
 
   template <class T>
   template <class U>
-  set<typename __combined<U, T>::type> set<T>::
-  operator^(set<U> const &other) const
+  set<typename __combined<U, T>::type>
+  set<T>::operator^(set<U> const &other) const
   {
     return symmetric_difference(other);
   }
@@ -475,7 +468,7 @@ namespace types
 
   /// empty_set implementation
 
-  empty_set empty_set::operator|(empty_set const &)
+  inline empty_set empty_set::operator|(empty_set const &)
   {
     return empty_set();
   }
@@ -498,10 +491,16 @@ namespace types
     return {};
   }
 
-  empty_set empty_set::operator^(empty_set const &) { return empty_set(); }
+  inline empty_set empty_set::operator^(empty_set const &)
+  {
+    return empty_set();
+  }
 
   template <class T>
-  set<T> empty_set::operator^(set<T> const &s) { return s; }
+  set<T> empty_set::operator^(set<T> const &s)
+  {
+    return s;
+  }
 
   template <class... Types>
   none_type empty_set::update(Types &&...)
@@ -509,17 +508,17 @@ namespace types
     return {};
   }
 
-  empty_set::operator bool()
+  inline empty_set::operator bool()
   {
     return false;
   }
 
-  empty_set::iterator empty_set::begin() const
+  inline empty_set::iterator empty_set::begin() const
   {
     return empty_iterator();
   }
 
-  empty_set::iterator empty_set::end() const
+  inline empty_set::iterator empty_set::end() const
   {
     return empty_iterator();
   }
@@ -529,7 +528,7 @@ namespace types
   {
     return false;
   }
-}
+} // namespace types
 PYTHONIC_NS_END
 #ifdef ENABLE_PYTHON_MODULE
 
@@ -544,7 +543,7 @@ PyObject *to_python<types::set<T>>::convert(types::set<T> const &v)
   return obj;
 }
 
-PyObject *to_python<types::empty_set>::convert(types::empty_set)
+inline PyObject *to_python<types::empty_set>::convert(types::empty_set)
 {
   return PySet_New(nullptr);
 }

--- a/pythran/pythonic/types/slice.hpp
+++ b/pythran/pythonic/types/slice.hpp
@@ -6,10 +6,10 @@
 
 #include "pythonic/builtins/None.hpp"
 
-#include <cassert>
-#include <stdexcept>
-#include <ostream>
 #include <algorithm>
+#include <cassert>
+#include <ostream>
+#include <stdexcept>
 
 PYTHONIC_NS_BEGIN
 
@@ -21,66 +21,66 @@ namespace types
   namespace details
   {
 
-    long roundup_divide(long a, long b)
+    inline long roundup_divide(long a, long b)
     {
       if (b > 0)
         return (a + b - 1) / b;
       else
         return (a + b + 1) / b;
     }
-  }
+  } // namespace details
 
-  normalized_slice::normalized_slice()
+  inline normalized_slice::normalized_slice()
   {
   }
-  normalized_slice::normalized_slice(long lower, long upper, long step)
+  inline normalized_slice::normalized_slice(long lower, long upper, long step)
       : lower(lower), upper(upper), step(step)
   {
   }
 
-  normalized_slice normalized_slice::
-  operator*(normalized_slice const &other) const
+  inline normalized_slice
+  normalized_slice::operator*(normalized_slice const &other) const
   {
     return {lower + step * other.lower, lower + step * other.upper,
             step * other.step};
   }
-  normalized_slice normalized_slice::
-  operator*(contiguous_normalized_slice const &other) const
+  inline normalized_slice
+  normalized_slice::operator*(contiguous_normalized_slice const &other) const
   {
     return {lower + step * other.lower, lower + step * other.upper,
             step * other.step};
   }
-  normalized_slice normalized_slice::operator*(slice const &other) const
+  inline normalized_slice normalized_slice::operator*(slice const &other) const
   {
     return (*this) * other.normalize(size());
   }
-  normalized_slice normalized_slice::
-  operator*(contiguous_slice const &other) const
+  inline normalized_slice
+  normalized_slice::operator*(contiguous_slice const &other) const
   {
     return (*this) * other.normalize(size());
   }
 
-  long normalized_slice::size() const
+  inline long normalized_slice::size() const
   {
     return std::max(0L, details::roundup_divide(upper - lower, step));
   }
 
-  long normalized_slice::get(long i) const
+  inline long normalized_slice::get(long i) const
   {
     return lower + i * step;
   }
 
-  slice::slice(none<long> lower, none<long> upper, none<long> step)
+  inline slice::slice(none<long> lower, none<long> upper, none<long> step)
       : lower(lower), upper(upper), step(step)
   {
   }
 
-  slice::slice()
+  inline slice::slice()
       : lower(builtins::None), upper(builtins::None), step(builtins::None)
   {
   }
 
-  slice slice::operator*(slice const &other) const
+  inline slice slice::operator*(slice const &other) const
   {
     // We do not implement these because it requires to know the "end"
     // value of the slice which is ! possible if it is ! "step == 1" slice
@@ -154,7 +154,7 @@ namespace types
      It also check for value bigger than len(a) to fit the size of the
      container
      */
-  normalized_slice slice::normalize(long max_size) const
+  inline normalized_slice slice::normalize(long max_size) const
   {
     long sstep = step.is_none() ? 1 : (long)step;
     long normalized_upper;
@@ -191,7 +191,7 @@ namespace types
    * An assert is raised when we can't compute the size without more
    * informations.
    */
-  long slice::size() const
+  inline long slice::size() const
   {
     long sstep = step.is_none() ? 1 : (long)step;
     assert(!(upper.is_none() && lower.is_none()));
@@ -209,55 +209,55 @@ namespace types
     return std::max(0L, details::roundup_divide(len, sstep));
   }
 
-  long slice::get(long i) const
+  inline long slice::get(long i) const
   {
     long sstep = step.is_none() ? 1 : (long)step;
     assert(!upper.is_none() && !lower.is_none());
     return (long)lower + i * sstep;
   }
 
-  contiguous_normalized_slice::contiguous_normalized_slice()
+  inline contiguous_normalized_slice::contiguous_normalized_slice()
   {
   }
 
-  contiguous_normalized_slice::contiguous_normalized_slice(long lower,
-                                                           long upper)
+  inline contiguous_normalized_slice::contiguous_normalized_slice(long lower,
+                                                                  long upper)
       : lower(lower), upper(upper)
   {
   }
 
-  contiguous_normalized_slice contiguous_normalized_slice::
-  operator*(contiguous_normalized_slice const &other) const
+  inline contiguous_normalized_slice contiguous_normalized_slice::operator*(
+      contiguous_normalized_slice const &other) const
   {
     return contiguous_normalized_slice(lower + other.lower,
                                        lower + other.upper);
   }
-  contiguous_normalized_slice contiguous_normalized_slice::
-  operator*(contiguous_slice const &other) const
+  inline contiguous_normalized_slice
+  contiguous_normalized_slice::operator*(contiguous_slice const &other) const
   {
     return (*this) * other.normalize(size());
   }
 
-  contiguous_normalized_slice contiguous_normalized_slice::
-  operator*(fast_contiguous_slice const &other) const
+  inline contiguous_normalized_slice contiguous_normalized_slice::operator*(
+      fast_contiguous_slice const &other) const
   {
     return (*this) * other.normalize(size());
   }
 
-  normalized_slice contiguous_normalized_slice::
-  operator*(normalized_slice const &other) const
+  inline normalized_slice
+  contiguous_normalized_slice::operator*(normalized_slice const &other) const
   {
     return normalized_slice(lower + step * other.lower,
                             lower + step * other.upper, step * other.step);
   }
 
-  normalized_slice contiguous_normalized_slice::
-  operator*(slice const &other) const
+  inline normalized_slice
+  contiguous_normalized_slice::operator*(slice const &other) const
   {
     return (*this) * other.normalize(size());
   }
 
-  long contiguous_normalized_slice::size() const
+  inline long contiguous_normalized_slice::size() const
   {
     return std::max(0L, upper - lower);
   }
@@ -267,13 +267,13 @@ namespace types
     return lower + i;
   }
 
-  contiguous_slice::contiguous_slice(none<long> lower, none<long> upper)
+  inline contiguous_slice::contiguous_slice(none<long> lower, none<long> upper)
       : lower(lower.is_none ? 0 : (long)lower), upper(upper)
   {
   }
 
-  contiguous_slice contiguous_slice::
-  operator*(contiguous_slice const &other) const
+  inline contiguous_slice
+  contiguous_slice::operator*(contiguous_slice const &other) const
   {
     long new_lower;
     if (other.lower < 0)
@@ -295,7 +295,7 @@ namespace types
     return {new_lower, new_upper};
   }
 
-  slice contiguous_slice::operator*(slice const &other) const
+  inline slice contiguous_slice::operator*(slice const &other) const
   {
     none<long> new_lower;
     if (other.lower.is_none() || (long)other.lower == 0) {
@@ -341,7 +341,8 @@ namespace types
      It also check for value bigger than len(a) to fit the size of the
      container
      */
-  contiguous_normalized_slice contiguous_slice::normalize(long max_size) const
+  inline contiguous_normalized_slice
+  contiguous_slice::normalize(long max_size) const
   {
     long normalized_upper;
     if (upper.is_none())
@@ -364,7 +365,7 @@ namespace types
     return contiguous_normalized_slice(normalized_lower, normalized_upper);
   }
 
-  long contiguous_slice::size() const
+  inline long contiguous_slice::size() const
   {
     long len;
     if (upper.is_none()) {
@@ -375,19 +376,19 @@ namespace types
     return std::max(0L, len);
   }
 
-  long contiguous_slice::get(long i) const
+  inline long contiguous_slice::get(long i) const
   {
     return int(lower) + i;
   }
 
-  fast_contiguous_slice::fast_contiguous_slice(none<long> lower,
-                                               none<long> upper)
+  inline fast_contiguous_slice::fast_contiguous_slice(none<long> lower,
+                                                      none<long> upper)
       : lower(lower.is_none ? 0 : (long)lower), upper(upper)
   {
   }
 
-  fast_contiguous_slice fast_contiguous_slice::
-  operator*(fast_contiguous_slice const &other) const
+  inline fast_contiguous_slice
+  fast_contiguous_slice::operator*(fast_contiguous_slice const &other) const
   {
     long new_lower = lower + other.lower * step;
 
@@ -399,8 +400,8 @@ namespace types
 
     return {new_lower, new_upper};
   }
-  contiguous_slice fast_contiguous_slice::
-  operator*(contiguous_slice const &other) const
+  inline contiguous_slice
+  fast_contiguous_slice::operator*(contiguous_slice const &other) const
   {
     long new_lower;
     if (other.lower < 0)
@@ -422,7 +423,7 @@ namespace types
     return {new_lower, new_upper};
   }
 
-  slice fast_contiguous_slice::operator*(slice const &other) const
+  inline slice fast_contiguous_slice::operator*(slice const &other) const
   {
     none<long> new_lower;
     if (other.lower.is_none() || (long)other.lower == 0) {
@@ -468,7 +469,7 @@ namespace types
      It also check for value bigger than len(a) to fit the size of the
      container
      */
-  contiguous_normalized_slice
+  inline contiguous_normalized_slice
   fast_contiguous_slice::normalize(long max_size) const
   {
     long normalized_upper;
@@ -488,13 +489,13 @@ namespace types
     return {normalized_lower, normalized_upper};
   }
 
-  long fast_contiguous_slice::size() const
+  inline long fast_contiguous_slice::size() const
   {
     assert(!upper.is_none());
     return std::max(0L, upper - lower);
   }
 
-  slice slice::operator*(contiguous_slice const &other) const
+  inline slice slice::operator*(contiguous_slice const &other) const
   {
     // We do ! implement these because it requires to know the "end"
     // value of the slice which is ! possible if it is ! "step == 1" slice
@@ -547,7 +548,7 @@ namespace types
     return os << "slice(" << s.lower << ", " << s.upper << ", " << s.step
               << ")";
   }
-}
+} // namespace types
 PYTHONIC_NS_END
 
 #ifdef ENABLE_PYTHON_MODULE
@@ -562,21 +563,21 @@ PyObject *to_python<types::bound<T>>::convert(types::bound<T> const &b)
     return ::to_python((T)b);
 }
 
-PyObject *to_python<types::contiguous_normalized_slice>::convert(
+inline PyObject *to_python<types::contiguous_normalized_slice>::convert(
     types::contiguous_normalized_slice const &v)
 {
   return PySlice_New(::to_python(v.lower), ::to_python(v.upper),
                      ::to_python(types::none_type{}));
 }
 
-PyObject *
+inline PyObject *
 to_python<types::contiguous_slice>::convert(types::contiguous_slice const &v)
 {
   return PySlice_New(::to_python(v.lower), ::to_python(v.upper),
                      ::to_python(types::none_type{}));
 }
 
-PyObject *
+inline PyObject *
 to_python<types::normalized_slice>::convert(types::normalized_slice const &v)
 {
   if (v.step > 0) {
@@ -590,7 +591,7 @@ to_python<types::normalized_slice>::convert(types::normalized_slice const &v)
   }
 }
 
-PyObject *to_python<types::slice>::convert(types::slice const &v)
+inline PyObject *to_python<types::slice>::convert(types::slice const &v)
 {
   if (v.step > 0) {
     return PySlice_New(::to_python(v.lower), ::to_python(v.upper),
@@ -603,12 +604,12 @@ PyObject *to_python<types::slice>::convert(types::slice const &v)
   }
 }
 
-bool from_python<types::slice>::is_convertible(PyObject *obj)
+inline bool from_python<types::slice>::is_convertible(PyObject *obj)
 {
   return PySlice_Check(obj);
 }
 
-types::slice from_python<types::slice>::convert(PyObject *obj)
+inline types::slice from_python<types::slice>::convert(PyObject *obj)
 {
   Py_ssize_t start, stop, step;
 #if PY_MAJOR_VERSION > 3 || (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION > 6) || \

--- a/pythran/pythonic/types/str.hpp
+++ b/pythran/pythonic/types/str.hpp
@@ -6,71 +6,72 @@
 #include "pythonic/types/tuple.hpp"
 
 #include "pythonic/types/assignable.hpp"
-#include "pythonic/utils/shared_ref.hpp"
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/int_.hpp"
+#include "pythonic/utils/shared_ref.hpp"
 
 #include <cassert>
-#include <string>
 #include <cstring>
 #include <sstream>
 #include <stdexcept>
+#include <string>
 
 PYTHONIC_NS_BEGIN
 
 namespace types
 {
 
-  chr::operator str() const
+  inline chr::operator str() const
   {
     return str(c);
   }
 
   /// const_sliced_str_iterator implementation
-  const_sliced_str_iterator::const_sliced_str_iterator(char const *data,
-                                                       long step)
+  inline const_sliced_str_iterator::const_sliced_str_iterator(char const *data,
+                                                              long step)
       : data(data), step(step)
   {
   }
 
-  const_sliced_str_iterator const_sliced_str_iterator::operator++()
+  inline const_sliced_str_iterator const_sliced_str_iterator::operator++()
   {
     data += step;
     return *this;
   }
 
-  bool const_sliced_str_iterator::
-  operator<(const_sliced_str_iterator const &other) const
+  inline bool const_sliced_str_iterator::operator<(
+      const_sliced_str_iterator const &other) const
   {
     return (step > 0) ? (data < other.data) : (data > other.data);
   }
 
-  bool const_sliced_str_iterator::
-  operator==(const_sliced_str_iterator const &other) const
+  inline bool const_sliced_str_iterator::operator==(
+      const_sliced_str_iterator const &other) const
   {
     return data == other.data;
   }
 
-  bool const_sliced_str_iterator::
-  operator!=(const_sliced_str_iterator const &other) const
+  inline bool const_sliced_str_iterator::operator!=(
+      const_sliced_str_iterator const &other) const
   {
     return data != other.data;
   }
 
-  chr const_sliced_str_iterator::operator*() const
+  inline chr const_sliced_str_iterator::operator*() const
   {
     return (*data);
   }
 
-  const_sliced_str_iterator const_sliced_str_iterator::operator-(long n) const
+  inline const_sliced_str_iterator
+  const_sliced_str_iterator::operator-(long n) const
   {
     const_sliced_str_iterator other(*this);
     other.data -= step * n;
     return other;
   }
 
-  long const_sliced_str_iterator::
-  operator-(const_sliced_str_iterator const &other) const
+  inline long const_sliced_str_iterator::operator-(
+      const_sliced_str_iterator const &other) const
   {
     return (data - other.data) / step;
   }
@@ -78,8 +79,7 @@ namespace types
   /// sliced_str implementation
   // constructor
   template <class S>
-  sliced_str<S>::sliced_str()
-      : data(utils::no_memory())
+  sliced_str<S>::sliced_str() : data(utils::no_memory())
   {
   }
 
@@ -157,8 +157,7 @@ namespace types
   template <class S>
   template <class Sp>
   typename std::enable_if<is_slice<Sp>::value, sliced_str<Sp>>::type
-      sliced_str<S>::
-      operator[](Sp const &s) const
+  sliced_str<S>::operator[](Sp const &s) const
   {
     return {*this, s.normalize(size())};
   }
@@ -217,7 +216,7 @@ namespace types
   }
 
   // io
-  std::ostream &operator<<(std::ostream &os, types::chr const &v)
+  inline std::ostream &operator<<(std::ostream &os, types::chr const &v)
   {
     return os << v.c;
   }
@@ -263,39 +262,37 @@ namespace types
   }
 
   /// str implementation
-  str::str() : data()
+  inline str::str() : data()
   {
   }
 
-  str::str(std::string const &s) : data(s)
+  inline str::str(std::string const &s) : data(s)
   {
   }
 
-  str::str(std::string &&s) : data(std::move(s))
+  inline str::str(std::string &&s) : data(std::move(s))
   {
   }
 
-  str::str(const char *s) : data(s)
+  inline str::str(const char *s) : data(s)
   {
   }
 
   template <size_t N>
-  str::str(const char(&s)[N])
-      : data(s)
+  str::str(const char (&s)[N]) : data(s)
   {
   }
 
-  str::str(const char *s, size_t n) : data(s, n)
+  inline str::str(const char *s, size_t n) : data(s, n)
   {
   }
 
-  str::str(char c) : data(1, c)
+  inline str::str(char c) : data(1, c)
   {
   }
 
   template <class S>
-  str::str(sliced_str<S> const &other)
-      : data(other.size(), 0)
+  str::str(sliced_str<S> const &other) : data(other.size(), 0)
   {
     auto iter = chars().begin();
     for (auto &&s : other)
@@ -303,8 +300,7 @@ namespace types
   }
 
   template <class T>
-  str::str(T const &begin, T const &end)
-      : data(begin, end)
+  str::str(T const &begin, T const &end) : data(begin, end)
   {
   }
 
@@ -316,13 +312,13 @@ namespace types
     *data = oss.str();
   }
 
-  str::operator char() const
+  inline str::operator char() const
   {
     assert(size() == 1);
     return (*data)[0];
   }
 
-  str::operator long int() const
+  inline str::operator long int() const
   { // Allows implicit conversion without loosing bool conversion
     char *endptr;
     auto dat = data->data();
@@ -335,7 +331,7 @@ namespace types
     return res;
   }
 
-  str::operator float() const
+  inline str::operator float() const
   {
     char *endptr;
     auto dat = data->data();
@@ -348,7 +344,7 @@ namespace types
     return res;
   }
 
-  str::operator double() const
+  inline str::operator double() const
   {
     char *endptr;
     auto dat = data->data();
@@ -381,106 +377,106 @@ namespace types
     return *this;
   }
 
-  str &str::operator+=(str const &s)
+  inline str &str::operator+=(str const &s)
   {
     *data += *s.data;
     return *this;
   }
-  str &str::operator+=(chr const &s)
+  inline str &str::operator+=(chr const &s)
   {
     *data += s.c;
     return *this;
   }
 
-  long str::size() const
+  inline long str::size() const
   {
     return data->size();
   }
 
-  typename str::iterator str::begin() const
+  inline typename str::iterator str::begin() const
   {
     return {data->begin()};
   }
 
-  typename str::reverse_iterator str::rbegin() const
+  inline typename str::reverse_iterator str::rbegin() const
   {
     string_iterator iter(data->end());
     return typename str::reverse_iterator(iter);
   }
 
-  typename str::iterator str::end() const
+  inline typename str::iterator str::end() const
   {
     return {data->end()};
   }
 
-  typename str::reverse_iterator str::rend() const
+  inline typename str::reverse_iterator str::rend() const
   {
     string_iterator iter(data->begin());
     return typename str::reverse_iterator(iter);
   }
 
-  auto str::c_str() const -> decltype(data->c_str())
+  inline auto str::c_str() const -> decltype(data->c_str())
   {
     return data->c_str();
   }
 
-  auto str::resize(long n) -> decltype(data->resize(n))
+  inline auto str::resize(long n) -> decltype(data->resize(n))
   {
     return data->resize(n);
   }
 
-  long str::find(str const &s, size_t pos) const
+  inline long str::find(str const &s, size_t pos) const
   {
     const char *res = strstr(c_str() + pos, s.c_str());
     return res ? res - c_str() : -1;
   }
 
-  bool str::contains(str const &v) const
+  inline bool str::contains(str const &v) const
   {
     return find(v) != -1;
   }
 
-  long str::find_first_of(str const &s, size_t pos) const
+  inline long str::find_first_of(str const &s, size_t pos) const
   {
     return data->find_first_of(*s.data, pos);
   }
 
-  long str::find_first_of(const char *s, size_t pos) const
+  inline long str::find_first_of(const char *s, size_t pos) const
   {
     return data->find_first_of(s, pos);
   }
 
-  long str::find_first_not_of(str const &s, size_t pos) const
+  inline long str::find_first_not_of(str const &s, size_t pos) const
   {
     return data->find_first_not_of(*s.data, pos);
   }
 
-  long str::find_last_not_of(str const &s, size_t pos) const
+  inline long str::find_last_not_of(str const &s, size_t pos) const
   {
     return data->find_last_not_of(*s.data, pos);
   }
 
-  str str::substr(size_t pos, size_t len) const
+  inline str str::substr(size_t pos, size_t len) const
   {
     return data->substr(pos, len);
   }
 
-  bool str::empty() const
+  inline bool str::empty() const
   {
     return data->empty();
   }
 
-  int str::compare(size_t pos, size_t len, str const &str) const
+  inline int str::compare(size_t pos, size_t len, str const &str) const
   {
     return data->compare(pos, len, *str.data);
   }
 
-  void str::reserve(size_t n)
+  inline void str::reserve(size_t n)
   {
     data->reserve(n);
   }
 
-  str &str::replace(size_t pos, size_t len, str const &str)
+  inline str &str::replace(size_t pos, size_t len, str const &str)
   {
     data->replace(pos, len, *str.data);
     return *this;
@@ -494,38 +490,38 @@ namespace types
     return *this;
   }
 
-  bool str::operator==(str const &other) const
+  inline bool str::operator==(str const &other) const
   {
     return *data == *other.data;
   }
 
-  bool str::operator!=(str const &other) const
+  inline bool str::operator!=(str const &other) const
   {
     return *data != *other.data;
   }
 
-  bool str::operator<=(str const &other) const
+  inline bool str::operator<=(str const &other) const
   {
     return *data <= *other.data;
   }
 
-  bool str::operator<(str const &other) const
+  inline bool str::operator<(str const &other) const
   {
     return *data < *other.data;
   }
 
-  bool str::operator>=(str const &other) const
+  inline bool str::operator>=(str const &other) const
   {
     return *data >= *other.data;
   }
 
-  bool str::operator>(str const &other) const
+  inline bool str::operator>(str const &other) const
   {
     return *data > *other.data;
   }
 
   template <class S>
-  bool str::operator==(sliced_str<S> const &other) const
+  inline bool str::operator==(sliced_str<S> const &other) const
   {
     if (size() != other.size())
       return false;
@@ -535,43 +531,43 @@ namespace types
         return false;
     return true;
   }
-  bool str::operator==(chr other) const
+  inline bool str::operator==(chr other) const
   {
     return size() == 1 && (*data)[0] == other.c;
   }
 
   template <class S>
-  typename std::enable_if<is_slice<S>::value, sliced_str<S>>::type str::
-  operator()(S const &s) const
+  typename std::enable_if<is_slice<S>::value, sliced_str<S>>::type
+  str::operator()(S const &s) const
   {
     return operator[](s);
   }
 
-  chr str::operator[](long i) const
+  inline chr str::operator[](long i) const
   {
     if (i < 0)
       i += size();
     return fast(i);
   }
 
-  chr str::fast(long i) const
+  inline chr str::fast(long i) const
   {
     return (*data)[i];
   }
 
   template <class S>
-  typename std::enable_if<is_slice<S>::value, sliced_str<S>>::type str::
-  operator[](S const &s) const
+  typename std::enable_if<is_slice<S>::value, sliced_str<S>>::type
+  str::operator[](S const &s) const
   {
     return {*this, s.normalize(size())};
   }
 
-  str::operator bool() const
+  inline str::operator bool() const
   {
     return !data->empty();
   }
 
-  long str::count(types::str const &sub) const
+  inline long str::count(types::str const &sub) const
   {
     long counter = 0;
     for (long z = find(sub);            // begin by looking for sub
@@ -583,26 +579,26 @@ namespace types
     return counter;
   }
 
-  str operator+(str const &self, str const &other)
+  inline str operator+(str const &self, str const &other)
   {
     return str(self.chars() + other.chars());
   }
-  str operator+(chr const &self, chr const &other)
+  inline str operator+(chr const &self, chr const &other)
   {
     char tmp[2] = {self.c, other.c};
     return str(&tmp[0], 2);
   }
-  str operator+(chr const &self, str const &other)
+  inline str operator+(chr const &self, str const &other)
   {
     return str(self.c + other.chars());
   }
-  str operator+(str const &self, chr const &other)
+  inline str operator+(str const &self, chr const &other)
   {
     return str(self.chars() + other.c);
   }
 
   template <size_t N>
-  str operator+(str const &self, char const(&other)[N])
+  str operator+(str const &self, char const (&other)[N])
   {
     std::string s;
     s.reserve(self.size() + N);
@@ -611,7 +607,7 @@ namespace types
     return {std::move(s)};
   }
   template <size_t N>
-  str operator+(chr const &self, char const(&other)[N])
+  str operator+(chr const &self, char const (&other)[N])
   {
     std::string s;
     s.reserve(1 + N);
@@ -621,7 +617,7 @@ namespace types
   }
 
   template <size_t N>
-  str operator+(char const(&self)[N], str const &other)
+  str operator+(char const (&self)[N], str const &other)
   {
     std::string s;
     s.reserve(other.size() + N);
@@ -631,7 +627,7 @@ namespace types
   }
 
   template <size_t N>
-  str operator+(char const(&self)[N], chr const &other)
+  str operator+(char const (&self)[N], chr const &other)
   {
     std::string s;
     s.reserve(1 + N);
@@ -641,22 +637,22 @@ namespace types
   }
 
   template <size_t N>
-  bool operator==(char const(&self)[N], str const &other)
+  bool operator==(char const (&self)[N], str const &other)
   {
     return other == self;
   }
 
-  bool operator==(chr self, str const &other)
+  inline bool operator==(chr self, str const &other)
   {
     return other == self;
   }
 
-  std::ostream &operator<<(std::ostream &os, str const &s)
+  inline std::ostream &operator<<(std::ostream &os, str const &s)
   {
     return os << s.c_str();
   }
 
-  str operator*(str const &s, long n)
+  inline str operator*(str const &s, long n)
   {
     if (n <= 0)
       return str();
@@ -668,12 +664,12 @@ namespace types
     return other;
   }
 
-  str operator*(long t, str const &s)
+  inline str operator*(long t, str const &s)
   {
     return s * t;
   }
 
-  str operator*(chr const &s, long n)
+  inline str operator*(chr const &s, long n)
   {
     if (n <= 0)
       return str();
@@ -683,52 +679,52 @@ namespace types
     return other;
   }
 
-  str operator*(long t, chr const &c)
+  inline str operator*(long t, chr const &c)
   {
     return c * t;
   }
-}
+} // namespace types
 
 namespace operator_
 {
 
   template <size_t N, class Arg>
-  auto mod(const char(&fmt)[N], Arg &&arg)
+  auto mod(const char (&fmt)[N], Arg &&arg)
       -> decltype(types::str(fmt) % std::forward<Arg>(arg))
   {
     return types::str(fmt) % std::forward<Arg>(arg);
   }
 
-  pythonic::types::str add(char const *self, char const *other)
+  inline pythonic::types::str add(char const *self, char const *other)
   {
     pythonic::types::str res{self};
     res += other;
     return res;
   }
 
-  pythonic::types::str mul(long self, char const *other)
+  inline pythonic::types::str mul(long self, char const *other)
   {
     return pythonic::types::str{other} * self;
   }
 
-  pythonic::types::str mul(char const *self, long other)
+  inline pythonic::types::str mul(char const *self, long other)
   {
     return pythonic::types::str{self} * other;
   }
-}
+} // namespace operator_
 PYTHONIC_NS_END
 
 namespace std
 {
 
-  size_t hash<pythonic::types::str>::
-  operator()(const pythonic::types::str &x) const
+  inline size_t
+  hash<pythonic::types::str>::operator()(const pythonic::types::str &x) const
   {
     return hash<std::string>()(x.chars());
   }
 
-  size_t hash<pythonic::types::chr>::
-  operator()(const pythonic::types::chr &x) const
+  inline size_t
+  hash<pythonic::types::chr>::operator()(const pythonic::types::chr &x) const
   {
     return x.c;
   }
@@ -738,7 +734,7 @@ namespace std
   {
     return pythonic::types::str(t[I]);
   }
-}
+} // namespace std
 #ifdef ENABLE_PYTHON_MODULE
 
 #ifndef PyString_FromStringAndSize
@@ -748,7 +744,7 @@ namespace std
 #define PyString_Check(x) PyUnicode_Check(x) && PyUnicode_IS_COMPACT_ASCII(x)
 #endif
 #ifndef PyString_AS_STRING
-#define PyString_AS_STRING (char *) _PyUnicode_COMPACT_DATA
+#define PyString_AS_STRING (char *)_PyUnicode_COMPACT_DATA
 #endif
 #ifndef PyString_GET_SIZE
 #define PyString_GET_SIZE PyUnicode_GET_LENGTH
@@ -757,12 +753,12 @@ namespace std
 
 PYTHONIC_NS_BEGIN
 
-PyObject *to_python<types::str>::convert(types::str const &v)
+inline PyObject *to_python<types::str>::convert(types::str const &v)
 {
   return PyString_FromStringAndSize(v.c_str(), v.size());
 }
 
-PyObject *to_python<types::chr>::convert(types::chr const &v)
+inline PyObject *to_python<types::chr>::convert(types::chr const &v)
 {
   return PyString_FromStringAndSize(&v.c, 1);
 }
@@ -774,11 +770,11 @@ to_python<types::sliced_str<S>>::convert(types::sliced_str<S> const &v)
   return ::to_python(types::str(v));
 }
 
-bool from_python<types::str>::is_convertible(PyObject *obj)
+inline bool from_python<types::str>::is_convertible(PyObject *obj)
 {
   return PyString_Check(obj);
 }
-types::str from_python<types::str>::convert(PyObject *obj)
+inline types::str from_python<types::str>::convert(PyObject *obj)
 {
   return {PyString_AS_STRING(obj), (size_t)PyString_GET_SIZE(obj)};
 }

--- a/pythran/pythonic/utils/yield.hpp
+++ b/pythran/pythonic/utils/yield.hpp
@@ -10,16 +10,16 @@
 #include "pythonic/types/generator.hpp"
 
 PYTHONIC_NS_BEGIN
-yielder::yielder() : __generator_state(0)
+inline yielder::yielder() : __generator_state(0)
 {
 }
 
-bool yielder::operator!=(yielder const &other) const
+inline bool yielder::operator!=(yielder const &other) const
 {
   return __generator_state != other.__generator_state;
 }
 
-bool yielder::operator==(yielder const &other) const
+inline bool yielder::operator==(yielder const &other) const
 {
   return __generator_state == other.__generator_state;
 }

--- a/pythran/transformations/expand_builtins.py
+++ b/pythran/transformations/expand_builtins.py
@@ -27,10 +27,6 @@ class ExpandBuiltins(Transformation):
     def __init__(self):
         Transformation.__init__(self, Locals, Globals)
 
-    def visit_NameConstant(self, node):
-        self.update = True
-        return ast.Constant(node.value, None)
-
     def visit_Name(self, node):
         s = node.id
         if s in ('None', 'True', 'False'):


### PR DESCRIPTION
And some others in the process. This is done by marking many functions inline, which actually solves us not following ODR rules, so that's fine.

Make that part of the core validation to avoid regress.

Fix #2076