### PR TITLE
Use pythran logger instead of default logger to report absence of spec

### DIFF
--- a/docs/CLI.rst
+++ b/docs/CLI.rst
@@ -65,7 +65,7 @@ That's some heavily templated code ;-) Pythran can then compile it for you to a 
 Pythran can also generate raw C++ code, using the ``-e`` switch::
 
   $> printf 'msg = \"hello world\"\ndef bar(): print(msg)' > cli_bar.py
-  $> pythran -e cli_bar.py -o cli_bar.hpp
+  $> pythran -e cli_bar.py -w -o cli_bar.hpp
   $> printf '#include \"cli_bar.hpp\"\nusing namespace __pythran_cli_bar ; int main() { bar()(); return 0 ; }' > cli_bar.cpp
   $> `pythran-config --compiler --cflags` -std=c++11 cli_bar.cpp -o cli_bar
   $> ./cli_bar

--- a/pythran/spec.py
+++ b/pythran/spec.py
@@ -90,9 +90,9 @@ class Spec(object):
                 self.functions[fname] = (signatures,)
 
         if not self:
-            import logging
-            logging.warning("No pythran specification, "
-                            "nothing will be exported")
+            from pythran.log import logger
+            logger.warning("No pythran specification, "
+                           "nothing will be exported")
 
     def keys(self):
         return list(self.functions.keys()) + list(self.capsules.keys())


### PR DESCRIPTION
Should fix #2121