### PR TITLE
Fix unnecessary complexity in return_alias computation

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15.0-beta.1", "pypy-3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "pypy-3.11"]
         cpp-version: [g++-12, clang-13]
     steps:
     - uses: actions/checkout@v6

--- a/pythran/analyses/aliases.py
+++ b/pythran/analyses/aliases.py
@@ -248,15 +248,24 @@ class Aliases(ModuleAnalysis[GlobalDeclarations]):
         >>> module.body[0].return_alias # doctest: +ELLIPSIS
         <function ...merge_return_aliases at...>
 
-        This field is a function that takes as many nodes as the function
-        argument count as input and returns an expression based on
+        This field is a function that takes as many sets as the function
+        argument count as input and returns a list of expression based on
         these arguments if the function happens to create aliasing
         between its input and output. In our case:
 
         >>> f = module.body[0].return_alias
-        >>> Aliases.dump(f([ast.Name('A', ast.Load(), None, None),
-        ...                 ast.Constant(1, None)]))
+        >>> Aliases.dump(f([{ast.Name('A', ast.Load(), None, None)},
+        ...                 {ast.Constant(1, None)}]))
         ['A']
+
+        If an argument may alias to several nodes, this is also taken into
+        account:
+
+        >>> f = module.body[0].return_alias
+        >>> Aliases.dump(f([{ast.Name('A', ast.Load(), None, None),
+        ...                  ast.Name('B', ast.Load(), None, None)},
+        ...                 {ast.Constant(1, None)}]))
+        ['A', 'B']
 
         This also works if the relationship between input and output
         is more complex:
@@ -264,14 +273,15 @@ class Aliases(ModuleAnalysis[GlobalDeclarations]):
         >>> module = ast.parse('def foo(a, b): return a or b[0]')
         >>> result = pm.gather(Aliases, module)
         >>> f = module.body[0].return_alias
-        >>> List = ast.List([ast.Name('L0', ast.Load(), None, None)],
+        >>> List = ast.List([ast.Name('E', ast.Load(), None, None)],
         ...                 ast.Load())
-        >>> Aliases.dump(f([ast.Name('B', ast.Load(), None, None), List]))
-        ['B', '[L0][0]']
+        >>> Aliases.dump(f([{ast.Name('A', ast.Load(), None, None), ast.Name('B', ast.Load(), None, None)}, {List}]))
+        ['A', 'B', '[E][0]']
 
-        Which actually means that when called with two arguments ``B`` and
-        the single-element list ``[L[0]]``, ``foo`` may returns either the
-        first argument, or the first element of the second argument.
+        Which actually means that when called with two arguments: ``A`` or
+        ``B``, and the single-element list ``[E]``, ``foo`` may return
+        either the first argument, or the first element of the second argument,
+        a.k.a ``E``.
         '''
         if not node.value:
             return
@@ -283,18 +293,17 @@ class Aliases(ModuleAnalysis[GlobalDeclarations]):
     def call_return_alias(self, node):
 
         def interprocedural_aliases(func, args):
-            arg_aliases = [self.result[arg] or {arg} for arg in args]
+            args_aliases = [self.result[arg] or {arg} for arg in args]
             return_aliases = set()
-            for args_combination in product(*arg_aliases):
-                for ra in func.return_alias(args_combination):
-                    if isinstance(ra, ast.Subscript):
-                        if isinstance(ra.value, ContainerOf):
-                            if np.isnan(ra.value.index) or (isnum(ra.slice) and
-                                                            ra.slice.value ==
-                                                            ra.value.index):
-                                return_aliases.update(ra.value.containees)
-                            continue
-                    return_aliases.add(ra)
+            for ra in func.return_alias(args_aliases):
+                if isinstance(ra, ast.Subscript):
+                    if isinstance(ra.value, ContainerOf):
+                        if np.isnan(ra.value.index) or (isnum(ra.slice) and
+                                                        ra.slice.value ==
+                                                        ra.value.index):
+                            return_aliases.update(ra.value.containees)
+                        continue
+                return_aliases.add(ra)
             return return_aliases
 
         def full_args(func, call):
@@ -604,7 +613,7 @@ class Aliases(ModuleAnalysis[GlobalDeclarations]):
 
                         def return_alias(args):
                             if w < len(args):
-                                return {args[w]}
+                                return args[w]
                             else:
                                 return {node.args.defaults[w - len(args)]}
                         return return_alias

--- a/pythran/tables.py
+++ b/pythran/tables.py
@@ -457,8 +457,10 @@ CLASSES = {
                 Fun[[Dict[T0, T1], T0], T1]
             ],
             return_alias=lambda args: {
-                ast.Subscript(args[0], args[1], ast.Load())
-            }.union({args[2]} if len(args) == 3 else set())
+                ast.Subscript(arg0, arg1, ast.Load())
+                              for arg0 in args[0]
+                              for arg1 in args[1]
+            }.union(args[2] if len(args) == 3 else set())
         ),
         "update": MethodIntr(update_effects),
         "values": ConstMethodIntr(signature=Fun[[Dict[T0, T1]], List[T1]]),
@@ -2775,7 +2777,7 @@ MODULES = {
             "abssqr": ConstFunctionIntr(),
             "static_list": ReadOnceFunctionIntr(
                 signature=Fun[[Iterable[T0]], List[T0]],
-                return_alias=lambda args: {args[0]}),
+                return_alias=lambda args: args[0]),
             "is_none": ConstFunctionIntr(),
             "kwonly": ConstFunctionIntr(),
             "len_set": ConstFunctionIntr(signature=Fun[[Iterable[T0]], int]),
@@ -4042,7 +4044,7 @@ MODULES = {
         # shares memory with its argument, but not the type.
         # Use a global effect to prevent the optimizer from removing it.
         "ravel": ConstMethodIntr(
-            #return_alias=lambda args: {args[0]},
+            #return_alias=lambda args: args[0],
             global_effects=True,
         ),
         "real": FunctionIntr(),

--- a/pythran/tests/test_typing.py
+++ b/pythran/tests/test_typing.py
@@ -234,6 +234,25 @@ def typing_aliasing_and_update_and_multiple_aliasing1(i):
     foo(i)(h, 1)
     return h'''
         self.run_test(code, 1, typing_aliasing_and_update_and_multiple_aliasing1=[int])
+    def test_typing_aliasing_complexity(self):
+        code = '''
+def sink(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9):
+    return a0
+
+def typing_aliasing_complexity(x):
+    b0 = x
+    b1 = x
+    b2 = x
+    b3 = x
+    b4 = x
+    b5 = x
+    b6 = x
+    b7 = x
+    b8 = x
+    b9 = x
+    return sink(b0, b1, b2, b3, b4, b5, b6, b7, b8, b9)'''
+        self.run_test(code, 11, typing_aliasing_complexity=[int])
+
 
 
     def test_functional_variant_assign0(self):


### PR DESCRIPTION
Have the return_alias attribute work on sets instead of elements, which makes the inference algorithm linear wrt. the number of arguments, while it was previously exponential.

Big thanks to @niterros for triggering this and providing both a simple reproducer and some exploration hints.

Fix #2343