### PR TITLE
Provide entry points pythran.import_pythrancode and pythran.import_py…

### DIFF
--- a/pythran/__init__.py
+++ b/pythran/__init__.py
@@ -41,6 +41,7 @@ import pythran.log
 from pythran.config import get_include
 from pythran.toolchain import (generate_cxx, compile_cxxfile, compile_cxxcode,
                                compile_pythrancode, compile_pythranfile,
+                               import_pythrancode, import_pythranfile,
                                test_compile)
 from pythran.spec import spec_parser
 from pythran.spec import load_specfile


### PR DESCRIPTION
…thranfile

These function calls perform a full parse & compile & import cycle, making it easy to integrate pythran in an existing codebase without relying on distutils / build system integration.

Fix #2080