### PR TITLE
Get rid of numpy.distutils

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.7, 3.9, '3.11', pypy-3.9]
+        python-version: [3.7, 3.9, 3.11, 3.12, pypy-3.9]
         cpp-version: [g++-8, clang-7]
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -24,7 +24,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install ipython nbval pytest-xdist cython wheel
+        pip install -r pythran/tests/requirements.txt
+        pip install pytest-xdist
         sudo apt install libopenblas-dev ${{ matrix.cpp-version }}
         if test ${{ matrix.python-version }} != 'pypy-3.9'; then pip install scipy ; fi
     - name: Setup

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -24,7 +24,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install ipython nbval pytest-xdist cython scipy wheel
+        pip install -r pythran/tests/requirements.txt scipy
+        pip install pytest-xdist
         sudo apt install libopenblas-dev ${{ matrix.cpp-version }}
     - name: Setup
       run: |

--- a/.github/workflows/icc.yml
+++ b/.github/workflows/icc.yml
@@ -24,7 +24,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install ipython nbval pytest-xdist cython wheel
+        pip install -r pythran/tests/requirements.txt
+        pip install pytest-xdist
         if test ${{ matrix.python-version }} != '3.10' ; then pip install scipy ; fi
         wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg
         echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list

--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -24,7 +24,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install ipython nbval pytest-xdist cython scipy wheel
+        pip install -r pythran/tests/requirements.txt scipy
+        pip install pytest-xdist
         sudo apt install libopenblas-dev ${{ matrix.cpp-version }}
     - name: Setup
       run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -28,7 +28,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install scipy wheel pythran-openblas pytest
+        pip install -r pythran/tests/requirements.txt scipy
+        pip install pythran-openblas pytest
     - name: Setup
       run: |
         python setup.py install

--- a/docs/DEVGUIDE.rst
+++ b/docs/DEVGUIDE.rst
@@ -68,8 +68,12 @@ Validation
 ----------
 
 ``pythran`` uses the ``unittest`` module and the `pytest
-<http://pytest.org/latest/>`_ package to manage test cases. The whole
-validation suite is run through the command::
+<http://pytest.org/latest/>`_ package to manage test cases.
+
+All requirements are listed in ``pythran/tests/requirements.txt``.
+
+
+The whole validation suite is run through the command::
 
     $> python -m pytest pythran/tests
 

--- a/pythran/dist.py
+++ b/pythran/dist.py
@@ -13,14 +13,17 @@ except ImportError:
 import os.path
 import os
 
-from distutils.command.build_ext import build_ext as LegacyBuildExt
+try:
+    from distutils.command.build_ext import build_ext as LegacyBuildExt
+except ImportError:
+    from setuptools.command.build_ext import build_ext as LegacyBuildExt
 
 try:
     # `numpy.distutils` is deprecated, and won't be present on Python >=3.12
     # If it is installed, we need to use it though, so try-import it:
     from numpy.distutils.extension import Extension
 except ImportError:
-    from distutils.extension import Extension
+    from setuptools.extension import Extension
 
 
 

--- a/pythran/tests/requirements.txt
+++ b/pythran/tests/requirements.txt
@@ -1,0 +1,4 @@
+ipython
+nbval
+cython
+wheel

--- a/pythran/tests/test_distutils_numpy/setup.py
+++ b/pythran/tests/test_distutils_numpy/setup.py
@@ -1,5 +1,10 @@
-from numpy.distutils.core import setup
-from numpy.distutils.command.build_ext import build_ext as npy_build_ext
+try:
+    from numpy.distutils.core import setup
+    from numpy.distutils.command.build_ext import build_ext as npy_build_ext
+except ImportError:
+    from distutils.core import setup
+    from distutils.command.build_ext import build_ext as npy_build_ext
+
 from pythran.dist import PythranExtension, PythranBuildExt
 
 module1 = PythranExtension('demo3.a', sources = ['demo3/a.py'])

--- a/pythran/toolchain.py
+++ b/pythran/toolchain.py
@@ -22,13 +22,17 @@ from pythran.version import __version__
 from pythran.utils import cxxid
 import pythran.frontend as frontend
 
-from distutils.errors import CompileError
-from distutils import sysconfig
+try:
+    from distutils.errors import CompileError
+    from distutils import sysconfig
+except ImportError:
+    from setuptools.errors import CompileError
+    from setuptools._distutils import sysconfig
 try:
     # `numpy.distutils is deprecated, may not be present, or broken
     from numpy.distutils.core import setup
 except Exception:
-    from distutils.core import setup
+    from setuptools import setup
 
 from tempfile import mkdtemp, NamedTemporaryFile
 import gast as ast

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 ply>=3.4
+setuptools
 gast~=0.5.0
 numpy
 beniget~=0.4.0


### PR DESCRIPTION
Since numpy 1.26.0, numpy.distutils is being removed in python 3.12, let's try to have a solution that work for 3.12 *and* previous version without numpy.distutils.

Fix #2148