### PR TITLE
Add basic support for type annotation

### DIFF
--- a/docs/MANUAL.rst
+++ b/docs/MANUAL.rst
@@ -282,6 +282,25 @@ Easy enough, isn't it?
     cannot go further that generic (a.k.a. heavily templated) c++ code. Use the
     ``-e`` switch!
 
+When Pythran needs a little help: type annotation
+*************************************************
+
+Type inference is hard. Pythran sometimes struggles to get the correct type of a
+variable, espetially when it's declared as an empty list, dictionary or set.
+
+Fortunately, it can also understand Python variable annotation, just like::
+
+    some_list : list[int] = []
+
+But because sometimes the typing depends on the type of other variables, or of
+the evaluation of an actual expression. The following is also valid in Pythran::
+
+    an_int_list = [5]
+    some_list : type(an_int_list) = []
+    some_dict : dict[str:type(some_list)] = {}
+
+This typing is optional and is taken as an extra hint to type inference.
+
 
 .pythran files
 --------------

--- a/pythran/analyses/aliases.py
+++ b/pythran/analyses/aliases.py
@@ -664,7 +664,9 @@ class Aliases(ModuleAnalysis):
             else:
                 self.visit(t)
 
-    visit_AnnAssign = visit_Assign
+    def visit_AnnAssign(self, node):
+        self.visit_Assign(node)
+        self.visit(node.annotation)
 
     def visit_For(self, node):
         '''

--- a/pythran/cxxtypes.py
+++ b/pythran/cxxtypes.py
@@ -89,6 +89,9 @@ std::declval<str>()))>::type>::type
     >>> builder.ListType(builder.NamedType('int'))
     pythonic::types::list<typename std::remove_reference<int>::type>
 
+    >>> builder.NDArrayType(builder.NamedType('int'), 1)
+    pythonic::types::ndarray<int, pythonic::types::pshape<long>>
+
     >>> builder.SetType(builder.NamedType('int'))
     pythonic::types::set<int>
 
@@ -202,7 +205,9 @@ std::declval<bool>()))
                     return ctx(self.orig)
                 else:
                     self.isrec = True
-                    return ctx(self.final_type)
+                    res = ctx(self.final_type)
+                    self.isrec = False
+                    return res
 
         class InstantiatedType(Type):
             """
@@ -472,6 +477,20 @@ std::declval<bool>()))
             def generate(self, ctx):
                 return 'pythonic::types::dict<{},{}>'.format(ctx(self.of_key),
                                                              ctx(self.of_val))
+
+        class NDArrayType(DependentType):
+            '''
+            Type holding a numpy array without view
+            '''
+            def __init__(self, dtype, nbdims):
+                super(DependentType, self).__init__(of=dtype, nbdims=nbdims)
+
+            def generate(self, ctx):
+                return 'pythonic::types::ndarray<{}, pythonic::types::pshape<{}>>'.format(
+                        ctx(self.of),
+                        ", ".join((['long'] * self.nbdims))
+                        )
+
 
         class ContainerType(DependentType):
             '''

--- a/pythran/pythonic/include/types/numpy_gexpr.hpp
+++ b/pythran/pythonic/include/types/numpy_gexpr.hpp
@@ -1026,6 +1026,12 @@ template <class Arg, class... S, class O>
 struct __combined<O, pythonic::types::numpy_gexpr<Arg, S...>> {
   using type = pythonic::types::numpy_gexpr<Arg, S...>;
 };
+
+template <class Arg, class... S, class O>
+struct __combined<O &, pythonic::types::numpy_gexpr<Arg, S...>> {
+  using type = pythonic::types::numpy_gexpr<Arg, S...>;
+};
+
 template <class Arg, class... S>
 struct __combined<pythonic::types::none_type,
                   pythonic::types::numpy_gexpr<Arg, S...>> {

--- a/pythran/tests/test_annotations.py
+++ b/pythran/tests/test_annotations.py
@@ -21,3 +21,86 @@ class TestBase(TestEnv):
         self.run_test("def fwd_ann_stmt(a): b: float; b = 1.; return a + b",
                       1,
                       fwd_ann_stmt=[int])
+
+class TestTypeAnnotation(TestEnv):
+
+    def test_int_ann(self):
+        self.run_test("def int_ann(a):\n b: int = 1; return a + b",
+                      1,
+                      int_ann=[int])
+
+    def test_bool_ann(self):
+        self.run_test("def bool_ann(a):\n b: bool = a; return b",
+                      True,
+                      bool_ann=[bool])
+
+    def test_float_ann(self):
+        self.run_test("def float_ann(a):\n b: float = 2.; return b * a",
+                      1,
+                      float_ann=[int])
+
+    def test_complex_ann(self):
+        self.run_test("def complex_ann(a):\n b: complex = 2.j; return b * a",
+                      1,
+                      complex_ann=[int])
+
+    def test_tuple_ann(self):
+        self.run_test("def tuple_ann(a):\n b: tuple[int, float] = (a, 1.); return b",
+                      1,
+                      tuple_ann=[int])
+
+    def test_list_ann(self):
+        self.run_test("def list_ann(a):\n b: list[int] = []; return b * a",
+                      1,
+                      list_ann=[int])
+
+    def test_set_ann(self):
+        self.run_test("def set_ann(a):\n b: set[int] = set(); return b",
+                      1,
+                      set_ann=[int])
+
+    def test_dict_ann(self):
+        self.run_test("def dict_ann(a):\n b: dict[int, str] = {}; return b",
+                      1,
+                      dict_ann=[int])
+
+    def test_typeof_ann_arg(self):
+        self.run_test("def typeof_ann_arg(a):\n b: dict[int, type(a)] = {}; return b",
+                      1,
+                      typeof_ann_arg=[int])
+
+    def test_typeof_ann_local(self):
+        self.run_test("def typeof_ann_local(a):\n c = a + 1\n b: list[type(c)] = []; return b * a, c",
+                      1,
+                      typeof_ann_local=[int])
+
+    def test_typeof_ann_expr(self):
+        self.run_test("def typeof_ann_expr(a):\n b: list[type(a * 2)] = []; return b * a",
+                      1,
+                      typeof_ann_expr=[int])
+
+    def test_typeof_ann_backward(self):
+        self.run_test("""
+import numpy as np
+def poo(b, a):
+    b.append(a)
+    b.append(2)
+
+def typeof_ann_backward(a):
+    b = []
+    c : type(b) = []
+    poo(b, a)
+    return b, c""",
+                      1,
+                      typeof_ann_backward=[int])
+
+    def test_np_int_ann(self):
+        self.run_test("import numpy as np\ndef npint_ann(a):\n b: np.int8 = 1; return a + b",
+                      1,
+                      npint_ann=[int])
+
+    def test_np_ndarray_ann(self):
+        self.run_test("import numpy as np\ndef npndarray_ann(a):\n b: np.ndarray[np.float32, 2] = np.ones((400,4), dtype=np.float32); return a + b",
+                      1,
+                      npndarray_ann=[int])
+

--- a/pythran/types/tog.py
+++ b/pythran/types/tog.py
@@ -953,6 +953,18 @@ def analyse(node, env, non_generic=None):
                         defn_type),
                     node)
         return env
+    elif isinstance(node, ast.AnnAssign):
+        defn_type = analyse(node.value, env, non_generic)
+        target_type = analyse(node.target, env, non_generic)
+        try:
+            unify(target_type, defn_type)
+        except InferenceError:
+            raise PythranTypeError(
+                "Invalid assignment from type `{}` to type `{}`".format(
+                    target_type,
+                    defn_type),
+                node)
+        return env
     elif isinstance(node, ast.AugAssign):
         # FIMXE: not optimal: evaluates type of node.value twice
         fake_target = deepcopy(node.target)

--- a/pythran/types/type_dependencies.py
+++ b/pythran/types/type_dependencies.py
@@ -334,15 +334,20 @@ class TypeDependencies(ModuleAnalysis):
         It is valid for subscript, `a[i] = foo()` means `a` type depend on
         `foo` return type.
         """
-        if not node.value:
-            return
         value_deps = self.visit(node.value)
-        targets = node.targets if isinstance(node, ast.Assign) else (node.target,)
-        for target in targets:
+        for target in node.targets:
             name = get_variable(target)
             if isinstance(name, ast.Name):
                 self.naming[name.id] = value_deps
-    visit_AnnAssign = visit_Assign
+
+    def visit_AnnAssign(self, node):
+        deps = []
+        if node.value:
+            deps.extend(self.visit(node.value))
+        deps.extend(self.visit(node.annotation))
+        name = get_variable(node.target)
+        if isinstance(name, ast.Name):
+            self.naming[name.id] = deps
 
     def visit_AugAssign(self, node):
         """


### PR DESCRIPTION
Pythran now understands type annotation attached to assignments. The type information takes precedence over the deduced type, which helps resolving issues with empty list / dict / set pythran previously had.

This patch does *not* add support for function return types, not does it changes anything in pythran decoration. Instead, it just adds support for local variable types.

Supported annotations are:

- bool / int / float / str
- tuple / list / set / dict
- plain ndarray (no view / transposed etc)
- numpy scalar types (int8, float32, complex128 etc)

It also supports deducing type from existing variables through `type(...)`, as in

   a = foo(...)
   b : list[type(a)] = []

which helps keeping the genericity of pythran code :-)