### PR TITLE
Fix filtering of empty sequence

### DIFF
--- a/pythran/pythonic/builtins/filter.hpp
+++ b/pythran/pythonic/builtins/filter.hpp
@@ -3,9 +3,9 @@
 
 #include "pythonic/include/builtins/filter.hpp"
 
-#include "pythonic/utils/iterator.hpp"
 #include "pythonic/itertools/common.hpp"
 #include "pythonic/utils/functor.hpp"
+#include "pythonic/utils/iterator.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -29,7 +29,8 @@ namespace builtins
     filter_iterator<Operator, List0>::filter_iterator(Operator _op, List0 &_seq)
         : op(_op), iter(_seq.begin()), iter_end(_seq.end())
     {
-      if (!test_filter(std::is_same<types::none_type, Operator>()))
+      if (iter != iter_end &&
+          !test_filter(std::is_same<types::none_type, Operator>()))
         next_value();
     }
 
@@ -41,15 +42,15 @@ namespace builtins
     }
 
     template <typename Operator, typename List0>
-    typename List0::value_type filter_iterator<Operator, List0>::
-    operator*() const
+    typename List0::value_type
+    filter_iterator<Operator, List0>::operator*() const
     {
       return *iter;
     }
 
     template <typename Operator, typename List0>
-    filter_iterator<Operator, List0> &filter_iterator<Operator, List0>::
-    operator++()
+    filter_iterator<Operator, List0> &
+    filter_iterator<Operator, List0>::operator++()
     {
       next_value();
       return *this;
@@ -65,22 +66,22 @@ namespace builtins
     }
 
     template <typename Operator, typename List0>
-    bool filter_iterator<Operator, List0>::
-    operator==(filter_iterator const &other) const
+    bool filter_iterator<Operator, List0>::operator==(
+        filter_iterator const &other) const
     {
       return !(iter != other.iter);
     }
 
     template <typename Operator, typename List0>
-    bool filter_iterator<Operator, List0>::
-    operator!=(filter_iterator const &other) const
+    bool filter_iterator<Operator, List0>::operator!=(
+        filter_iterator const &other) const
     {
       return iter != other.iter;
     }
 
     template <typename Operator, typename List0>
-    bool filter_iterator<Operator, List0>::
-    operator<(filter_iterator const &other) const
+    bool filter_iterator<Operator, List0>::operator<(
+        filter_iterator const &other) const
     {
       return iter != other.iter;
     }
@@ -112,7 +113,7 @@ namespace builtins
     {
       return end_iter;
     }
-  }
+  } // namespace details
 
   template <typename Operator, typename List0>
   details::filter<typename std::remove_cv<
@@ -123,7 +124,7 @@ namespace builtins
   {
     return {std::forward<Operator>(_op), std::forward<List0>(_seq)};
   }
-}
+} // namespace builtins
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/include/builtins/filter.hpp
+++ b/pythran/pythonic/include/builtins/filter.hpp
@@ -1,9 +1,9 @@
 #ifndef PYTHONIC_INCLUDE_BUILTIN_FILTER_HPP
 #define PYTHONIC_INCLUDE_BUILTIN_FILTER_HPP
 
-#include "pythonic/include/utils/iterator.hpp"
 #include "pythonic/include/itertools/common.hpp"
 #include "pythonic/include/utils/functor.hpp"
+#include "pythonic/include/utils/iterator.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -44,9 +44,9 @@ namespace builtins
     };
 
     // Inherit from iterator_reminder to keep a reference on the iterator
-    // && avoid a dangling reference
+    // and avoid a dangling reference
     // FIXME: It would be better to have a copy only if needed but Pythran
-    // typing is ! good enough for this as arguments have
+    // typing is not good enough for this as arguments have
     // remove_cv/remove_ref
     template <typename Operator, typename List0>
     struct filter : utils::iterator_reminder<false, List0>,
@@ -64,7 +64,7 @@ namespace builtins
       iterator const &begin() const;
       iterator const &end() const;
     };
-  }
+  } // namespace details
 
   template <typename Operator, typename List0>
   details::filter<typename std::remove_cv<
@@ -74,7 +74,18 @@ namespace builtins
   filter(Operator &&_op, List0 &&_seq);
 
   DEFINE_FUNCTOR(pythonic::builtins, filter);
-}
+} // namespace builtins
 PYTHONIC_NS_END
+
+/* type inference stuff  {*/
+#include "pythonic/include/types/combined.hpp"
+
+template <class E, class Op, class T>
+struct __combined<E, pythonic::builtins::details::filter<Op, T>> {
+  using type =
+      typename __combined<E, container<typename pythonic::builtins::details::
+                                           filter<Op, T>::value_type>>::type;
+};
+/* } */
 
 #endif

--- a/pythran/pythonic/itertools/ifilter.hpp
+++ b/pythran/pythonic/itertools/ifilter.hpp
@@ -1,129 +1,23 @@
 #ifndef PYTHONIC_ITERTOOLS_IFILTER_HPP
 #define PYTHONIC_ITERTOOLS_IFILTER_HPP
 
+#include "pythonic/builtins/filter.hpp"
 #include "pythonic/include/itertools/ifilter.hpp"
-#include "pythonic/utils/iterator.hpp"
-#include "pythonic/itertools/common.hpp"
-#include "pythonic/utils/functor.hpp"
 
 PYTHONIC_NS_BEGIN
 
 namespace itertools
 {
 
-  namespace details
-  {
-    template <typename Operator, typename List0>
-    bool ifilter_iterator<Operator, List0>::test_filter(std::false_type)
-    {
-      return op(*iter);
-    }
-
-    template <typename Operator, typename List0>
-    bool ifilter_iterator<Operator, List0>::test_filter(std::true_type)
-    {
-      return *iter;
-    }
-
-    template <typename Operator, typename List0>
-    ifilter_iterator<Operator, List0>::ifilter_iterator(Operator _op,
-                                                        List0 &_seq)
-        : op(_op), iter(_seq.begin()), iter_end(_seq.end())
-    {
-      if (!test_filter(std::is_same<types::none_type, Operator>()))
-        next_value();
-    }
-
-    template <typename Operator, typename List0>
-    ifilter_iterator<Operator, List0>::ifilter_iterator(npos, Operator _op,
-                                                        List0 &_seq)
-        : op(_op), iter(_seq.end()), iter_end(_seq.end())
-    {
-    }
-
-    template <typename Operator, typename List0>
-    typename List0::value_type ifilter_iterator<Operator, List0>::
-    operator*() const
-    {
-      return *iter;
-    }
-
-    template <typename Operator, typename List0>
-    ifilter_iterator<Operator, List0> &ifilter_iterator<Operator, List0>::
-    operator++()
-    {
-      next_value();
-      return *this;
-    }
-
-    template <typename Operator, typename List0>
-    void ifilter_iterator<Operator, List0>::next_value()
-    {
-      while (++iter != iter_end) {
-        if (test_filter(std::is_same<types::none_type, Operator>()))
-          return;
-      }
-    }
-
-    template <typename Operator, typename List0>
-    bool ifilter_iterator<Operator, List0>::
-    operator==(ifilter_iterator const &other) const
-    {
-      return !(iter != other.iter);
-    }
-
-    template <typename Operator, typename List0>
-    bool ifilter_iterator<Operator, List0>::
-    operator!=(ifilter_iterator const &other) const
-    {
-      return iter != other.iter;
-    }
-
-    template <typename Operator, typename List0>
-    bool ifilter_iterator<Operator, List0>::
-    operator<(ifilter_iterator const &other) const
-    {
-      return iter != other.iter;
-    }
-
-    template <typename Operator, typename List0>
-    ifilter<Operator, List0>::ifilter(Operator _op, List0 const &_seq)
-        : utils::iterator_reminder<false, List0>(_seq),
-          iterator(_op, this->values), end_iter(npos(), _op, this->values)
-    {
-    }
-
-    template <typename Operator, typename List0>
-    typename ifilter<Operator, List0>::iterator &
-    ifilter<Operator, List0>::begin()
-    {
-      return *this;
-    }
-
-    template <typename Operator, typename List0>
-    typename ifilter<Operator, List0>::iterator const &
-    ifilter<Operator, List0>::begin() const
-    {
-      return *this;
-    }
-
-    template <typename Operator, typename List0>
-    typename ifilter<Operator, List0>::iterator const &
-    ifilter<Operator, List0>::end() const
-    {
-      return end_iter;
-    }
-  }
-
   template <typename Operator, typename List0>
-  details::ifilter<typename std::remove_cv<
-                       typename std::remove_reference<Operator>::type>::type,
-                   typename std::remove_cv<
-                       typename std::remove_reference<List0>::type>::type>
+  details::filter<typename std::remove_cv<
+                      typename std::remove_reference<Operator>::type>::type,
+                  typename std::remove_cv<
+                      typename std::remove_reference<List0>::type>::type>
   ifilter(Operator &&_op, List0 &&_seq)
   {
     return {std::forward<Operator>(_op), std::forward<List0>(_seq)};
   }
-}
+} // namespace itertools
 PYTHONIC_NS_END
 #endif

--- a/pythran/tests/test_itertools.py
+++ b/pythran/tests/test_itertools.py
@@ -39,6 +39,10 @@ class TestItertools(TestEnv):
     def test_ifilter_on_generator(self):
         self.run_test("def ifilterg_(l0): return list(filter(lambda x: (x % 2) == 1, (y for x in l0 for y in range(x))))", [0,1,2,3,4,5], ifilterg_=[List[int]])
 
+    def test_ifilter_on_empty_sequence(self):
+        self.run_test("def ifilter_empty(l0): return list(filter(lambda x: x, l0))",
+                      [], ifilter_empty=[List[int]])
+
     def test_product(self):
         self.run_test("def product_(l0,l1): from itertools import product; return sum(map(lambda t : t[0]*t[1], product(l0,l1)))", [0,1,2,3,4,5], [10,11], product_=[List[int],List[int]])
 


### PR DESCRIPTION
As a side effect, syndicate code between builtins.filter iterator and itertools.ifilter iterator, as they basically where the same (itertools.ifilter no longer exist in python3...)