### PR TITLE
Fix np.roll GCC array-bounds warning, shift/axis normalization, and empty np.median

### DIFF
--- a/pythran/pythonic/numpy/median.hpp
+++ b/pythran/pythonic/numpy/median.hpp
@@ -9,6 +9,7 @@
 #include "pythonic/utils/allocate.hpp"
 #include "pythonic/utils/functor.hpp"
 #include <algorithm>
+#include <limits>
 
 PYTHONIC_NS_BEGIN
 
@@ -62,15 +63,19 @@ namespace numpy
   decltype(std::declval<T>() + 1.) median(types::ndarray<T, pS> const &arr, types::none_type)
   {
     size_t n = arr.flat_size();
+    // numpy warns and returns nan for an empty input; without this guard the
+    // reads below run off the end of a zero-byte allocation.
+    if (n == 0)
+      return std::numeric_limits<double>::quiet_NaN();
     T *tmp = utils::allocate<T>(n);
     std::copy(arr.buffer, arr.buffer + n, tmp);
     std::nth_element(tmp, tmp + n / 2, tmp + n, ndarray::comparator<T>{});
-#if defined(_GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
     T t0 = tmp[n / 2];
-#if defined(_GNUC__) && !defined(__clang__)
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
     if (n % 2 == 1) {

--- a/pythran/pythonic/numpy/roll.hpp
+++ b/pythran/pythonic/numpy/roll.hpp
@@ -3,6 +3,8 @@
 
 #include "pythonic/include/numpy/roll.hpp"
 
+#include "pythonic/builtins/ValueError.hpp"
+#include "pythonic/operator_/mod.hpp"
 #include "pythonic/types/ndarray.hpp"
 #include "pythonic/utils/functor.hpp"
 #include "pythonic/utils/numpy_conversion.hpp"
@@ -16,15 +18,18 @@ namespace numpy
   template <class T, class pS>
   types::ndarray<T, pS> roll(types::ndarray<T, pS> const &expr, long shift)
   {
-    long expr_fsize = expr.flat_size();
-    if (expr_fsize == 0)
-      return expr.copy();
-    else if (shift < 0)
-      shift += expr_fsize;
-    else if (shift >= expr_fsize)
-      shift %= expr_fsize;
-
     types::ndarray<T, pS> out(expr._shape, builtins::None);
+    long expr_fsize = expr.flat_size();
+    // Nothing to roll: `out` has the right shape and no element, so it already
+    // matches `expr`. Returning it instead of `expr.copy()` also keeps GCC
+    // from deriving a zero-sized allocation for `copy()`, which triggers bogus
+    // -Warray-bounds. See #2472.
+    if (expr_fsize == 0)
+      return out;
+    // Python's floored modulo brings `shift` into [0, dim) whatever its sign;
+    // a plain `shift += dim` would only correct by one period.
+    shift = operator_::mod(shift, expr_fsize);
+
     std::copy(expr.fbegin(), expr.fend() - shift,
               std::copy(expr.fend() - shift, expr.fend(), out.fbegin()));
     return out;
@@ -70,15 +75,19 @@ namespace numpy
   template <class T, class pS>
   types::ndarray<T, pS> roll(types::ndarray<T, pS> const &expr, long shift, long axis)
   {
+    constexpr long ndim = types::ndarray<T, pS>::value;
     auto expr_shape = sutils::array(expr._shape);
-    if (expr_shape[axis] == 0)
-      return expr.copy();
-    if (shift < 0)
-      shift += expr_shape[axis];
-    else if (shift >= expr_shape[axis])
-      shift %= expr_shape[axis];
-
     types::ndarray<T, pS> out(expr._shape, builtins::None);
+    if (axis < 0)
+      axis += ndim;
+    if (axis < 0 || axis >= ndim)
+      throw types::ValueError("axis out of bounds");
+    // Nothing to roll: return the empty `out`, not `expr.copy()`. See the
+    // single-shift overload and #2472.
+    if (expr.flat_size() == 0)
+      return out;
+    shift = operator_::mod(shift, expr_shape[axis]);
+
     _roll(out.fbegin(), expr.fbegin(), shift, axis, expr_shape, utils::int_<0>());
     return out;
   }
@@ -127,18 +136,30 @@ namespace numpy
   {
     constexpr long ndim = types::ndarray<T, pS>::value;
     auto expr_shape = sutils::array(expr._shape);
-    long axes_shifts[ndim] = {0};
-    for (size_t i = 0; i < N; ++i)
-      axes_shifts[axes[i]] += shifts[i];
-
+    types::ndarray<T, pS> out(expr._shape, builtins::None);
     for (size_t i = 0; i < N; ++i) {
-      if (axes_shifts[i] < 0)
-        axes_shifts[i] += expr_shape[i];
-      else if (axes_shifts[i] >= expr_shape[i])
-        axes_shifts[i] %= expr_shape[i];
+      long axis = axes[i];
+      if (axis < 0)
+        axis += ndim;
+      if (axis < 0 || axis >= ndim)
+        throw types::ValueError("axis out of bounds");
+      axes[i] = axis;
+    }
+    // Nothing to roll (and no dimension to take a modulo of): return the
+    // empty `out`, not `expr.copy()`. See the single-shift overload and #2472.
+    if (expr.flat_size() == 0)
+      return out;
+
+    // Accumulate per-dimension shifts, keeping every entry in [0, dim):
+    // taking each shift modulo its dimension before adding keeps repeated
+    // axes from overflowing, and the trailing modulo reduces the sum of two
+    // such values back into range.
+    long axes_shifts[ndim] = {0};
+    for (size_t i = 0; i < N; ++i) {
+      long dim = expr_shape[axes[i]];
+      axes_shifts[axes[i]] = (axes_shifts[axes[i]] + operator_::mod(shifts[i], dim)) % dim;
     }
 
-    types::ndarray<T, pS> out(expr._shape, builtins::None);
     _rolls(out.fbegin(), expr.fbegin(), axes_shifts, expr_shape, utils::int_<0>());
     return out;
   }

--- a/pythran/tests/test_numpy_func0.py
+++ b/pythran/tests/test_numpy_func0.py
@@ -5,6 +5,7 @@ import numpy
 from packaging import version
 import tempfile
 import os
+import warnings
 
 from pythran.typing import NDArray, List, Tuple
 
@@ -266,6 +267,11 @@ def np_rosen_der(x):
 
     def test_nan_to_num0(self):
         self.run_test("def np_nan_to_num0(a): import numpy as np ; return np.nan_to_num(a)", numpy.array([numpy.inf, -numpy.inf, numpy.nan, -128, 128]), np_nan_to_num0=[NDArray[float,:]])
+
+    def test_median_empty(self):
+        with numpy.errstate(all="ignore"), warnings.catch_warnings():
+            warnings.simplefilter("ignore", RuntimeWarning)
+            self.run_test("def np_median_empty(a): from numpy import median ; return median(a)", numpy.array([], dtype=float), np_median_empty=[NDArray[float,:]])
 
     def test_median0(self):
         self.run_test("def np_median0(a): from numpy import median ; return median(a)", numpy.array([[1, 2], [3, 4]]), np_median0=[NDArray[int,:,:]])
@@ -708,6 +714,54 @@ def np_ravel3(v):
 
     def test_rollaxis0(self):
         self.run_test("def np_rollaxis0(x): from numpy import rollaxis; return rollaxis(x, 1)", numpy.arange(24).reshape(2,3,4), np_rollaxis0=[NDArray[int, :, :, :]])
+
+    def test_roll22(self):
+        """Out-of-range axes raise like numpy's AxisError, a ValueError subclass."""
+        self.run_test("def np_roll22(x):\n from numpy import roll\n r = 0\n try:\n  r += roll(x, 1, 7)[0, 0]\n except ValueError:\n  r += 1\n try:\n  r += roll(x, (1,), (-5,))[0, 0]\n except ValueError:\n  r += 1\n return r",
+        numpy.arange(12).reshape(3, 4), np_roll22=[NDArray[int, :, :]])
+
+    def test_roll21(self):
+        """Empty array whose rolled axis is non-empty."""
+        self.run_test("def np_roll21(x): from numpy import roll; return roll(x, 1, 1)",
+        numpy.arange(0).reshape(0, 3), np_roll21=[NDArray[int, :, :]])
+
+    def test_roll20(self):
+        """Shift larger than the rolled dimension, tuple form."""
+        self.run_test("def np_roll20(x): from numpy import roll; return roll(x, (-50, 60), (-2, -1))",
+        numpy.arange(12).reshape(3, 4), np_roll20=[NDArray[int, :, :]])
+
+    def test_roll19(self):
+        """Negative axes, tuple form."""
+        self.run_test("def np_roll19(x): from numpy import roll; return roll(x, (1, 2), (-2, -1))",
+        numpy.arange(12).reshape(3, 4), np_roll19=[NDArray[int, :, :]])
+
+    def test_roll18(self):
+        """Fewer (shift, axis) pairs than dimensions."""
+        self.run_test("def np_roll18(x): from numpy import roll; return roll(x, (5,), (2,))",
+        numpy.arange(24).reshape(2, 3, 4), np_roll18=[NDArray[int, :, :, :]])
+
+    def test_roll17(self):
+        """Empty array, tuple form."""
+        self.run_test("def np_roll17(x): from numpy import roll; return roll(x, (1, 2), (0, 1))",
+        numpy.arange(0).reshape(0, 3), np_roll17=[NDArray[int, :, :]])
+
+    def test_roll16(self):
+        """Negative axis."""
+        self.run_test("def np_roll16(x): from numpy import roll; return roll(x, 1, -1)",
+        numpy.arange(12).reshape(3, 4), np_roll16=[NDArray[int, :, :]])
+
+    def test_roll15(self):
+        """Negative shift larger than the rolled dimension."""
+        self.run_test("def np_roll15(x): from numpy import roll; return roll(x, -123)",
+        numpy.arange(12), np_roll15=[NDArray[int, :]])
+
+    def test_roll14(self):
+        self.run_test("def np_roll14(x): from numpy import roll; return roll(x, -1, 0)",
+        numpy.arange(0).reshape(0, 3), np_roll14=[NDArray[int, :, :]])
+
+    def test_roll13(self):
+        self.run_test("def np_roll13(x): from numpy import roll; return roll(x, -1, 0)",
+        numpy.array([], dtype=int), np_roll13=[NDArray[int, :]])
 
     def test_roll12(self):
         self.run_test("def np_roll12(x): from numpy import roll; return roll(x, (1, 2, -3), (2, 0, 1))",


### PR DESCRIPTION
Fixes #2472.

I asked Claude Opus 5 then Fable 5 to look into the issue. It did, then opened this PR. Its description is below. I reviewed the changes, which all seem like clear fixes:

- `operator_::mod` simplifies things
- single-to-double-underscore (typo I think?)
- checks for size-zero and short circuits look reasonable
- `axes_shifts` changes are probably most complex, but makes sense after reviewing how NumPy handles stuff like `np.roll(x, (1, 1), (0, 0))) (which ends up being a "roll by 2 along axis 0")
- tests look good

So Claude authored all of this and I reviewed. Happy to take responsibility for the code. But also okay with me to close (or a maintainer take over) if needed!

Claude's more detailed and complete summary is below (to separate the machine-generated from human-generated text).

<details>
<summary>Claude summary</summary>

As reported there, GCC 13 issues a bogus `-Werror=array-bounds` for `expr.copy()` on `np.roll`'s empty-input path, because it derives a zero-sized allocation for the freshly allocated output (SciPy hit this via `scipy/signal/_max_len_seq_inner.py` and worked around it in scipy/scipy#25961). The first commit removes the `copy()` calls: the output array is already allocated, and on the empty path it can be returned directly. It also fixes a `_GNUC__` → `__GNUC__` typo in `median.hpp` that left a `-Wmaybe-uninitialized` suppression dead since it was introduced.

Working on this uncovered several `np.roll` correctness bugs, fixed in the second commit:

- `|shift| >= dim`: `shift += dim` only corrects by one period, so `np.roll(x, -123)` on a 12-element array read and wrote out of bounds (segfaults on master).
- negative `axis` was never normalized, so `np.roll(x, 1, -1)` silently returned the array unrolled.
- in the tuple form, the normalization loop ran over the *pair count* but indexed by *dimension*, so `np.roll(x, (5,), (2,))` on a `(2, 3, 4)` array read out of bounds and returned garbage.
- the tuple form had no empty guard before the modulo, so `np.roll(x, (1, 2), (0, 1))` on a `(0, 3)` array crashed with SIGFPE.

Review of that work then surfaced a few remaining holes, addressed in the last two commits:

- out-of-range axes (past the negative fold) read past the shape array in the single-axis overload and wrote past a stack array in the tuple overload; both now throw `ValueError` like `numpy.reduce` already does (numpy raises `AxisError`, a `ValueError` subclass).
- shifts on a repeated axis were summed before any modulo and could overflow; each shift is now reduced modulo its dimension before accumulating.
- the new normalization helper duplicated `operator_::mod`, so it now just uses that.
- `np.median` of an empty array read past a zero-byte allocation — the very read whose warning the revived pragma suppresses — and now returns nan as numpy does.

All fixed cases are covered by new tests (`test_roll13`–`test_roll22`, `test_median_empty`), each verified against numpy's behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>