### PR TITLE
Do not warn on unused template

### DIFF
--- a/pythran/pythran-darwin.cfg
+++ b/pythran/pythran-darwin.cfg
@@ -4,7 +4,7 @@ undefs=
 include_dirs=
 libs=
 library_dirs=
-cflags=-std=c++17 -fno-math-errno -Wno-unused-function
+cflags=-std=c++17 -fno-math-errno -Wno-unused-function -Wno-unused-template
 ldflags=
 blas=blas
 CC=

--- a/pythran/pythran-linux2.cfg
+++ b/pythran/pythran-linux2.cfg
@@ -4,7 +4,7 @@ undefs=
 include_dirs=
 libs=
 library_dirs=
-cflags=-std=c++17 -fno-math-errno -fvisibility=hidden -fno-wrapv -Wno-unused-function -Wno-int-in-bool-context -Wno-unknown-warning-option
+cflags=-std=c++17 -fno-math-errno -fvisibility=hidden -fno-wrapv -Wno-unused-function -Wno-int-in-bool-context -Wno-unknown-warning-option -Wno-unused-template
 ldflags=-fvisibility=hidden -Wl,-strip-all
 blas=blas
 CC=


### PR DESCRIPTION
pythonic is relatively fine-grain in terms of dependencies, but so far that it only contains the needed (template) functions.

Fix #2477