### PR TITLE
xsimd_scalar.hpp: fix for missing __exp10 on macOS < 10.9

### DIFF
--- a/pythran/xsimd/arch/xsimd_scalar.hpp
+++ b/pythran/xsimd/arch/xsimd_scalar.hpp
@@ -24,6 +24,10 @@
 #include "xtl/xcomplex.hpp"
 #endif
 
+#ifdef __APPLE__
+#include <AvailabilityMacros.h>
+#endif
+
 namespace xsimd
 {
     template <class T, class A>
@@ -468,7 +472,7 @@ namespace xsimd
         return !(x0 == x1);
     }
 
-#if defined(__APPLE__)
+#if defined(__APPLE__) && (MAC_OS_X_VERSION_MIN_REQUIRED > 1080)
     inline float exp10(const float& x) noexcept
     {
         return __exp10f(x);
@@ -485,6 +489,15 @@ namespace xsimd
     inline double exp10(const double& x) noexcept
     {
         return ::exp10(x);
+    }
+#elif !defined(__clang__) && defined(__GNUC__) && (__GNUC__ >= 5)
+    inline float exp10(const float& x) noexcept
+    {
+        return __builtin_exp10f(x);
+    }
+    inline double exp10(const double& x) noexcept
+    {
+        return __builtin_exp10(x);
     }
 #elif defined(_WIN32)
     template <class T, class = typename std::enable_if<std::is_scalar<T>::value>::type>


### PR DESCRIPTION
Fixes: https://github.com/serge-sans-paille/pythran/issues/2164

Apparently `__exp10` and `__exp10f` do not exist on macOS until 10.9: https://lists.llvm.org/pipermail/llvm-commits/Week-of-Mon-20131216/199358.html
And indeed, on 10.6 existing code is broken.

Use existing fallback instead, fix the macros.