### PR TITLE
Fix interaction between as np.asarray and array slices

### DIFF
--- a/pythran/pythonic/include/numpy/asarray.hpp
+++ b/pythran/pythonic/include/numpy/asarray.hpp
@@ -21,6 +21,10 @@ namespace numpy
     F &&operator()(F &&a, dtype d = types::none_type());
   };
 
+  template <class Arg, class... S, class T>
+  struct _asarray<types::numpy_gexpr<Arg, S...>, T> : _asarray<std::decay_t<Arg>, T> {
+  };
+
   template <class E>
   auto asarray(E &&e, types::none_type d = types::none_type())
       -> decltype(_asarray<std::decay_t<E>, typename types::dtype_of<std::decay_t<E>>::type>{}(

--- a/pythran/pythonic/numpy/append.hpp
+++ b/pythran/pythonic/numpy/append.hpp
@@ -3,7 +3,7 @@
 
 #include "pythonic/include/numpy/append.hpp"
 
-#include "pythonic/numpy/asarray.hpp"
+#include "pythonic/numpy/ndarray/flatten.hpp"
 #include "pythonic/types/ndarray.hpp"
 #include "pythonic/utils/functor.hpp"
 
@@ -17,7 +17,7 @@ namespace numpy
                                   types::pshape<long>>>
   append(types::ndarray<T, pS> const &nto, F const &data)
   {
-    auto ndata = numpy::functor::asarray{}(data);
+    auto ndata = numpy::ndarray::functor::flatten{}(data);
     long nsize = nto.flat_size() + ndata.flat_size();
     types::ndarray<typename __combined<T, typename types::dtype_of<F>::type>::type,
                    types::pshape<long>>
@@ -47,7 +47,7 @@ namespace numpy
                  types::pshape<long>>
   append(T const &to, F const &data)
   {
-    return append(numpy::functor::asarray{}(to), data);
+    return append(numpy::ndarray::functor::flatten{}(to), data);
   }
 } // namespace numpy
 PYTHONIC_NS_END

--- a/pythran/pythonic/numpy/copyto.hpp
+++ b/pythran/pythonic/numpy/copyto.hpp
@@ -1,7 +1,7 @@
 #ifndef PYTHONIC_NUMPY_COPYTO_HPP
 #define PYTHONIC_NUMPY_COPYTO_HPP
 
-#include "pythonic//numpy/asarray.hpp"
+#include "pythonic//numpy/array.hpp"
 #include "pythonic/include/numpy/copyto.hpp"
 
 #include "pythonic/types/ndarray.hpp"
@@ -15,7 +15,7 @@ namespace numpy
   {
     using out_type = types::ndarray<T, pS>;
     if (may_overlap(out, expr)) {
-      auto aexpr = asarray(expr);
+      auto aexpr = array(expr);
       utils::broadcast_copy<
           out_type &, decltype(aexpr), out_type::value,
           (int)out_type::value - (int)utils::dim_of<E>::value,
@@ -43,7 +43,7 @@ namespace numpy
   {
     using out_type = types::numpy_texpr<types::ndarray<T, pS>>;
     if (may_overlap(out, expr)) {
-      auto aexpr = asarray(expr);
+      auto aexpr = array(expr);
       utils::broadcast_copy<
           out_type &, decltype(aexpr), out_type::value,
           (int)out_type::value - (int)utils::dim_of<E>::value,

--- a/pythran/tests/test_numpy_func2.py
+++ b/pythran/tests/test_numpy_func2.py
@@ -562,6 +562,11 @@ def test_copy0(x):
     def test_asarray6(self):
         self.run_test("def np_asarray6(a):\n from numpy import asarray\n return asarray(a, dtype=int)", 1.5, np_asarray6=[float])
 
+    def test_asarray7(self):
+        self.run_test("def np_asarray7(a):\n from numpy import asarray; x = asarray(a[:-1]); y = asarray(x); y[0] = 1; return x[0], y[0]",
+                      numpy.array([0, 1, 2, 3]),
+                      np_asarray7=[NDArray[int, :]])
+
     if hasattr(numpy, 'farray'):
         def test_asfarray0(self):
             self.run_test("def np_asfarray0(a):\n from numpy import asfarray; b = asfarray(a) ; return a is b", numpy.arange(3.), np_asfarray0=[NDArray[float,:]])


### PR DESCRIPTION
Array slices are still arrays for np.asarray.

Fix #2460, by courtesy of @jeanlaroche for the reproducer.