### PR TITLE
Remove any usage of __PYTHRAN__ macro

### DIFF
--- a/pythran/config.py
+++ b/pythran/config.py
@@ -197,8 +197,6 @@ def make_extension(python, **extra):
 
     if python:
         extension['define_macros'].append('ENABLE_PYTHON_MODULE')
-    extension['define_macros'].append(
-        '__PYTHRAN__={}'.format(sys.version_info.major))
 
     pythonic_dir = get_include()
 

--- a/pythran/pythonic/builtins/oct.hpp
+++ b/pythran/pythonic/builtins/oct.hpp
@@ -17,13 +17,7 @@ namespace builtins
   types::str oct(T const &v)
   {
     std::ostringstream oss;
-    oss <<
-#if defined(__PYTHRAN__) && __PYTHRAN__ == 3
-        "0o"
-#else
-        '0'
-#endif
-        << std::oct << v;
+    oss << "0o" << std::oct << v;
     return oss.str();
   }
 } // namespace builtins


### PR DESCRIPTION
It was only used once, as a legacy of Python 2 support (see 36d11d0d351d846b1a977746350f2d182ea21671 for the origin of the remaining piece of code). This should make #2257 easier too.