### PR TITLE
Handle situation where we already have an incompatible scipy version …

### DIFF
--- a/pythran/tables.py
+++ b/pythran/tables.py
@@ -4583,7 +4583,7 @@ def save_arguments(module_name, elements):
                 obj = getattr(themodule, elem)
                 while hasattr(obj, '__wrapped__'):
                     obj = obj.__wrapped__
-            except (AttributeError, ImportError, TypeError):
+            except (AttributeError, ImportError, TypeError, ValueError):
                 continue
 
             # first try to gather info through getfullargspec


### PR DESCRIPTION
…installed

This could lead to ValueError being raised while importing scipy, ignore them.

Fix #2194