### PR TITLE
Use npy_creal/npy_cimag from npy_math in from_python::convert

### DIFF
--- a/pythran/pythonic/types/complex.hpp
+++ b/pythran/pythonic/types/complex.hpp
@@ -177,6 +177,7 @@ PYTHONIC_NS_END
 #ifdef ENABLE_PYTHON_MODULE
 
 #include "numpy/arrayscalars.h"
+#include "numpy/npy_math.h"
 #include "pythonic/python/core.hpp"
 
 PYTHONIC_NS_BEGIN
@@ -228,7 +229,7 @@ inline std::complex<long double>
 from_python<std::complex<long double>>::convert(PyObject *obj)
 {
   auto val = PyArrayScalar_VAL(obj, CLongDouble);
-  return {val.real, val.imag};
+  return {npy_creall(val), npy_cimagl(val)};
 }
 
 template <>
@@ -243,7 +244,7 @@ inline std::complex<float>
 from_python<std::complex<float>>::convert(PyObject *obj)
 {
   auto val = PyArrayScalar_VAL(obj, CFloat);
-  return {val.real, val.imag};
+  return {npy_crealf(val), npy_cimagf(val)};
 }
 PYTHONIC_NS_END
 #endif


### PR DESCRIPTION
Hey 👋 !

These changes are necessary so that pythran continues to work with numpy complex types after numpy/numpy#24085 has been merged (this PR removes the complex structs that numpy has been using and replaces them with C99 native complex types, which do not have `.real` & `.imag` attributes) and numpy 2.0 has been released.

I'm not sure whether I should open a corresponding issue as well, so please let me know in case I need to do something more.