### PR TITLE
Make sure an array of float32 added to a float64 scalar generates an …

### DIFF
--- a/pythran/pythonic/include/types/numpy_broadcast.hpp
+++ b/pythran/pythonic/include/types/numpy_broadcast.hpp
@@ -163,13 +163,13 @@ namespace types
    *
    * Have them behave like infinite arrays of that value
    *
-   * B is the original type of the broadcast value, && T is the type of the
+   * B is the original type of the broadcast value, and T is the type of the
    *expression it is combined with
-   * if both B && T are integer types, we choose T instead of B to prevent
-   *automatic conversion into larger types
+   * if both B and T are integer types, we choose T instead of B to prevent
+   * automatic conversion into larger types
    *
    * That way, np.ones(10, dtype=np.uint8) + 1 yields an array of np.uint8,
-   *although 1 is of type long
+   * although 1 is of type long
    */
   template <class dtype, bool is_vectorizable>
   struct broadcast_base {
@@ -258,8 +258,8 @@ namespace types
   template <class T, class B>
   struct broadcast_dtype {
     using type =
-        typename std::conditional<std::is_integral<T>::value &&
-                                      std::is_integral<B>::value,
+        typename std::conditional<(std::is_integral<T>::value && std::is_integral<B>::value)
+                                  ||(std::is_floating_point<T>::value && std::is_floating_point<B>::value),
                                   T, typename __combined<T, B>::type>::type;
   };
 #ifndef USE_XSIMD

--- a/pythran/tests/test_conversion.py
+++ b/pythran/tests/test_conversion.py
@@ -178,11 +178,31 @@ def dict_of_complex64_and_complex_128(l):
     def test_broadcasted_uint8(self):
         self.run_test('def broadcasted_uint8(l): return l - 4', np.ones(10,dtype=np.uint8).reshape(5,2), broadcasted_uint8=[NDArray[np.uint8, :, :]])
 
+    def test_broadcasted_uint8_dtype(self):
+        self.run_test('def broadcasted_uint8_dtype(l): return str((l - 4).dtype)',
+                      np.ones(10,dtype=np.uint8).reshape(5,2),
+                      broadcasted_uint8_dtype=[NDArray[np.uint8, :, :]])
+
     def test_broadcasted_int16(self):
         self.run_test('def broadcasted_int16(l): return l * 4', np.ones(10,dtype=np.int16).reshape(5,2), broadcasted_int16=[NDArray[np.int16, :, :]])
 
     def test_broadcasted_uint16(self):
         self.run_test('def broadcasted_uint16(l): return l / 4', np.ones(10,dtype=np.uint16).reshape(5,2), broadcasted_uint16=[NDArray[np.uint16, :, :]])
+
+    def test_broadcasted_uint16_dtype(self):
+        self.run_test('def broadcasted_uint16_dtype(l): return str((l / 4).dtype)',
+                      np.ones(10,dtype=np.uint16).reshape(5,2),
+                      broadcasted_uint16_dtype=[NDArray[np.uint16, :, :]])
+
+    def test_broadcasted_float32(self):
+        self.run_test('def broadcasted_float32(l): return l * 4.',
+                      np.ones(10,dtype=np.float32).reshape(5,2),
+                      broadcasted_float32=[NDArray[np.float32, :, :]])
+
+    def test_broadcasted_float32_dtype(self):
+        self.run_test('def broadcasted_float32_dtype(l): return str((l * 4.).dtype)',
+                      np.ones(10,dtype=np.float32).reshape(5,2),
+                      broadcasted_float32_dtype=[NDArray[np.float32, :, :]])
 
     @unittest.skip("no dynamic type promotion in pythran :-/")
     def test_broadcasted_large_int8(self):


### PR DESCRIPTION
…array of float32

There's a dynamic choice to be made here, and we choose the most conservative one that does not require upcasting every element of the array.

Fix #2090