### PR TITLE
Improve numpy_expr with ndarray combiner

### DIFF
--- a/pythran/pythonic/include/types/numpy_expr.hpp
+++ b/pythran/pythonic/include/types/numpy_expr.hpp
@@ -851,7 +851,10 @@ struct __combined<pythonic::types::numpy_expr<Op, Args...>, pythonic::types::num
 
 template <class T, class pS, class Op, class... Args>
 struct __combined<pythonic::types::numpy_expr<Op, Args...>, pythonic::types::ndarray<T, pS>> {
-  using type = pythonic::types::ndarray<T, pS>;
+  using type = pythonic::types::ndarray<
+    typename __combined<typename pythonic::types::numpy_expr<Op, Args...>::dtype,
+             T>::type,
+             pythonic::sutils::merged_shapes_t<pythonic::types::ndarray<T, pS>::value, typename pythonic::types::numpy_expr<Op, Args...>::shape_t, pS>>;
 };
 
 template <class T, class Op, class... Args>

--- a/pythran/tests/test_ndarray.py
+++ b/pythran/tests/test_ndarray.py
@@ -1700,3 +1700,13 @@ def test_combiner_5(a, idx, k):
                       numpy.array([0, 2, 4,]),
                       1,
                       test_combiner_5=[NDArray[float,:], NDArray[int, :],int])
+
+    def test_combiner_7(self):
+        code = '''
+import numpy as np
+def test_combiner_7(a, k):
+    x = (a + 1) if k else np.zeros(3)
+    return np.sum(x)
+'''
+        self.run_test(code, numpy.ones(10), 1,
+                      test_combiner_7=[NDArray[float,:], int])


### PR DESCRIPTION
Honor type combination and shape merging correctly.

By courtesy of @jeanlaroche for the initial reproducer.

Fix #2454