### PR TITLE
Add missing operators to nditerator

### DIFF
--- a/pythran/pythonic/include/types/nditerator.hpp
+++ b/pythran/pythonic/include/types/nditerator.hpp
@@ -66,6 +66,9 @@ namespace types
     bool operator!=(nditerator<E> const &other) const;
     bool operator==(nditerator<E> const &other) const;
     bool operator<(nditerator<E> const &other) const;
+    bool operator>(nditerator<E> const &other) const;
+    bool operator<=(nditerator<E> const &other) const;
+    bool operator>=(nditerator<E> const &other) const;
     nditerator &operator=(nditerator const &other);
   };
 
@@ -92,6 +95,9 @@ namespace types
     bool operator!=(const_nditerator<E> const &other) const;
     bool operator==(const_nditerator<E> const &other) const;
     bool operator<(const_nditerator<E> const &other) const;
+    bool operator>(const_nditerator<E> const &other) const;
+    bool operator<=(const_nditerator<E> const &other) const;
+    bool operator>=(const_nditerator<E> const &other) const;
     const_nditerator &operator=(const_nditerator const &other);
   };
 #ifdef USE_XSIMD
@@ -115,6 +121,9 @@ namespace types
     bool operator!=(const_simd_nditerator const &other) const;
     bool operator==(const_simd_nditerator const &other) const;
     bool operator<(const_simd_nditerator const &other) const;
+    bool operator>(const_simd_nditerator const &other) const;
+    bool operator<=(const_simd_nditerator const &other) const;
+    bool operator>=(const_simd_nditerator const &other) const;
     const_simd_nditerator &operator=(const_simd_nditerator const &other);
     void store(xsimd::batch<typename E::dtype> const &);
   };

--- a/pythran/pythonic/types/nditerator.hpp
+++ b/pythran/pythonic/types/nditerator.hpp
@@ -98,6 +98,24 @@ namespace types
   }
 
   template <class E>
+  bool nditerator<E>::operator>(nditerator<E> const &other) const
+  {
+    return index > other.index;
+  }
+
+  template <class E>
+  bool nditerator<E>::operator<=(nditerator<E> const &other) const
+  {
+    return !(index > other.index);
+  }
+
+  template <class E>
+  bool nditerator<E>::operator>=(nditerator<E> const &other) const
+  {
+    return !(index < other.index);
+  }
+
+  template <class E>
   nditerator<E> &nditerator<E>::operator=(nditerator<E> const &other)
   {
     assert(&data == &other.data);
@@ -189,6 +207,24 @@ namespace types
   }
 
   template <class E>
+  bool const_nditerator<E>::operator>(const_nditerator<E> const &other) const
+  {
+    return index > other.index;
+  }
+
+  template <class E>
+  bool const_nditerator<E>::operator<=(const_nditerator<E> const &other) const
+  {
+    return !(index > other.index);
+  }
+
+  template <class E>
+  bool const_nditerator<E>::operator>=(const_nditerator<E> const &other) const
+  {
+    return !(index < other.index);
+  }
+
+  template <class E>
   const_nditerator<E> &
   const_nditerator<E>::operator=(const_nditerator const &other)
   {
@@ -269,6 +305,27 @@ namespace types
       const_simd_nditerator<E> const &other) const
   {
     return data < other.data;
+  }
+
+  template <class E>
+  bool const_simd_nditerator<E>::operator>(
+      const_simd_nditerator<E> const &other) const
+  {
+    return data > other.data;
+  }
+
+  template <class E>
+  bool const_simd_nditerator<E>::operator<=(
+      const_simd_nditerator<E> const &other) const
+  {
+    return !(data > other.data);
+  }
+
+  template <class E>
+  bool const_simd_nditerator<E>::operator>=(
+      const_simd_nditerator<E> const &other) const
+  {
+    return !(data < other.data);
   }
 
   template <class E>


### PR DESCRIPTION
As nditerator implements `operator-`, it is supposed to be a random_access_iterator. Then, some comparators are missing and should be added.

pythran cannot build when `CXXFLAGS=-D_GLIBCXX_DEBUG` as https://github.com/gcc-mirror/gcc/blob/releases/gcc-14.3.0/libstdc%2B%2B-v3/include/debug/helper_functions.h#L190 uses `<=` operator:

```
scipy/interpolate/_rbfinterp_pythran.cpp:1442:130:   required from here
/usr/include/c++/10/debug/helper_functions.h:172:13: error: no match for ‘operator<=’ (operand types are ‘{anonymous}::pythonic::types::const_nditerator<{anonymous}::pythonic::types::ndarray<double, {anonymous}::pythonic::types::pshape<long int, long int> > >’ and ‘{anonymous}::pythonic::types::const_nditerator<{anonymous}::pythonic::types::ndarray<double, {anonymous}::pythonic::types::pshape<long int, long int> > >’)
  172 |  && __first <= __last;
      |     ~~~~~~~~^~~~~~~~~
```

I refered https://github.com/google/flatbuffers/pull/8309 for the implementation.

(By the way the initial motivation was similar issue in https://github.com/opencv/opencv/issues/27410)