### PR TITLE
replace quansight-labs/setup-python with actions/setup-python

### DIFF
--- a/.github/workflows/freethreading.yml
+++ b/.github/workflows/freethreading.yml
@@ -22,7 +22,7 @@ jobs:
         sudo apt install ${{ matrix.cpp-version }}
         sudo apt install libopenblas-dev  # for meson integration testing
     - name: Setup Python ${{ matrix.python-version }}
-      uses: quansight-labs/setup-python@v5.3.1
+      uses: actions/setup-python@v5.5.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
The changes in the fork were upstreamed and released in 5.5.0. See https://github.com/actions/setup-python/releases/tag/v5.5.0.