### PR TITLE
Add support for numpy.concat, numpy.linalg.vector_norm and numpy.lina…

### DIFF
--- a/pythran/pythonic/include/numpy/asfarray.hpp
+++ b/pythran/pythonic/include/numpy/asfarray.hpp
@@ -8,7 +8,9 @@ PYTHONIC_NS_BEGIN
 
 namespace numpy
 {
-  template <class E, class dtype = functor::float64>
+  template <class E, class dtype = std::conditional_t<
+                         types::is_complex<typename std::decay_t<E>::dtype>::value,
+                         functor::complex256, functor::float64>>
   auto asfarray(E &&e, dtype d = dtype()) -> decltype(asarray(std::forward<E>(e), d));
   DEFINE_FUNCTOR(pythonic::numpy, asfarray);
 } // namespace numpy

--- a/pythran/pythonic/include/numpy/concat.hpp
+++ b/pythran/pythonic/include/numpy/concat.hpp
@@ -1,0 +1,15 @@
+#ifndef PYTHONIC_INCLUDE_NUMPY_CONCAT_HPP
+#define PYTHONIC_INCLUDE_NUMPY_CONCAT_HPP
+
+#include "pythonic/include/numpy/concatenate.hpp"
+#include "pythonic/include/utils/functor.hpp"
+
+PYTHONIC_NS_BEGIN
+
+namespace numpy
+{
+  USING_FUNCTOR(concat, numpy::functor::concatenate);
+}
+PYTHONIC_NS_END
+
+#endif

--- a/pythran/pythonic/include/numpy/linalg/matrix_norm.hpp
+++ b/pythran/pythonic/include/numpy/linalg/matrix_norm.hpp
@@ -1,0 +1,22 @@
+#ifndef PYTHONIC_INCLUDE_NUMPY_LINALG_MATRIX_NORM_HPP
+#define PYTHONIC_INCLUDE_NUMPY_LINALG_MATRIX_NORM_HPP
+
+#include "pythonic/include/numpy/linalg/norm.hpp"
+
+PYTHONIC_NS_BEGIN
+namespace numpy
+{
+  namespace linalg
+  {
+    template <class Array, class Ord = types::str>
+    auto matrix_norm(Array &&array, bool keep_dims = true, Ord &&ord = "fro")
+    {
+      assert(keep_dims && "unsupported keep_dims=false");
+      return norm(std::forward<Array>(array), std::forward<Ord>(ord));
+    }
+    DEFINE_FUNCTOR(pythonic::numpy::linalg, matrix_norm);
+  } // namespace linalg
+} // namespace numpy
+PYTHONIC_NS_END
+
+#endif

--- a/pythran/pythonic/include/numpy/linalg/norm.hpp
+++ b/pythran/pythonic/include/numpy/linalg/norm.hpp
@@ -31,6 +31,9 @@ namespace numpy
     norm_t<Array> norm(Array &&array, double ord, types::none_type axis = {});
 
     template <class Array>
+    norm_dtype_t<Array> norm(Array &&array, types::str const &ord, types::none_type axis = {});
+
+    template <class Array>
     norm_t<Array> norm(Array &&array, types::none_type ord, double axis);
 
     template <class Array>
@@ -41,6 +44,7 @@ namespace numpy
 
     template <class Array>
     norm_t<Array> norm(Array &&array, double ord, types::array_tuple<long, 2> axis);
+
     DEFINE_FUNCTOR(pythonic::numpy::linalg, norm);
   } // namespace linalg
 } // namespace numpy

--- a/pythran/pythonic/include/numpy/linalg/vector_norm.hpp
+++ b/pythran/pythonic/include/numpy/linalg/vector_norm.hpp
@@ -1,0 +1,22 @@
+#ifndef PYTHONIC_INCLUDE_NUMPY_LINALG_VECTOR_NORM_HPP
+#define PYTHONIC_INCLUDE_NUMPY_LINALG_VECTOR_NORM_HPP
+
+#include "pythonic/include/numpy/linalg/norm.hpp"
+
+PYTHONIC_NS_BEGIN
+namespace numpy
+{
+  namespace linalg
+  {
+    template <class Array, class Axis = types::none_type, class Ord = double>
+    auto vector_norm(Array &&array, Axis &&axis = {}, bool keep_dims = true, Ord &&ord = 2)
+    {
+      assert(keep_dims && "unsupported keep_dims=false");
+      return norm(std::forward<Array>(array), std::forward<Ord>(ord), std::forward<Axis>(axis));
+    }
+    DEFINE_FUNCTOR(pythonic::numpy::linalg, vector_norm);
+  } // namespace linalg
+} // namespace numpy
+PYTHONIC_NS_END
+
+#endif

--- a/pythran/pythonic/numpy/asfarray.hpp
+++ b/pythran/pythonic/numpy/asfarray.hpp
@@ -11,7 +11,8 @@ namespace numpy
   template <class E, class dtype>
   auto asfarray(E &&e, dtype d) -> decltype(asarray(std::forward<E>(e), d))
   {
-    static_assert(std::is_floating_point<typename dtype::type>::value,
+    static_assert(std::is_floating_point<typename dtype::type>::value ||
+                      types::is_complex<typename dtype::type>::value,
                   "expected a floating point type");
     return asarray(std::forward<E>(e), d);
   }

--- a/pythran/pythonic/numpy/concat.hpp
+++ b/pythran/pythonic/numpy/concat.hpp
@@ -1,0 +1,7 @@
+#ifndef PYTHONIC_NUMPY_CONCAT_HPP
+#define PYTHONIC_NUMPY_CONCAT_HPP
+
+#include "pythonic/include/numpy/concat.hpp"
+#include "pythonic/numpy/concatenate.hpp"
+
+#endif

--- a/pythran/pythonic/numpy/linalg/matrix_norm.hpp
+++ b/pythran/pythonic/numpy/linalg/matrix_norm.hpp
@@ -1,0 +1,6 @@
+#ifndef PYTHONIC_NUMPY_LINALG_MATRIX_NORM_HPP
+#define PYTHONIC_NUMPY_LINALG_MATRIX_NORM_HPP
+#include "pythonic/include/numpy/linalg/matrix_norm.hpp"
+#include "pythonic/numpy/linalg/norm.hpp"
+
+#endif

--- a/pythran/pythonic/numpy/linalg/norm.hpp
+++ b/pythran/pythonic/numpy/linalg/norm.hpp
@@ -41,6 +41,21 @@ namespace numpy
     }
 
     template <class Array>
+    norm_dtype_t<Array> norm(Array &&x, types::str const &ord, types::none_type)
+    {
+      switch (std::decay_t<Array>::value) {
+      case 2:
+        if (ord == "fro")
+          return pythonic::numpy::functor::sqrt{}(pythonic::numpy::functor::sum{}(
+              pythonic::numpy::functor::real{}(pythonic::numpy::functor::conj{}(x)*x)));
+        else
+          throw pythonic::builtins::NotImplementedError("We need more dev!");
+      default:
+        throw pythonic::builtins::NotImplementedError("Invalid norm order for matrices.");
+      }
+    }
+
+    template <class Array>
     norm_t<Array> norm(Array &&x, double ord, long axis)
     {
       auto &&y = pythonic::numpy::functor::asfarray{}(x);
@@ -62,6 +77,7 @@ namespace numpy
             1. / ord);
       }
     }
+
     template <class Array>
     norm_t<Array> norm(Array &&x, types::none_type ord, double axis)
     {
@@ -77,6 +93,7 @@ namespace numpy
     {
       throw pythonic::builtins::NotImplementedError("We need more dev!");
     }
+
   } // namespace linalg
 } // namespace numpy
 PYTHONIC_NS_END

--- a/pythran/pythonic/numpy/linalg/vector_norm.hpp
+++ b/pythran/pythonic/numpy/linalg/vector_norm.hpp
@@ -1,0 +1,6 @@
+#ifndef PYTHONIC_NUMPY_LINALG_VECTOR_NORM_HPP
+#define PYTHONIC_NUMPY_LINALG_VECTOR_NORM_HPP
+#include "pythonic/include/numpy/linalg/vector_norm.hpp"
+#include "pythonic/numpy/linalg/norm.hpp"
+
+#endif

--- a/pythran/tables.py
+++ b/pythran/tables.py
@@ -3820,7 +3820,9 @@ MODULES = {
         "lexsort": ConstFunctionIntr(),
         "linalg": {
             "norm": FunctionIntr(),
+            "matrix_norm": FunctionIntr(),
             "matrix_power": ConstFunctionIntr(requires_blas=True),
+            "vector_norm": FunctionIntr(),
         },
         "linspace": ConstFunctionIntr(),
         "log": ConstFunctionIntr(),
@@ -4559,6 +4561,9 @@ if 'VMSError' in sys.modules['builtins'].__dict__:
 # WindowsError is only available on Windows
 if 'WindowsError' in sys.modules['builtins'].__dict__:
     MODULES['builtins']['WindowsError'] = ConstExceptionIntr()
+
+# numpy alias
+MODULES['numpy']['concat'] = MODULES['numpy']['concatenate']
 
 # detect and prune unsupported modules
 for module_name in ["omp", "scipy", "scipy.special"]:

--- a/pythran/tests/test_numpy_func2.py
+++ b/pythran/tests/test_numpy_func2.py
@@ -330,6 +330,9 @@ def test_copy0(x):
     def test_concatenate3(self):
         self.run_test("def np_concatenate3(a): from numpy import array, concatenate ; return concatenate([[1],a + a])", numpy.array([1, 2]), np_concatenate3=[NDArray[int,:]])
 
+    def test_concatenate4(self):
+        self.run_test("def np_concatenate4(a): from numpy import array, concat ; return concat([[1],a + a])", numpy.array([1, 2]), np_concatenate4=[NDArray[int,:]])
+
     def test_hstack_empty(self):
         code = 'def np_test_stack_empty(a): import numpy as np;return np.stack(a)'
         with self.assertRaises(ValueError):

--- a/pythran/tests/test_numpy_linalg.py
+++ b/pythran/tests/test_numpy_linalg.py
@@ -56,3 +56,24 @@ class TestNumpyLinalg(TestEnv):
                               LA.norm(c, ord=1, axis=1),
                      )''',
                       10, linalg_norm_pydoc=[int])
+
+    def test_linalg_matrix_norm0(self):
+        self.run_test("def linalg_matrix_norm0(x): from numpy.linalg import matrix_norm ; return matrix_norm(x)",
+                      numpy.arange(6.).reshape((3,2)),
+                      linalg_matrix_norm0=[NDArray[float,:,:]])
+
+    def test_linalg_matrix_norm1(self):
+        self.run_test("def linalg_matrix_norm1(x): from numpy.linalg import matrix_norm ; return matrix_norm(x)",
+                      numpy.arange(6.).reshape((3,2)) * 1j + 2,
+                      linalg_matrix_norm1=[NDArray[complex,:,:]])
+
+    def test_linalg_vector_norm0(self):
+        self.run_test("def linalg_vector_norm0(x): from numpy.linalg import vector_norm ; return vector_norm(x)",
+                      numpy.arange(6.),
+                      linalg_vector_norm0=[NDArray[float,:]])
+
+    def test_linalg_vector_norm1(self):
+        self.run_test("def linalg_vector_norm1(x): from numpy.linalg import vector_norm ; return vector_norm(x)",
+                      numpy.arange(6.) * 1j - 2,
+                      linalg_vector_norm1=[NDArray[complex,:]])
+


### PR DESCRIPTION
…lg.matrix_norm

Not all arguments of vector_norm and matrix_norm are implemented, but the default should be ok.

Fix #2379