### PR TITLE
CI updates: add Python 3.11, and other minor maintenance

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10-dev, pypy-3.9]
+        python-version: [3.7, 3.9, '3.11', pypy-3.9]
         cpp-version: [g++-8, clang-7]
     steps:
     - uses: actions/checkout@v2
     - name: Setup Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -26,7 +26,7 @@ jobs:
         pip install -r requirements.txt
         pip install ipython nbval pytest-xdist cython wheel
         sudo apt install libopenblas-dev ${{ matrix.cpp-version }}
-        if test ${{ matrix.python-version }} != '3.10-dev' -a ${{ matrix.python-version }} != 'pypy-3.9'; then pip install scipy ; fi
+        if test ${{ matrix.python-version }} != 'pypy-3.9'; then pip install scipy ; fi
     - name: Setup
       run: |
         python setup.py install

--- a/.github/workflows/icc.yml
+++ b/.github/workflows/icc.yml
@@ -1,4 +1,4 @@
-name: core
+name: icc
 
 on:
   push:
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.10-dev]
+        python-version: ['3.10']
         cpp-version: [icpc]
     steps:
     - uses: actions/checkout@v2
     - name: Setup Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -25,7 +25,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install ipython nbval pytest-xdist cython wheel
-        if test ${{ matrix.python-version }} != '3.10-dev' ; then pip install scipy ; fi
+        if test ${{ matrix.python-version }} != '3.10' ; then pip install scipy ; fi
         wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg
         echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
         sudo apt update

--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.8, '3.10']
         cpp-version: [g++-8]
     steps:
     - uses: actions/checkout@v2
     - name: Setup Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.7
         architecture: ${{ matrix.architecture }}


### PR DESCRIPTION
- Spread out jobs more across Python versions
- Update to the latest setup-python actions
- ~Run tests in `core.yml` on Ubuntu 22.04~

One other thing I considered but didn't do is to reduce the matrix in `core.yml` across Python versions and GCC/Clang. Now everything is double; it'd be much more efficient to test like:
- py37 : gcc
- py38 : clang
- py39: gcc
- etc.
Only PyPy is different enough that it should be tested with both GCC and Clang for the same PyPy interpreter version.

@serge-sans-paille happy to do that too if you want.