### PR TITLE
Fix annotation of numpy.array

### DIFF
--- a/pythran/optimizations/constant_folding.py
+++ b/pythran/optimizations/constant_folding.py
@@ -475,7 +475,7 @@ class ConstantFolding(Transformation):
                 pass
             except Exception as e:
                 if not cfg.getboolean('pythran', 'ignore_fold_error'):
-                    msg = 'when folding expression, pythran met the following'\
+                    msg = 'when folding expression, pythran met the following '\
                           'runtime exception:\n>>> {}'
                     raise PythranSyntaxError(msg.format(e), node)
 

--- a/pythran/tables.py
+++ b/pythran/tables.py
@@ -3187,9 +3187,9 @@ MODULES = {
             return_range=interval.positive_values
         ),
         "around": ConstFunctionIntr(signature=_numpy_around_signature),
-        "array": ReadOnceFunctionIntr(signature=_numpy_array_signature,
-                                      args=('object', 'dtype'),
-                                      defaults=(None,)),
+        "array": FunctionIntr(signature=_numpy_array_signature,
+                              args=('object', 'dtype'),
+                              defaults=(None,)),
         "array2string": ConstFunctionIntr(
             signature=_numpy_array_str_signature),
         "array_equal": ConstFunctionIntr(signature=Fun[[T0, T1], bool]),

--- a/pythran/tests/test_numpy_func2.py
+++ b/pythran/tests/test_numpy_func2.py
@@ -728,6 +728,9 @@ def test_copy0(x):
     def test_array2D_(self):
         self.run_test("def np_array2D_(a):\n from numpy import array\n return array(a)", [[1,2],[3,4]], np_array2D_=[List[List[int]]])
 
+    def test_array_iter(self):
+        self.run_test("def np_array_iter():\n from numpy import array\n return array(list(reversed(range(0, 300)))) + 3", np_array_iter=[])
+
     def test_array_typed(self):
         self.run_test("def np_array_typed(a):\n from numpy import array, int64\n return array(a, int64)", [1.,2.,3.], np_array_typed=[List[float]])
 


### PR DESCRIPTION
It is not valid to consider it as 'read_once' as it behaves differently when taking a list or an iterator as input.

Fix #2135