### PR TITLE
Distinguish between combiner and update_combiner

### DIFF
--- a/pythran/cxxtypes.py
+++ b/pythran/cxxtypes.py
@@ -224,8 +224,9 @@ pythonic::types::attr::REAL{}, std::declval<complex>()))
 
             """
 
-            def __init__(self, *types):
+            def __init__(self, *types, update=False):
                 super(CombinedTypes, self).__init__(types=types)
+                self.update = update
 
             def iscombined(self):
                 return True
@@ -250,7 +251,8 @@ pythonic::types::attr::REAL{}, std::declval<complex>()))
                     sys.setrecursionlimit(current_recursion_limit)
                     return stypes[0]
                 else:
-                    stmp = f'typename __combined<{",".join(stypes)}>::type'
+                    typename = '__combine_updated' if self.update else '__combined'
+                    stmp = f'typename {typename}<{",".join(stypes)}>::type'
                     sys.setrecursionlimit(current_recursion_limit)
                     return stmp
 

--- a/pythran/pythonic/include/numpy/copyto.hpp
+++ b/pythran/pythonic/include/numpy/copyto.hpp
@@ -27,6 +27,13 @@ namespace numpy
     return {};
   }
 
+  template <class E, class F>
+  types::none_type copyto(E &&out, F const &expr)
+  {
+    std::move(out)[types::fast_contiguous_slice(0, types::none_type{})] = expr;
+    return {};
+  }
+
   DEFINE_FUNCTOR(pythonic::numpy, copyto);
 } // namespace numpy
 PYTHONIC_NS_END

--- a/pythran/pythonic/include/types/combined.hpp
+++ b/pythran/pythonic/include/types/combined.hpp
@@ -28,6 +28,23 @@ struct __combined<T0, T1, T2, Types...>
     : __combined<typename __combined<T0, T1>::type, T2, Types...> {
 };
 
+template <class... Types>
+struct __combine_updated ;
+
+template <class T>
+struct __combine_updated<T> {
+  using type = T;
+};
+
+template <class T0, class T1>
+struct __combine_updated<T0, T1> : __combined<T0, T1> {
+};
+
+template <class T0, class T1, class T2, class... Types>
+struct __combine_updated<T0, T1, T2, Types...>
+    : __combine_updated<typename __combine_updated<T0, T1>::type, T2, Types...> {
+};
+
 template <class T0, class T1>
 struct __combined<T0, T1> {
   // callable -> functor

--- a/pythran/pythonic/include/types/numpy_gexpr.hpp
+++ b/pythran/pythonic/include/types/numpy_gexpr.hpp
@@ -901,10 +901,17 @@ struct __combined<pythonic::types::numpy_gexpr<Arg, S...>,
         pythonic::types::array_tuple<long, t0::value<t1::value ? t1::value : t0::value>>;
 };
 
-template <class Arg, class... S, class O>
+template <class Arg, class... S,  class O>
 struct __combined<pythonic::types::numpy_gexpr<Arg, S...>, O> {
+  using t = pythonic::types::numpy_gexpr<Arg, S...>;
+  using type = typename pythonic::assignable<decltype(std::declval<t>() + std::declval<O>())>::type;
+};
+
+template <class Arg, class... S, class O>
+struct __combine_updated<pythonic::types::numpy_gexpr<Arg, S...>, O> {
   using type = pythonic::types::numpy_gexpr<Arg, S...>;
 };
+
 template <class Arg, class... S, class T>
 struct __combined<pythonic::types::list<T>, pythonic::types::numpy_gexpr<Arg, S...>> {
   using type = pythonic::types::list<

--- a/pythran/tests/test_ndarray.py
+++ b/pythran/tests/test_ndarray.py
@@ -1721,3 +1721,13 @@ def test_combiner_7(a, k):
 '''
         self.run_test(code, numpy.ones(10), 1,
                       test_combiner_7=[NDArray[float,:], int])
+
+    def test_combiner_8(self):
+        code = '''
+import numpy as np
+def test_combiner_8(a, k):
+    x = (a + 1) if k == 1 else (a[1:] if k == 2 else a * 3)
+    return x
+'''
+        self.run_test(code, numpy.ones(10), 3,
+                      test_combiner_8=[NDArray[float,:], int])

--- a/pythran/tests/test_ndarray.py
+++ b/pythran/tests/test_ndarray.py
@@ -1731,3 +1731,16 @@ def test_combiner_8(a, k):
 '''
         self.run_test(code, numpy.ones(10), 3,
                       test_combiner_8=[NDArray[float,:], int])
+
+
+    def test_combiner_9(self):
+        code = '''
+import numpy as np
+def test_combiner_9(a, k):
+    x = a [:2]
+    for i in range(k):
+        x = x + a[i:i+2]
+    return x
+'''
+        self.run_test(code, numpy.array([3., -1., 4., -1., 5., 9., 2., 6.]), 3,
+                      test_combiner_9=[NDArray[float,:], int])

--- a/pythran/types/types.py
+++ b/pythran/types/types.py
@@ -219,11 +219,12 @@ class Types(ModuleAnalysis[Reorder, StrictAliases, LazynessAnalysis,
         self.curr_locals_declaration = None
         self.ptype_count = 0
 
-    def combined(self, *types):
+    def combined(self, *types, update=False):
         all_types = ordered_set()
         for ty in types:
             if isinstance(ty, self.builder.CombinedTypes):
                 all_types.extend(ty.types)
+                update |= ty.update
             elif ty is not self.builder.UnknownType:
                 all_types.append(ty)
 
@@ -234,15 +235,22 @@ class Types(ModuleAnalysis[Reorder, StrictAliases, LazynessAnalysis,
         else:
             all_types = all_types[:cfg.getint('typing', 'max_combiner')]
             if {type(ty) for ty in all_types} == {self.builder.ListType}:
-                return self.builder.ListType(self.combined(*[ty.of for ty in all_types]))
+                return self.builder.ListType(self.combined(*[ty.of for ty in
+                                                             all_types],
+                                                           update=update))
             if {type(ty) for ty in all_types} == {self.builder.SetType}:
-                return self.builder.SetType(self.combined(*[ty.of for ty in all_types]))
+                return self.builder.SetType(self.combined(*[ty.of for ty in
+                                                            all_types],
+                                                          update=update))
             if {type(ty) for ty in all_types} == {self.builder.Assignable}:
-                return self.builder.Assignable(self.combined(*[ty.of for ty in all_types]))
+                return self.builder.Assignable(self.combined(*[ty.of for ty in
+                                                               all_types],
+                                                             update=update))
             if {type(ty) for ty in all_types} == {self.builder.Lazy}:
-                return self.builder.Lazy(self.combined(*[ty.of for ty in all_types]))
-
-            return self.builder.CombinedTypes(*all_types)
+                return self.builder.Lazy(self.combined(*[ty.of for ty in
+                                                         all_types],
+                                                       update=update))
+            return self.builder.CombinedTypes(*all_types, update=update)
 
 
 
@@ -480,7 +488,9 @@ class Types(ModuleAnalysis[Reorder, StrictAliases, LazynessAnalysis,
         if isinstance(curr_ty, tuple):
             return
 
-        self.result[node] = self.combined(curr_ty, ty)
+        isupdate = isinstance(getattr(node, 'ctx', None), ast.Store) and any(isinstance(ancestor, ast.AugAssign) for ancestor in self.ancestors[node])
+        isupdate |= curr_ty is not self.builder.UnknownType
+        self.result[node] = self.combined(curr_ty, ty, update=isupdate)
 
     def visit_Import(self, node):
         for alias in node.names:
@@ -642,8 +652,8 @@ class Types(ModuleAnalysis[Reorder, StrictAliases, LazynessAnalysis,
 
     def visit_IfExp(self, node):
         self.generic_visit(node)
-        self.update_type(node, None, self.result[node.body])
-        self.update_type(node, None, self.result[node.orelse])
+        self.update_type(node, None, self.combined(self.result[node.body],
+                                                   self.result[node.orelse]))
 
     def visit_Compare(self, node):
         self.generic_visit(node)


### PR DESCRIPTION
The latter matters when updating a numpy_gexpr, something regular combiner did not handle.

Fix #24451