### PR TITLE
Fix typing of array.typecodes for Python 3.15

### DIFF
--- a/pythran/intrinsic.py
+++ b/pythran/intrinsic.py
@@ -255,6 +255,8 @@ class ConstantIntr(Intrinsic):
         """ Forward arguments and remove arguments effects. """
         kwargs["argument_effects"] = ()
         super(ConstantIntr, self).__init__(**kwargs)
+        if 'signature' in kwargs:
+            self.signature = kwargs['signature']
 
     def isliteral(self):
         """ Mark this intrinsic as a literal. """

--- a/pythran/tables.py
+++ b/pythran/tables.py
@@ -4731,9 +4731,10 @@ def fill_constants_types(module_name, elements):
         if isinstance(intrinsic, dict):  # Submodule case
             fill_constants_types(module_name + (elem,), intrinsic)
         elif isinstance(intrinsic, ConstantIntr):
-            # use introspection to get the Python constants types
-            cst = getattr(import_module(".".join(module_name)), elem)
-            intrinsic.signature = type(cst)
+            if not hasattr(intrinsic, 'signature'):
+                # use introspection to get the Python constants types
+                cst = getattr(import_module(".".join(module_name)), elem)
+                intrinsic.signature = type(cst)
 
 
 fill_constants_types((), MODULES)


### PR DESCRIPTION
Python 3.15 changed array.typecodes from str to tuple to support type codes longer than 1 character (Zf and Zd).
See https://github.com/python/cpython/issues/148675

Pythran's fill_constants_types() uses type() introspection on live Python constants to set signatures, which now produces tuple instead of str. Meanwhile, the explicit ConstantIntr(signature=str) was silently ignored because ConstantIntr.__init__ never stored it.

Fix ConstantIntr to preserve an explicitly provided signature, and skip introspection in fill_constants_types when one is already set.

Without the fix, pytest pythran/tests/test_array.py -k test_typecodes fails with:

```
        else:
>           raise NotImplementedError(t)
E           NotImplementedError: <class 'tuple'>

pythran/types/tog.py:480: NotImplementedError
```

Assisted-By: Claude Opus 4.6