### PR TITLE
Add support for numpy.vectorize

### DIFF
--- a/pythran/pythonic/include/numpy/vectorize.hpp
+++ b/pythran/pythonic/include/numpy/vectorize.hpp
@@ -1,0 +1,35 @@
+#ifndef PYTHONIC_INCLUDE_NUMPY_VECTORIZE_HPP
+#define PYTHONIC_INCLUDE_NUMPY_VECTORIZE_HPP
+
+#include "pythonic/include/types/numpy_expr.hpp"
+#include "pythonic/include/utils/functor.hpp"
+
+PYTHONIC_NS_BEGIN
+
+namespace numpy
+{
+  template <class F>
+  struct vectorized {
+    using callable = void;
+    template <typename... T>
+    auto operator()(T &&...args) const ->
+        typename std::enable_if<!types::valid_numexpr_parameters<
+                                    typename std::decay<T>::type...>::value,
+                                decltype(F{}(std::forward<T>(args)...))>::type;
+
+    template <class... E>
+    typename std::enable_if<
+        types::valid_numexpr_parameters<typename std::decay<E>::type...>::value,
+        types::numpy_expr<F,
+                          typename types::adapt_type<E, E...>::type...>>::type
+    operator()(E &&...args) const;
+  };
+
+  template <class F>
+  vectorized<F> vectorize(F const &);
+
+  DEFINE_FUNCTOR(pythonic::numpy, vectorize);
+} // namespace numpy
+PYTHONIC_NS_END
+
+#endif

--- a/pythran/pythonic/numpy/vectorize.hpp
+++ b/pythran/pythonic/numpy/vectorize.hpp
@@ -1,0 +1,41 @@
+#ifndef PYTHONIC_NUMPY_VECTORIZE_HPP
+#define PYTHONIC_NUMPY_VECTORIZE_HPP
+
+#include "pythonic/include/numpy/vectorize.hpp"
+#include "pythonic/types/numpy_expr.hpp"
+
+#include "pythonic/utils/functor.hpp"
+
+PYTHONIC_NS_BEGIN
+
+namespace numpy
+{
+  template <typename F>
+  template <typename... T>
+  auto vectorized<F>::operator()(T &&...args) const -> typename std::enable_if<
+      !types::valid_numexpr_parameters<typename std::decay<T>::type...>::value,
+      decltype(F{}(std::forward<T>(args)...))>::type
+  {
+    return F{}(std::forward<T>(args)...);
+  }
+
+  template <class F>
+  template <class... E>
+  typename std::enable_if<
+      types::valid_numexpr_parameters<typename std::decay<E>::type...>::value,
+      types::numpy_expr<F, typename types::adapt_type<E, E...>::type...>>::type
+  vectorized<F>::operator()(E &&...args) const
+  {
+    return {std::forward<E>(args)...};
+  }
+
+  template <class F>
+  vectorized<F> vectorize(F const &)
+  {
+    return {};
+  }
+
+} // namespace numpy
+PYTHONIC_NS_END
+
+#endif

--- a/pythran/tables.py
+++ b/pythran/tables.py
@@ -4060,6 +4060,7 @@ MODULES = {
         "unravel_index": ConstFunctionIntr(),
         "ushort": ConstFunctionIntr(signature=_int_signature),
         "var": ConstMethodIntr(),
+        "vectorize": ConstFunctionIntr(),
         "vdot": ConstMethodIntr(),
         "vstack": ConstFunctionIntr(),
         "where": ConstFunctionIntr(),

--- a/pythran/tests/test_numpy_func1.py
+++ b/pythran/tests/test_numpy_func1.py
@@ -323,6 +323,56 @@ class TestNumpyFunc1(TestEnv):
                       numpy.array([2., -2., 2., -2.]),
                       np_remainder0=[NDArray[float,:], NDArray[float,:]])
 
+    def test_vectorize0(self):
+        self.run_test("""
+            def np_vectorize0(x):
+                from numpy import vectorize;
+                return vectorize(lambda x: x + 1)(x)""",
+                      numpy.array([1, 2, 3, 4]),
+                      np_vectorize0=[NDArray[int , :]])
+
+    def test_vectorize1(self):
+        self.run_test("""
+            def np_vectorize1(x):
+                from numpy import vectorize;
+                return vectorize(lambda x: x + 1)(x)""",
+                      5,
+                      np_vectorize1=[int])
+
+    def test_vectorize2(self):
+        self.run_test("""
+            def np_vectorize2(x):
+                from numpy import vectorize;
+                return vectorize(lambda x: x + 1)(x)""",
+                      5j,
+                      np_vectorize2=[complex])
+
+    def test_vectorize3(self):
+        self.run_test("""
+            def np_vectorize3(x):
+                from numpy import vectorize;
+                return vectorize(lambda x: x + 1j)(x)""",
+                      numpy.array([1., 2., 3., 4.]),
+                      np_vectorize3=[NDArray[float , :]])
+
+    def test_vectorize4(self):
+        self.run_test("""
+            def np_vectorize4(x):
+                from numpy import vectorize;
+                from operator import add
+                return vectorize(add)(x, 9.)""",
+                      numpy.array([1, 2, 3, 4]),
+                      np_vectorize4=[NDArray[int , :]])
+
+    def test_vectorize5(self):
+        self.run_test("""
+            def np_vectorize5(x):
+                from numpy import vectorize;
+                v = vectorize(lambda x, y: x + 3 * y)
+                return v(x, x), v(x, 1)""",
+                      numpy.array([1, 2, 3, 4]),
+                      np_vectorize5=[NDArray[int , :]])
+
     def test_numpy_ones_list(self):
         self.run_test(
             "def np_ones_list(u): from numpy import ones; return ones([u,u])",


### PR DESCRIPTION
This all relies on existing logic around numpy_expr, so no big deal in terms of extra features to add.

This also paves the way for #2141  as we now "just" need to write a generic converted for `numpy::vectorized<F>`.