### PR TITLE
Fix pythran support for numpy.float128

### DIFF
--- a/pythran/pythonic/include/numpy/float128.hpp
+++ b/pythran/pythonic/include/numpy/float128.hpp
@@ -12,7 +12,11 @@ namespace numpy
   namespace details
   {
 
-    long double float128();
+    inline long double float128()
+    {
+      return {};
+    }
+
     template <class V>
     long double float128(V v);
   } // namespace details

--- a/pythran/pythonic/include/types/ndarray.hpp
+++ b/pythran/pythonic/include/types/ndarray.hpp
@@ -17,10 +17,12 @@
 #include "pythonic/include/types/tuple.hpp"
 
 #include "pythonic/include/numpy/bool_.hpp"
+#include "pythonic/include/numpy/complex256.hpp"
 #include "pythonic/include/numpy/complex128.hpp"
 #include "pythonic/include/numpy/complex64.hpp"
 #include "pythonic/include/numpy/float32.hpp"
 #include "pythonic/include/numpy/float64.hpp"
+#include "pythonic/include/numpy/float128.hpp"
 #include "pythonic/include/numpy/int16.hpp"
 #include "pythonic/include/numpy/int32.hpp"
 #include "pythonic/include/numpy/int64.hpp"
@@ -798,6 +800,10 @@ namespace types
     template <>
     struct dtype_helper<double> {
       using type = pythonic::numpy::functor::float64;
+    };
+    template <>
+    struct dtype_helper<long double> {
+      using type = pythonic::numpy::functor::float128;
     };
     template <>
     struct dtype_helper<std::complex<float>> {

--- a/pythran/pythonic/numpy/float128.hpp
+++ b/pythran/pythonic/numpy/float128.hpp
@@ -15,11 +15,6 @@ namespace numpy
   namespace details
   {
 
-    inline long double float128()
-    {
-      return {};
-    }
-
     template <class V>
     long double float128(V v)
     {

--- a/pythran/tests/test_numpy_func2.py
+++ b/pythran/tests/test_numpy_func2.py
@@ -206,6 +206,12 @@ class TestNumpyFunc2(TestEnv):
                   numpy.arange(10,dtype=float),
                   np_convolve_2=[NDArray[float,:],NDArray[float,:]])
 
+    def test_convolve_2b(self):
+        self.run_test("def np_convolve_2b(a,b):\n from numpy import convolve\n return convolve(a,b)",
+                  numpy.arange(12,dtype=numpy.float128),
+                  numpy.arange(10,dtype=numpy.float128),
+                  np_convolve_2b=[NDArray[numpy.float128,:],NDArray[numpy.float128,:]])
+
     def test_convolve_3(self):
         self.run_test("def np_convolve_3(a,b):\n from numpy import convolve\n return convolve(a,b,'valid')",
                   numpy.arange(12,dtype=float),


### PR DESCRIPTION
Related to #2275, but it's not enough to match scipy.signal.convolve performance.