### PR TITLE
Update gast and beniget requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ply>=3.4
 setuptools
-gast~=0.6.0
+gast~=0.7.0
 numpy
-beniget~=0.4.0
+beniget~=0.5.0


### PR DESCRIPTION
This mostly brings in better gast support for py3.12+ nodes