### PR TITLE
Avoid redefining `NPY_NO_DEPRECATED_API` if already defined by user

### DIFF
--- a/pythran/pythonic/include/types/ndarray.hpp
+++ b/pythran/pythonic/include/types/ndarray.hpp
@@ -52,9 +52,9 @@
 #include <ostream>
 
 #ifdef ENABLE_PYTHON_MODULE
-// Cython still uses the deprecated API, so we can't set this macro in this
-// case!
-#ifndef CYTHON_ABI
+// Cython 0.29.x still uses the deprecated API, so we can't set this macro in
+// this case! Also avoid redefining it if already set by the Pythran user.
+#if !defined(CYTHON_ABI) && !defined(NPY_NO_DEPRECATED_API)
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #endif
 #include "numpy/arrayobject.h"

--- a/pythran/pythonic/python/core.hpp
+++ b/pythran/pythonic/python/core.hpp
@@ -11,9 +11,9 @@
 #include <type_traits>
 #include <utility>
 
-// Cython still uses the deprecated API, so we can't set this macro in this
-// case!
-#ifndef CYTHON_ABI
+// Cython 0.29.x still uses the deprecated API, so we can't set this macro in
+// this case! Also avoid redefining it if already set by the Pythran user.
+#if !defined(CYTHON_ABI) && !defined(NPY_NO_DEPRECATED_API)
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #endif
 #include "numpy/arrayobject.h"


### PR DESCRIPTION
This caused macro redefined warnings in SciPy when globally setting this macro on all build targets that have a numpy dependency.