### PR TITLE
Only link with blas when needed

### DIFF
--- a/pythran/config.py
+++ b/pythran/config.py
@@ -160,10 +160,8 @@ def make_extension(python, **extra):
     cfg = init_cfg('pythran.cfg',
                    'pythran-{}.cfg'.format(sys.platform),
                    '.pythranrc',
-                   extra.get('config', None))
+                   extra.pop('config', None))
 
-    if 'config' in extra:
-        extra.pop('config')
 
     def parse_define(define):
         index = define.find('=')

--- a/pythran/intrinsic.py
+++ b/pythran/intrinsic.py
@@ -67,6 +67,7 @@ class Intrinsic(object):
                                        lambda call: UNKNOWN_RANGE)
         self.return_range_content = kwargs.get("return_range_content",
                                                lambda c: UNKNOWN_RANGE)
+        self.requires_blas = kwargs.get("requires_blas", False)
 
     def isliteral(self):
         return False

--- a/pythran/pythonic/include/operator_/imatmul.hpp
+++ b/pythran/pythonic/include/operator_/imatmul.hpp
@@ -1,8 +1,8 @@
 #ifndef PYTHONIC_INCLUDE_OPERATOR_IMATMUL_HPP
 #define PYTHONIC_INCLUDE_OPERATOR_IMATMUL_HPP
 
-#include "pythonic/include/utils/functor.hpp"
 #include "pythonic/include/numpy/dot.hpp"
+#include "pythonic/include/utils/functor.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -12,10 +12,10 @@ namespace operator_
   template <class A, class B>
   A imatmul(A const &a, B &&b);
   template <class A, class B>
-  A imatmul(A &a, B &&b);
+  A &imatmul(A &a, B &&b);
 
   DEFINE_FUNCTOR(pythonic::operator_, imatmul);
-}
+} // namespace operator_
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/numpy/vdot.hpp
+++ b/pythran/pythonic/numpy/vdot.hpp
@@ -3,11 +3,11 @@
 
 #include "pythonic/include/numpy/vdot.hpp"
 
-#include "pythonic/utils/functor.hpp"
-#include "pythonic/types/ndarray.hpp"
-#include "pythonic/numpy/dot.hpp"
 #include "pythonic/numpy/asarray.hpp"
 #include "pythonic/numpy/conjugate.hpp"
+#include "pythonic/numpy/dot.hpp"
+#include "pythonic/types/ndarray.hpp"
+#include "pythonic/utils/functor.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -21,16 +21,14 @@ namespace numpy
   {
     if (types::is_complex<typename U::dtype>::value &&
         types::is_complex<typename V::dtype>::value) {
-      puts("complex");
       return functor::dot{}(functor::asarray{}(functor::conjugate{}(u)).flat(),
                             functor::asarray{}(v).flat());
     } else {
-      puts("simplex");
       return functor::dot{}(functor::asarray{}(u).flat(),
                             functor::asarray{}(v).flat());
     }
   }
-}
+} // namespace numpy
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/pythonic/operator_/imatmul.hpp
+++ b/pythran/pythonic/operator_/imatmul.hpp
@@ -3,8 +3,8 @@
 
 #include "pythonic/include/operator_/imatmul.hpp"
 
-#include "pythonic/utils/functor.hpp"
 #include "pythonic/numpy/dot.hpp"
+#include "pythonic/utils/functor.hpp"
 
 PYTHONIC_NS_BEGIN
 
@@ -19,10 +19,10 @@ namespace operator_
   template <class A, class B>
   A &imatmul(A &a, B &&b)
   {
-    return a = numpy::functor::dot(a,
-                                   std::forward<B>(b)); // FIXME: improve that
+    return a = numpy::functor::dot{}(a,
+                                     std::forward<B>(b)); // FIXME: improve that
   }
-}
+} // namespace operator_
 PYTHONIC_NS_END
 
 #endif

--- a/pythran/tests/test_advanced.py
+++ b/pythran/tests/test_advanced.py
@@ -287,6 +287,14 @@ def combiner_on_empty_list():
             numpy.array([[0., 2.], [1., 3.]]),
             matmul_operator=[NDArray[float, :,:], NDArray[float, :,:]])
 
+    def test_imatmul_operator(self):
+        code = 'def imatmul_operator(x, y): x @= y; return x'
+        self.run_test(
+            code,
+            numpy.array([[1., 1.], [2., 2.]]),
+            numpy.array([[0., 2.], [1., 3.]]),
+            imatmul_operator=[NDArray[float, :,:], NDArray[float, :,:]])
+
     def test_generator_handler_name(self):
         code = '''
             def foo(x):

--- a/pythran/tests/test_advanced.py
+++ b/pythran/tests/test_advanced.py
@@ -5,6 +5,7 @@ from unittest import skip, skipIf
 import numpy
 
 from pythran.typing import *
+from packaging.version import Version
 
 class TestAdvanced(TestEnv):
 
@@ -287,6 +288,7 @@ def combiner_on_empty_list():
             numpy.array([[0., 2.], [1., 3.]]),
             matmul_operator=[NDArray[float, :,:], NDArray[float, :,:]])
 
+    @skipIf(Version(numpy.__version__) <= Version('1.26'), "Not supported upstream")
     def test_imatmul_operator(self):
         code = 'def imatmul_operator(x, y): x @= y; return x'
         self.run_test(

--- a/pythran/tests/test_distutils/b.py
+++ b/pythran/tests/test_distutils/b.py
@@ -1,0 +1,4 @@
+#pythran export b(int)
+import numpy
+def b(n): return numpy.ones((n, n)) @ numpy.ones((n, n))
+

--- a/pythran/tests/test_distutils/setup.py
+++ b/pythran/tests/test_distutils/setup.py
@@ -2,9 +2,10 @@ from distutils.core import setup
 from pythran.dist import PythranExtension, PythranBuildExt
 
 module1 = PythranExtension('demo', sources = ['a.py'])
+module2 = PythranExtension('demo', sources = ['b.py'])
 
 setup(name = 'demo',
       version = '1.0',
       description = 'This is a demo package',
       cmdclass={"build_ext": PythranBuildExt},
-      ext_modules = [module1])
+      ext_modules = [module1, module2])

--- a/pythran/tests/test_ndarray.py
+++ b/pythran/tests/test_ndarray.py
@@ -2,8 +2,6 @@ from pythran.tests import TestEnv
 from pythran.typing import NDArray, Tuple, List
 
 import numpy
-from distutils.version import LooseVersion
-
 import unittest
 
 try:

--- a/pythran/tests/test_numpy_fft.py
+++ b/pythran/tests/test_numpy_fft.py
@@ -2,7 +2,7 @@ import unittest
 from pythran.tests import TestEnv
 import numpy
 from pythran.typing import NDArray
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 
 class TestNumpyRFFT(TestEnv):
@@ -18,7 +18,7 @@ class TestNumpyRFFT(TestEnv):
     def test_rfft_3(self):
         self.run_test("def test_rfft_3(x,n): from numpy.fft import rfft ; return rfft(x,n)", numpy.arange(0,8.),7, test_rfft_3=[NDArray[float,:],int])
 
-    @unittest.skipIf(LooseVersion(numpy.__version__) >= '2', "see https://github.com/numpy/numpy/issues/26349")
+    @unittest.skipIf(Version(numpy.__version__) >= Version('2'), "see https://github.com/numpy/numpy/issues/26349")
     def test_rfft_4(self):
         self.run_test("def test_rfft_4(x,n): from numpy.fft import rfft ; return rfft(x,n)", numpy.arange(0,8.),6, test_rfft_4=[NDArray[float,:],int])
 
@@ -132,7 +132,7 @@ class TestNumpyFFTN(TestEnv):
 
     # Various norms
 
-    @unittest.skipIf(LooseVersion(numpy.__version__) <'1.20', "introduced in 1.20")
+    @unittest.skipIf(Version(numpy.__version__) < Version('1.20'), "introduced in 1.20")
     def test_fftn_12(self):
         self.run_test("def test_fftn_12(x): from numpy.fft import fftn ; return fftn(x, (6,), norm='backward')",
                       numpy.arange(0,8), test_fftn_12=[NDArray[int,:]])
@@ -140,7 +140,7 @@ class TestNumpyFFTN(TestEnv):
         self.run_test("def test_fftn_13(x): from numpy.fft import fftn ; return fftn(x, (8,), norm='ortho')",
                       numpy.arange(0,8.), test_fftn_13=[NDArray[float,:]])
 
-    @unittest.skipIf(LooseVersion(numpy.__version__) <'1.20', "introduced in 1.20")
+    @unittest.skipIf(Version(numpy.__version__) < Version('1.20'), "introduced in 1.20")
     def test_fftn_14(self):
         self.run_test("def test_fftn_14(x): from numpy.fft import fftn ; return fftn(x, (10,), norm='forward')",
                       numpy.arange(0, 8.) + 1.j, test_fftn_14=[NDArray[complex,:]])
@@ -258,7 +258,7 @@ class TestNumpyIHFFT(TestEnv):
     def test_ihfft_3(self):
         self.run_test("def test_ihfft_3(x,n): from numpy.fft import ihfft ; return ihfft(x,n)", numpy.arange(0,8.),7, test_ihfft_3=[NDArray[float,:],int])
 
-    @unittest.skipIf(LooseVersion(numpy.__version__) >= '2', "see https://github.com/numpy/numpy/issues/26349")
+    @unittest.skipIf(Version(numpy.__version__) >= Version('2'), "see https://github.com/numpy/numpy/issues/26349")
     def test_ihfft_4(self):
         self.run_test("def test_ihfft_4(x,n): from numpy.fft import ihfft ; return ihfft(x,n)", numpy.arange(0,8.),6, test_ihfft_4=[NDArray[float,:],int])
 


### PR DESCRIPTION
Based on the included headers, pythran now automatically removes the blas dependency.

Also do some cleanups (removing debug lines, some formatting, fix imatmul headers).

Fix #2203