### PR TITLE
Simplify generated expression for lazy and assignable_noescape types

### DIFF
--- a/pythran/backend.py
+++ b/pythran/backend.py
@@ -444,21 +444,15 @@ class CxxFunction(ast.NodeVisitor):
                                             alltargets)
             elif isinstance(self.types[targets[0]],
                             self.types.builder.Assignable):
-                alltargets = '{} {}'.format(
-                    self.types.builder.AssignableNoEscape(
-                        self.types.builder.NamedType(
-                            'decltype({})'.format(value))).sgenerate(),
-                    alltargets)
+                alltargets = 'auto {}'.format(alltargets)
+                value = 'pythonic::make_assignable_noescape({})'.format(value)
             else:
                 assert isinstance(self.types[targets[0]],
                                   (self.types.builder.Lazy,
                                    self.types.builder.NamedType,
                                    self.types.builder.ListType))
-                alltargets = '{} {}'.format(
-                    self.types.builder.Lazy(
-                        self.types.builder.NamedType(
-                            'decltype({})'.format(value))).sgenerate(),
-                    alltargets)
+                alltargets = 'auto {}'.format(alltargets)
+                value = 'pythonic::make_lazy({})'.format(value)
         stmt = Assign(alltargets, value)
         return self.process_omp_attachements(node, stmt)
 

--- a/pythran/pythonic/include/types/assignable.hpp
+++ b/pythran/pythonic/include/types/assignable.hpp
@@ -71,9 +71,20 @@ template <class T>
 struct assignable<T &&> : assignable<T> {
 };
 
+template<class T>
+typename assignable<T>::type make_assignable(T&& val) {
+  return std::forward<T>(val);
+}
+
+
 template <class T>
 struct lazy : assignable<T> {
 }; // very conservative
+
+template<class T>
+typename lazy<T>::type make_lazy(T&& val) {
+  return std::forward<T>(val);
+}
 
 template <class T>
 struct assignable_noescape : assignable<T> {
@@ -94,6 +105,11 @@ struct assignable_noescape<T &> : assignable_noescape<T> {
 template <class T>
 struct assignable_noescape<T &&> : assignable_noescape<T> {
 };
+
+template<class T>
+typename assignable_noescape<T>::type make_assignable_noescape(T&& val) {
+  return std::forward<T>(val);
+}
 
 template <class T>
 struct returnable : assignable<T> {

--- a/pythran/pythonic/include/types/file.hpp
+++ b/pythran/pythonic/include/types/file.hpp
@@ -31,6 +31,7 @@ namespace types
 
   public:
     file_iterator(file &ref);
+    file_iterator(file &ref, file_iterator const &from);
     file_iterator();
     bool operator==(file_iterator const &f2) const;
     bool operator!=(file_iterator const &f2) const;
@@ -42,6 +43,7 @@ namespace types
   struct _file {
     FILE *f;
     _file();
+    _file(const _file &) = delete;
     _file(types::str const &filename, types::str const &strmode = "r");
     FILE *operator*() const;
     ~_file();
@@ -63,6 +65,15 @@ namespace types
 
     // Constructors
     file();
+    file(file &&other) noexcept
+        : file_iterator(*this, other), data(std::move(other.data)), is_open(other.is_open),
+          mode(std::move(other.mode)), name(std::move(other.name)),
+          newlines(std::move(other.newlines))
+    {
+    }
+
+    file(file const &other) = default;
+
     file(types::str const &filename, types::str const &strmode = "r");
 
     // Iterators

--- a/pythran/pythonic/include/utils/iterator.hpp
+++ b/pythran/pythonic/include/utils/iterator.hpp
@@ -25,7 +25,7 @@ namespace utils
   template <class T, class... Others>
   struct iterator_reminder<true, T, Others...> {
     std::tuple<T, Others...> values;
-    // FIXME : It works only because template arguments are ! references
+    // FIXME : It works only because template arguments are not references
     // so it trigger a copy.
     iterator_reminder() = default;
     iterator_reminder(T const &v, Others const &...o);

--- a/pythran/pythonic/types/file.hpp
+++ b/pythran/pythonic/types/file.hpp
@@ -35,7 +35,7 @@ namespace types
   {
   }
 
-  // TODO : no check on file existance?
+  // TODO : no check on file existence?
   inline _file::_file(types::str const &filename, types::str const &strmode)
       : f(fopen(filename.c_str(), strmode.c_str()))
   {
@@ -264,6 +264,10 @@ namespace types
   // for line in open("myfile"):
   //     print line
   inline file_iterator::file_iterator(file &ref) : f(&ref), set(false), position(ref.tell())
+  {
+  }
+  inline file_iterator::file_iterator(file &ref, file_iterator const &from)
+      : f(&ref), set(from.set), curr(from.curr), position(from.position)
   {
   }
 


### PR DESCRIPTION
As a side effect it also fixes the first compiler crash from #2265, although the example code from there still does not compile.