### PR TITLE
Allow taking the real/imag part of a numpy_iexpr

### DIFF
--- a/pythran/pythonic/include/types/ndarray.hpp
+++ b/pythran/pythonic/include/types/ndarray.hpp
@@ -825,8 +825,8 @@ namespace builtins
     template <>
     struct _build_gexpr<1> {
       template <class E, class... S>
-      types::numpy_gexpr<E, types::normalize_t<S>...>
-      operator()(E const &a, S const &...slices);
+        auto
+      operator()(E const &a, S const &...slices) -> decltype(E(a)(slices...));
     };
 
     template <class E>

--- a/pythran/tests/test_ndarray.py
+++ b/pythran/tests/test_ndarray.py
@@ -109,6 +109,16 @@ class TestNdarray(TestEnv):
                       1j * numpy.arange(10, dtype=numpy.complex128),
                       ndarray_imag_vexpr_read=[NDArray[complex, :]])
 
+    def test_ndarray_real_iexpr_read(self):
+        self.run_test('def ndarray_real_iexpr_read(a): return a[1].real',
+                      numpy.arange(10, dtype=numpy.complex128),
+                      ndarray_real_iexpr_read=[NDArray[complex, :]])
+
+    def test_ndarray_imag_iexpr_read(self):
+        self.run_test('def ndarray_imag_iexpr_read(a): return a[1].imag',
+                      1j * numpy.arange(10, dtype=numpy.complex128),
+                      ndarray_imag_iexpr_read=[NDArray[complex, :]])
+
     def test_numpy_augassign0(self):
         self.run_test('def numpy_augassign0(a): a+=1; return a',
                       numpy.arange(100).reshape((10, 10)),


### PR DESCRIPTION
But this creates a copy, I'm not very happy with this solution. Ideally we could avoid it.

Fix #2173