### PR TITLE
hotfix: address metaclass definition in `PythranBuildExt`

### DIFF
--- a/pythran/dist.py
+++ b/pythran/dist.py
@@ -130,14 +130,10 @@ class PythranBuildExtMixIn(object):
                 msvc._find_exe = find_exe
 
 
-class PythranBuildExtMeta(type):
-
+class PythranBuildExtMeta(type(LegacyBuildExt)):
     def __getitem__(self, base):
-        class PythranBuildExt(PythranBuildExtMixIn, base):
-            pass
-
-        return PythranBuildExt
-
+        return type(
+            'PythranBuildExt', (PythranBuildExtMixIn, base), {})
 
 class PythranBuildExt(PythranBuildExtMixIn, LegacyBuildExt, metaclass=PythranBuildExtMeta):
     pass


### PR DESCRIPTION
## Description

I'm not sure if this is the best fix for #2228 or if this is something that should be resolved in `setuptools` instead, but this PR is a small fix that resolves the metaclass conflict in Pythran that is coming from `setuptools`'s new v73.0.0 release. I can close this PR if it gets resolved elsewhere!

```
TypeError: metaclass conflict: the metaclass of a derived class must be a (non-strict) subclass of the metaclasses of all its bases
```

The test suite are proceeding to run on my fork here: https://github.com/agriyakhetarpal/pythran/pull/1 and I have verified that the fix works, and in the meantime, #2229 pins `setuptools` to <73 which is an easier fix to incorporate.

## Changes made

-  `PythranBuildExtMeta` derives from `type(LegacyBuildExt)` – which ensures that `PythranBuildExtMeta` is a subclass of the metaclass used by `LegacyBuildExt`, and
- instead of defining a new class inside the `__getitem__` method, it now uses the `type()` function to dynamically construct a new class.

## Additional context

xref to some downstream issues where this was discovered:

1. https://github.com/pyodide/pyodide/pull/5011, https://github.com/pyodide/pyodide/issues/5018
2. https://github.com/scipy/scipy/issues/21416
3. https://github.com/conda-forge/setuptools-feedstock/pull/356