### PR TITLE
fix: pin setuptools dependency below 73.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ pythran-config = "pythran.config:run"
 
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools>=62"]
+requires = ["setuptools>=62,<73.0.0"]
 
 [tool.setuptools]
 packages = ['pythran', 'pythran.analyses', 'pythran.transformations',


### PR DESCRIPTION
Closes #2228 

Please see above issue for description of failure.
The release of setuptools 73.0.0 appears to have broken the build process for pythran.

This can be mitigated by updating the build files, but as an immediate fix, pin to existing lower versions that build successfully.