### PR TITLE
ENH: improvements to pythran-config for build system integration

### DIFF
--- a/.github/workflows/no-setuptools.yml
+++ b/.github/workflows/no-setuptools.yml
@@ -27,6 +27,9 @@ jobs:
       run: |
         python -m pip install .
         python -m pip uninstall -y setuptools  # the goal of that check is to test codegen without setuptools
+    - name: Testing pythran-config
+      run: |
+        pythran-config --cflags-pythran-only
     - name: Testing scipy
       run: |
         find pythran/tests/scipy/ -name '*.py' -exec pythran -E {} \;


### PR DESCRIPTION
xref gh-2257. Putting this up for discussion early, with some comments. I considered adding `--config compiler.blas=none|openblas` support, but that then also has to interact with `--cflags` etc., so it's not clear that that works well for inclusion in 0.17.1 - and this can be added later.

The `--cflags-pythran-only` is the only thing we need for SciPy. It allows me to remove all this special handling:
https://github.com/scipy/scipy/blob/b98e79e4b326bf3beb4d861a744101ee7f438471/scipy/meson.build#L103-L138

and replace it with:
```meson
pythran_dep = []
if use_pythran
  pythran_dep = dependency('pythran', version: '>=0.17.1')
endif
```