### PR TITLE
Fix broadcasting issue.

### DIFF
--- a/pythran/pythonic/numpy/reduce.hpp
+++ b/pythran/pythonic/numpy/reduce.hpp
@@ -139,7 +139,7 @@ namespace numpy
     template <class T>
     reduce_result_type<Op, E> operator()(E const &expr, T p) const
     {
-      if (utils::no_broadcast_vectorize(expr))
+      if (utils::no_broadcast_ex(expr))
         return _reduce<Op, E::value, types::vectorizer_nobroadcast>{}(expr, p);
       else
         return _reduce<Op, E::value, types::vectorizer>{}(expr, p);

--- a/pythran/tests/test_numpy_broadcasting.py
+++ b/pythran/tests/test_numpy_broadcasting.py
@@ -232,3 +232,9 @@ class TestBroadcasting(TestEnv):
             data[1:] = np.ones([1, n - 1])
             return data'''
         self.run_test(code, 4, downcasting1=[int])
+
+    def test_broadcast_sum_runtime_shape(self):
+        self.run_test('def broadcast_sum_runtime_shape(a, b): return float((a * b).sum())',
+                      np.array([[1.0], [2.0]]),
+                      np.array([[10.0, 20.0, 30.0], [10.0, 20.0, 30.0]]),
+                      broadcast_sum_runtime_shape=[NDArray[float, :, :], NDArray[float, :, :]])


### PR DESCRIPTION
I used claude code to diagnose and fix the broadcasting issue (hard to believe we've never encountered it before).
Jean

Fix _no_broadcast_vectorize on inner-dim broadcast with runtime shape

The check only compared arg.shape<0>() == size(), so a broadcast on
a non-outer dim (e.g. a (2,1) arg from expand_dims against (2,3))
got mis-classified as "no broadcast" when the arg's shape type was
fully runtime (no integral_constant<long, 1> marker). Mirror
_no_broadcast_ex by comparing the full shape with the
is_trivial_broadcast short-circuit. Also adds .copy() to numpy_expr.
