### PR TITLE
setuptools 62+ required to build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ pythran-config = "pythran.config:run"
 
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools"]
+requires = ["setuptools>=62"]
 
 [tool.setuptools]
 packages = ['pythran', 'pythran.analyses', 'pythran.transformations',


### PR DESCRIPTION
Originally discovered by @rgommers 

Starting with #2162, building pythran with setuptools 60 or older results in failure to detect project name or version:
```
  Created wheel for UNKNOWN: filename=UNKNOWN-0.0.0-py3-none-any.whl size=2302 sha256=b46d11132f5384c143756b1ed741d7a1848b92f77ddc837eaebf68ad91ae333b
```
and setuptools 61 fails with:
```
  ValueError: invalid pyproject.toml config: `tool.setuptools.dynamic`
```
Setuptools 62 or newer is required to build from source.